### PR TITLE
ci(release): use docker-container buildx driver for GHA cache export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+          components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
       - name: Build and push image to GHCR
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
cache-to=type=gha fails on the default docker driver ("Cache export is not supported for the docker driver"). Add docker/setup-buildx-action with the docker-container driver.