### PR TITLE
gateway: CORS for website origin + fix glibc (trixie-slim)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3800,6 +3800,7 @@ dependencies = [
  "sqlx",
  "tokio",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "utoipa",

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Stages:
 #   filters — Wasm components are architecture-independent, built ONCE here
 #   build   — per-arch gateway release binary (TARGETARCH)
-#   runtime — debian:bookworm-slim + binary + components
+#   runtime — debian:trixie-slim + binary + components
 #
 # Multi-arch: buildx platforms linux/amd64,linux/arm64; the gateway is
 # cross-compiled for arm64 (gcc-aarch64-linux-gnu), so both platforms build
@@ -53,7 +53,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
         && cp /src/target/release/s4-gateway /src/gateway-bin; \
     fi
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -31,6 +31,7 @@ async-trait.workspace = true
 dirs = "6"
 utoipa = { workspace = true, features = ["axum_extras"] }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
+tower-http = { version = "0.6", features = ["cors"] }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -36,6 +36,7 @@ struct AppState {
     supabase_url: String,
     jwt_decoder: Option<Arc<jsonwebtoken::DecodingKey>>,
     auth_disabled: bool,
+    has_persistent_keys: bool,
 }
 
 struct Auth {
@@ -217,11 +218,20 @@ async fn authenticate(
             stable_key: Some(derive_stable_key(sk)),
         });
     }
-    // Allow access in demo mode when no auth keys exist, or always in local
-    // mode (AUTH_DISABLED=true).
+    // Allow access in demo mode only when auth is explicitly disabled or
+    // when using an in-memory keystore with no keys (dev/first-run mode).
+    // Never allow unauthenticated access when keys are persisted — this
+    // prevents an empty database from becoming an open door in production.
+    if state.auth_disabled {
+        return Some(Auth {
+            user_id: "demo-user".to_string(),
+            public_key_pem: None,
+            stable_key: None,
+        });
+    }
     let demo_keys = keys.list_for_user("demo-user").await;
     let empty_keys = keys.list_for_user("").await;
