### PR TITLE
ci: skip docker-dependent steps under act

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,11 @@ jobs:
         run: cargo test --workspace
 
       - name: Build SDKs (drift check)
+        if: ${{ !env.ACT }}
         run: |
           bash scripts/generate-sdks.sh
           git diff --exit-code -- sdks/
 
       - name: End-to-end (MinIO)
+        if: ${{ !env.ACT }}
         run: bash scripts/e2e-local.sh


### PR DESCRIPTION
SDK drift (openapi-generator container) and the MinIO e2e need the docker socket, which act can't mount under colima. Guard both with `if: \${{ !env.ACT }}` — skipped locally, still enforced on GitHub. Local e2e: `just e2e`.