### PR TITLE
perf(release): halve build time — filters built once, artifacts extracted from image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,40 +13,87 @@ env:
   CARGO_BUILD_JOBS: 2
 
 jobs:
-  check:
+  fmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain (from rust-toolchain.toml)
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
-          components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Install wasm-tools
-        run: cargo install --locked wasm-tools
-
+          components: rustfmt
       - name: Format
         run: cargo fmt --check
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
       - name: Lint
         run: cargo clippy --all-targets -- -D warnings
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: Install wasm-tools
+        run: cargo install --locked wasm-tools
       - name: Build Wasm filters
         run: bash scripts/build-filters.sh
-
       - name: Test
         run: cargo test --workspace
 
+  sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: Install wasm-tools
+        run: cargo install --locked wasm-tools
       - name: Build SDKs (drift check)
         if: ${{ !env.ACT }}
         run: |
           bash scripts/generate-sdks.sh
           git diff --exit-code -- sdks/
 
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: Install wasm-tools
+        run: cargo install --locked wasm-tools
       - name: End-to-end (MinIO)
         if: ${{ !env.ACT }}
         run: bash scripts/e2e-local.sh
+
+  # Aggregate status so branch protection's required `check` keeps working
+  # and never ends up "skipped" when a constituent job fails.
+  check:
+    needs: [fmt, lint, test, sdk, e2e]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any check failed
+        if: ${{ contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled') }}
+        run: exit 1
+      - name: All checks passed
+        if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
+        run: echo "all checks passed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,31 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Install wasm-tools
-        run: cargo install --locked wasm-tools
-
-      - name: Build Wasm filters
-        run: bash scripts/build-filters.sh
-
-      - name: Build gateway
-        run: cargo build --release -p s4-gateway
-
-      - name: Collect artifacts
-        run: |
-          mkdir -p dist/filters
-          cp target/components/*.component.wasm dist/filters/
-          cp target/release/s4-gateway dist/s4-gateway-linux-x86_64
-          tar -czf dist/s4-filters.tar.gz -C dist filters
-          tar -czf dist/s4-python-sdk.tar.gz -C sdks python
-          tar -czf dist/s4-typescript-sdk.tar.gz -C sdks typescript
-
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -58,6 +33,9 @@ jobs:
         with:
           driver: docker-container
 
+      # Single build: the Dockerfile compiles the wasm filters once (arch
+      # independent) and the gateway per-arch. No separate runner-side Rust
+      # builds — the release artifacts below are extracted from the image.
       - name: Build and push image to GHCR
         uses: docker/build-push-action@v6
         with:
@@ -67,6 +45,17 @@ jobs:
           tags: ${{ env.IMAGE }}:${{ github.ref_name }}, ${{ env.IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha, mode=max
+
+      - name: Extract release artifacts from image
+        run: |
+          mkdir -p dist/filters
+          docker create --name s4-extract --platform linux/amd64 "${{ env.IMAGE }}:${{ github.ref_name }}"
+          docker cp s4-extract:/usr/local/bin/s4-gateway dist/s4-gateway-linux-x86_64
+          docker cp s4-extract:/app/components/. dist/filters/
+          docker rm s4-extract
+          tar -czf dist/s4-filters.tar.gz -C dist filters
+          tar -czf dist/s4-python-sdk.tar.gz -C sdks python
+          tar -czf dist/s4-typescript-sdk.tar.gz -C sdks typescript
 
       - name: Make image public
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,21 @@
 # syntax=docker/dockerfile:1
 # Deploy image for the S4 gateway: release binary + Wasm filter components.
 #
-# Build:      docker build -t s4-gateway .
-# Via CI:     .github/workflows/release.yml (docker/build-push-action, gha cache)
-# Locally:    dagger call publish --tag=... (see dagger/main.py)
+# Stages:
+#   filters — Wasm components are architecture-independent, built ONCE here
+#   build   — per-arch gateway release binary (TARGETARCH)
+#   runtime — debian:bookworm-slim + binary + components
 #
-# Multi-arch: buildx platforms linux/amd64,linux/arm64. The gateway is
-# cross-compiled per TARGETARCH so both platforms build natively in buildkit
-# (no QEMU), and cargo registry + target dirs ride on BuildKit cache mounts
-# so incremental builds reuse compiled deps.
+# Multi-arch: buildx platforms linux/amd64,linux/arm64; the gateway is
+# cross-compiled for arm64 (gcc-aarch64-linux-gnu), so both platforms build
+# natively with no QEMU. Cargo registry + target ride on BuildKit cache
+# mounts so repeat builds reuse compiled deps.
 
-FROM rust:1-bookworm AS build
+FROM rust:1-bookworm AS filters
 WORKDIR /src
 
-ARG TARGETARCH
-
-# Cross toolchain for the arm64 build (no-op cost on amd64).
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu \
-    && rm -rf /var/lib/apt/lists/*
-
-# Rust 2024 edition requires a recent toolchain; rust:1 tracks latest.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     rustup target add wasm32-unknown-unknown \
-    && if [ "$TARGETARCH" = "arm64" ]; then rustup target add aarch64-unknown-linux-gnu; fi \
     && cargo install --locked wasm-tools --version 1.255.0 --root /opt/wasm-tools
 ENV PATH="/opt/wasm-tools/bin:$PATH"
 
@@ -36,35 +28,39 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     bash scripts/build-filters.sh \
     && cp -r /src/target/components /src/components-out
 
-# Release gateway binary, compiled for the target architecture
+FROM rust:1-bookworm AS build
+WORKDIR /src
+ARG TARGETARCH
+
+# Cross toolchain for the arm64 build.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+# Release gateway binary, compiled for the target architecture, then copied
+# out of the cache mount to a stable path.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/src/target \
     if [ "$TARGETARCH" = "arm64" ]; then \
-        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-        cargo build --release --target aarch64-unknown-linux-gnu -p s4-gateway; \
+        rustup target add aarch64-unknown-linux-gnu \
+        && CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+        cargo build --release --target aarch64-unknown-linux-gnu -p s4-gateway \
+        && cp /src/target/aarch64-unknown-linux-gnu/release/s4-gateway /src/gateway-bin; \
     else \
-        cargo build --release -p s4-gateway; \
-    fi
-
-# Copy the freshly-built binary out of the cache mount to a stable path.
-RUN --mount=type=cache,target=/src/target \
-    if [ "$TARGETARCH" = "arm64" ]; then \
-        cp /src/target/aarch64-unknown-linux-gnu/release/s4-gateway /src/gateway-bin; \
-    else \
-        cp /src/target/release/s4-gateway /src/gateway-bin; \
+        cargo build --release -p s4-gateway \
+        && cp /src/target/release/s4-gateway /src/gateway-bin; \
     fi
 
 FROM debian:bookworm-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*
-
 COPY --from=build /src/gateway-bin /usr/local/bin/s4-gateway
-COPY --from=build /src/components-out /app/components
-
+COPY --from=filters /src/components-out /app/components
 ENV S4_FILTER_COMPONENT=/app/components/pii-default.component.wasm
 ENV S4_PLUGINS_DIR=/app/components
 ENV LISTEN_ADDR=0.0.0.0:8080
 EXPOSE 8080
-
 ENTRYPOINT ["s4-gateway"]


### PR DESCRIPTION
## What
- **Dockerfile**: split into `filters` (wasm components — architecture-independent, built **once**) and `build` (per-`TARGETARCH` gateway only) stages. Binary/components copied out of the cargo cache mounts within the same RUN.
- **release.yml**: dropped all runner-side Rust builds (toolchain, wasm-tools, filters, gateway). The job now builds+pushes the multi-arch image once and extracts `dist/` artifacts via `docker create`+`docker cp`.
- Result: the release job is ~2 of 3 full workspace compiles shorter; the GHA layer cache (`cache-to: type=gha, mode=max`) makes subsequent tags incremental.

## Verification
- Restructured Dockerfile built locally with buildx (arm64): image runs, /health OK, PII redaction e2e PASS.