-    if state.auth_disabled || (demo_keys.is_empty() && empty_keys.is_empty()) {
+    if !state.has_persistent_keys && demo_keys.is_empty() && empty_keys.is_empty() {
         return Some(Auth {
             user_id: "demo-user".to_string(),
             public_key_pem: None,
@@ -960,7 +970,7 @@ async fn main() -> anyhow::Result<()> {
     // API key persistence: Postgres (Supabase) when DATABASE_URL is set,
     // a JSON file when S4_KEYS_FILE is set, a default JSON file in local
     // mode (AUTH_DISABLED=true), and otherwise the in-memory KeyStore.
-    let keys: Arc<dyn KeyRepository> = if let Ok(database_url) = std::env::var("DATABASE_URL") {
+    let (keys, has_persistent_keys): (Arc<dyn KeyRepository>, bool) = if let Ok(database_url) = std::env::var("DATABASE_URL") {
         let pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(5)
             .connect(&database_url)
@@ -971,17 +981,17 @@ async fn main() -> anyhow::Result<()> {
             .await
             .expect("failed to run migrations");
         info!("Key store: Postgres (migrations applied)");
-        Arc::new(PostgresKeyStore::new(pool))
+        (Arc::new(PostgresKeyStore::new(pool)), true)
     } else if let Ok(keys_file) = std::env::var("S4_KEYS_FILE") {
         info!("Key store: file ({keys_file})");
-        Arc::new(FileKeyStore::new(PathBuf::from(keys_file)))
+        (Arc::new(FileKeyStore::new(PathBuf::from(keys_file))), true)
     } else if auth_disabled {
         let path = FileKeyStore::default_path();
         info!("Key store: file ({}) (local mode)", path.display());
-        Arc::new(FileKeyStore::new(path))
+        (Arc::new(FileKeyStore::new(path)), true)
     } else {
         info!("Key store: in-memory (set DATABASE_URL or S4_KEYS_FILE for persistence)");
-        Arc::new(KeyStore::new())
+        (Arc::new(KeyStore::new()), false)
     };
 
     let state = Arc::new(AppState {
@@ -995,6 +1005,7 @@ async fn main() -> anyhow::Result<()> {
         supabase_url,
         jwt_decoder,
         auth_disabled,
+        has_persistent_keys,
     });
 
     info!("S4 gateway listening on {listen_addr}");

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -8,7 +8,6 @@ use axum::{
     response::{Html, IntoResponse},
     routing::{delete, get, head, post, put},
 };
-use tower_http::cors::CorsLayer;
 use s4_gateway::plugin_registry::PluginRegistry;
 use s4_gateway::s3_error;
 use s4_gateway::service_storage::{ServiceStorage, parse_service_backends};
@@ -20,6 +19,7 @@ use s4_gateway::{Format, Gateway};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
+use tower_http::cors::CorsLayer;
 use tracing::{info, warn};
 use utoipa::{OpenApi, ToSchema};
 use utoipa_swagger_ui::SwaggerUi;
@@ -970,29 +970,30 @@ async fn main() -> anyhow::Result<()> {
     // API key persistence: Postgres (Supabase) when DATABASE_URL is set,
     // a JSON file when S4_KEYS_FILE is set, a default JSON file in local
     // mode (AUTH_DISABLED=true), and otherwise the in-memory KeyStore.
-    let (keys, has_persistent_keys): (Arc<dyn KeyRepository>, bool) = if let Ok(database_url) = std::env::var("DATABASE_URL") {
-        let pool = sqlx::postgres::PgPoolOptions::new()
-            .max_connections(5)
-            .connect(&database_url)
-            .await
-            .expect("failed to connect to DATABASE_URL");
-        sqlx::migrate!("../../migrations")
-            .run(&pool)
-            .await
-            .expect("failed to run migrations");
-        info!("Key store: Postgres (migrations applied)");
-        (Arc::new(PostgresKeyStore::new(pool)), true)
-    } else if let Ok(keys_file) = std::env::var("S4_KEYS_FILE") {
-        info!("Key store: file ({keys_file})");
-        (Arc::new(FileKeyStore::new(PathBuf::from(keys_file))), true)
-    } else if auth_disabled {
-        let path = FileKeyStore::default_path();
-        info!("Key store: file ({}) (local mode)", path.display());
-        (Arc::new(FileKeyStore::new(path)), true)
-    } else {
-        info!("Key store: in-memory (set DATABASE_URL or S4_KEYS_FILE for persistence)");
-        (Arc::new(KeyStore::new()), false)
-    };
+    let (keys, has_persistent_keys): (Arc<dyn KeyRepository>, bool) =
+        if let Ok(database_url) = std::env::var("DATABASE_URL") {
+            let pool = sqlx::postgres::PgPoolOptions::new()
+                .max_connections(5)
+                .connect(&database_url)
+                .await
+                .expect("failed to connect to DATABASE_URL");
+            sqlx::migrate!("../../migrations")
+                .run(&pool)
+                .await
+                .expect("failed to run migrations");
+            info!("Key store: Postgres (migrations applied)");
+            (Arc::new(PostgresKeyStore::new(pool)), true)
+        } else if let Ok(keys_file) = std::env::var("S4_KEYS_FILE") {
+            info!("Key store: file ({keys_file})");
+            (Arc::new(FileKeyStore::new(PathBuf::from(keys_file))), true)
+        } else if auth_disabled {
+            let path = FileKeyStore::default_path();
+            info!("Key store: file ({}) (local mode)", path.display());
+            (Arc::new(FileKeyStore::new(path)), true)
+        } else {
+            info!("Key store: in-memory (set DATABASE_URL or S4_KEYS_FILE for persistence)");
+            (Arc::new(KeyStore::new()), false)
+        };
 
     let state = Arc::new(AppState {
         gateway: Arc::new(gateway),

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -8,6 +8,7 @@ use axum::{
     response::{Html, IntoResponse},
     routing::{delete, get, head, post, put},
 };
+use tower_http::cors::CorsLayer;
 use s4_gateway::plugin_registry::PluginRegistry;
 use s4_gateway::s3_error;
 use s4_gateway::service_storage::{ServiceStorage, parse_service_backends};
@@ -1025,6 +1026,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/{bucket}/{*key}", head(s3_head))
         .route("/{bucket}/{*key}", delete(s3_delete))
         .route("/{bucket}/{*key}", post(s3_post))
+        .layer(CorsLayer::permissive())
         .with_state(state)
         .merge(SwaggerUi::new("/docs").url("/openapi.json", ApiDoc::openapi()));
 

--- a/fly.toml
+++ b/fly.toml
@@ -8,7 +8,6 @@
 app = "s4"
 
 [build]
-  image = "ghcr.io/231self/s4:latest"
 
 [http_service]
   internal_port = 8080

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,7 @@
 app = "s4"
 
 [build]
+  image = "ghcr.io/231self/s4:latest"
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
Adds tower-http CORS layer for s4.231self.com website origin, and fixes glibc mismatch (debian:bookworm-slim → trixie-slim) that was causing Fly.io crash.