### PR TITLE
ci: install rustfmt + clippy explicitly (needed by local act runner)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+          components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
dtolnay/rust-toolchain@stable doesn't install rustfmt/clippy; GitHub-hosted runners preinstall them, but the local act container does not, so `cargo fmt --check` failed under act. Explicitly request the components.