### PR TITLE
ci(release): repo-scoped GHCR image, auto-public, prune old versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,10 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  IMAGE: ghcr.io/${{ github.repository_owner }}/s4
+  # Repo-scoped image: the workflow's GITHUB_TOKEN can manage visibility and
+  # prune old versions of repo-scoped packages (org-scoped packages require
+  # an org-owner PAT). Registry path must be lowercase.
+  IMAGE: ghcr.io/${{ github.repository_owner }}/s4/s4
 
 jobs:
   release:
@@ -64,6 +67,36 @@ jobs:
           tags: ${{ env.IMAGE }}:${{ github.ref_name }}, ${{ env.IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha, mode=max
+
+      - name: Make image public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X PATCH "/repos/${{ github.repository }}/packages/container/s4" \
+            -f visibility=public \
+            || echo "warning: could not set image visibility to public"
+
+      - name: Prune old image versions (keep latest + last 3 tags)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          keep=3
+          # Newest-first tagged versions (latest is first); delete everything
+          # past the keep window. Best-effort so it never blocks a release.
+          gh api --paginate "/repos/${{ github.repository }}/packages/container/s4/versions?per_page=100" \
+            --jq '[.[] | select((.metadata.container.tags | length) > 0)
+                   | {id, created: .created_at, tag: .metadata.container.tags[0]}]
+                  | sort_by(.created) | reverse' \
+            | jq -c '.[]' \
+            | tail -n +$((keep + 2)) \
+            | while read -r v; do
+                id=$(echo "$v" | jq -r .id)
+                tag=$(echo "$v" | jq -r .tag)
+                echo "pruning image version $tag ($id)"
+                gh api -X DELETE "/repos/${{ github.repository }}/packages/container/s4/versions/$id" \
+                  || echo "warning: could not delete $tag"
+              done
+          echo "prune done (kept latest + $keep tags)"
 
       - name: Create GitHub Release
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,9 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
         cargo build --release -p s4-gateway; \
     fi
 
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
+# Copy the freshly-built binary out of the cache mount to a stable path.
+RUN --mount=type=cache,target=/src/target \
+    if [ "$TARGETARCH" = "arm64" ]; then \
         cp /src/target/aarch64-unknown-linux-gnu/release/s4-gateway /src/gateway-bin; \
     else \
         cp /src/target/release/s4-gateway /src/gateway-bin; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,11 @@ ENV PATH="/opt/wasm-tools/bin:$PATH"
 COPY . .
 
 # Wasm filter components (pii-default, envelope-encrypt, stable-encrypt, ...)
+# Copied out of the cache mount to a stable path for the runtime stage.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/src/target \
-    bash scripts/build-filters.sh
+    bash scripts/build-filters.sh \
+    && cp -r /src/target/components /src/components-out
 
 # Release gateway binary, compiled for the target architecture
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -58,7 +60,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /src/gateway-bin /usr/local/bin/s4-gateway
-COPY --from=build /src/target/components /app/components
+COPY --from=build /src/components-out /app/components
 
 ENV S4_FILTER_COMPONENT=/app/components/pii-default.component.wasm
 ENV S4_PLUGINS_DIR=/app/components

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ s4ctl put ./data.csv ingest/data.csv --bucket s4-local
 s4ctl get ingest/data.csv --bucket s4-local
 ```
 
-`s4ctl local init` pulls `ghcr.io/231self/s4` and runs the gateway in local mode
+`s4ctl local init` pulls `ghcr.io/231self/s4/s4` and runs the gateway in local mode
 (`AUTH_DISABLED=true`, keys persisted on a volume, in-memory storage). `s4ctl local
 down` stops it. For durable local storage (MinIO), clone the repo and use
 `just dev-up`.
@@ -91,7 +91,7 @@ Two local pipeline runners, both with persistent caches:
   cache server, so cargo deps are reused across runs).
 - **`just build-local` / `just image-local` / `just publish-local TAG=x`** — dagger
   pipeline (`dagger/main.py`) with cargo registry + target dirs on persistent cache
-  volumes; `publish-local` pushes to `ghcr.io/231self/s4` (needs `docker login ghcr.io`
+  volumes; `publish-local` pushes to `ghcr.io/231self/s4/s4` (needs `docker login ghcr.io`
   once).
 
 See `CONTRIBUTING.md`.

--- a/crates/s4ctl/src/main.rs
+++ b/crates/s4ctl/src/main.rs
@@ -762,7 +762,7 @@ async fn main() -> anyhow::Result<()> {
 
         Command::Local { cmd } => {
             const LOCAL_GATEWAY_NAME: &str = "s4-local-gateway";
-            const LOCAL_GATEWAY_IMAGE: &str = "ghcr.io/231self/s4:latest";
+            const LOCAL_GATEWAY_IMAGE: &str = "ghcr.io/231self/s4/s4:latest";
             const LOCAL_GATEWAY_PORT: u16 = 8080;
 
             match cmd {

--- a/dagger/src/s_4/__init__.py
+++ b/dagger/src/s_4/__init__.py
@@ -3,7 +3,7 @@
 Run locally (requires the Dagger CLI + engine):
     dagger call ci                      # fmt + clippy + filters + tests (cached)
     dagger call image                   # assemble the deploy image
-    dagger call publish --tag=v0.2.0    # build + push ghcr.io/231self/s4:<tag>
+    dagger call publish --tag=v0.2.0    # build + push ghcr.io/231self/s4/s4:<tag>
 
 Sources are cloned in-engine via dag.git (no host filesystem dependency),
 and cargo registry + target dirs live on persistent cache volumes, so
@@ -13,7 +13,7 @@ repeated runs reuse compiled dependencies instead of recompiling.
 import dagger
 from dagger import dag, function, object_type
 
-REGISTRY = "ghcr.io/231self/s4"
+REGISTRY = "ghcr.io/231self/s4/s4"
 REPO = "https://github.com/231self/S4.git"
 DEFAULT_REF = "main"
 


### PR DESCRIPTION
## Why
The org-scoped image (ghcr.io/231self/s4) can't be managed by the workflow's GITHUB_TOKEN (visibility + deletion require an org-owner PAT). Repo-scoped packages (`ghcr.io/231self/s4/s4`) are fully manageable by the workflow token.

## What
- **Auto-public**: `PATCH /repos/{owner}/{repo}/packages/container/s4` visibility=public after each push (no more manual org setting).
- **Version cap**: prune keeps `latest` + last 3 tags; older versions deleted on each release (best-effort, never blocks the release).
- Image references updated: `s4ctl local init`, README, dagger `publish-local`.

Note: public GHCR storage is free, so this is hygiene, not cost — but it bounds growth.