### PR TITLE
ci(release): lowercase GHCR image name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  IMAGE: ghcr.io/${{ github.repository }}
+  IMAGE: ghcr.io/${{ github.repository_owner }}/s4
 
 jobs:
   release:


### PR DESCRIPTION
Docker requires lowercase repository names; `ghcr.io/231self/S4` is rejected. Use `ghcr.io/231self/s4`.