### PR TITLE
ci(release): make GHCR image public after push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,13 @@ jobs:
           docker push $IMAGE:${{ github.ref_name }}
           docker push $IMAGE:latest
 
+      - name: Make image public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X PATCH "/orgs/${{ github.repository_owner }}/packages/container/s4" \
+            -f visibility=public
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GHCR packages default to private; flip the org container package to public after each release so `docker pull ghcr.io/231self/s4` works without auth.