### PR TITLE
ci: cap cargo build jobs to 2 (avoids OOM under act/colima)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
+  # Keep link-time memory bounded: matches GitHub's 2-vCPU runner and keeps
+  # local (act/colima) builds from exhausting a shared Docker VM.
+  CARGO_BUILD_JOBS: 2
 
 jobs:
   check:


### PR DESCRIPTION
Local act runs OOM-killed the linker (signal 9) in the shared colima VM. GitHub's 2-vCPU runner already uses 2 jobs, so this is a no-op there and keeps local memory bounded.