### PR TITLE
examples: B2 envelope-encryption demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ cargo install s4ctl --git https://github.com/231self/S4
 s4ctl local init                  # runs the published gateway image (Docker)
 s4ctl plugin list                 # the pii-default plugin is preloaded
 
+# A sample file to push through the pipeline:
+echo "jane.doe@example.com 4111111111111111" > data.csv
+
 # Write data through the pipeline; it is transformed before it reaches storage
 s4ctl put ./data.csv ingest/data.csv --bucket s4-local
 
@@ -42,9 +45,9 @@ s4ctl get ingest/data.csv --bucket s4-local
 ```
 
 `s4ctl local init` pulls `ghcr.io/231self/s4/s4` and runs the gateway in local mode
-(`AUTH_DISABLED=true`, keys persisted on a volume, in-memory storage). `s4ctl local
-down` stops it. For durable local storage (MinIO), clone the repo and use
-`just dev-up`.
+(`AUTH_DISABLED=true`, keys persisted on a volume, in-memory storage); it picks a
+free port (8080+) and binds the loopback interface only. `s4ctl local down` stops it.
+For durable local storage (MinIO), clone the repo and use `just dev-up`.
 
 ## Run your own plugin
 
@@ -160,6 +163,22 @@ See `CONTRIBUTING.md`.
 - `docs/plugins.md` — create and consume your own plugins.
 - `docs/adr/` — architecture decision records.
 - `AGENTS.md` — development conventions.
+
+## LLM agents
+
+Coding agents (Claude Code, Kilo, Cursor, …) read `AGENTS.md` from the repo root
+automatically. For reusable, domain-specific S4 context, install the bundled skill:
+
+```bash
+# Claude Code (user-global):
+mkdir -p ~/.claude/skills && ln -s "$(pwd)/skills/s4" ~/.claude/skills/s4
+# Kilo (user-global):
+mkdir -p ~/.kilo/skills && ln -s "$(pwd)/skills/s4" ~/.kilo/skills/s4
+```
+
+The skill teaches agents what S4 is, the plugin pipeline, build/test/run commands,
+crate layout, and the CI/release gotchas (BuildKit cache mounts, act/colima,
+multi-arch builds).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,64 @@ s4ctl plugin reorder pii-default my-filter
 
 Full guide: [docs/plugins.md](docs/plugins.md).
 
+## Usage examples
+
+Everything below is copy-paste runnable.
+
+**Redaction — PII filtered on write**
+
+```bash
+# Local gateway (published image, Docker, in-memory storage):
+s4ctl local init
+s4ctl put ./data.csv ingest/data.csv --bucket s4-local
+s4ctl get ingest/data.csv --bucket s4-local     # emails/SSNs/cards redacted
+
+# Durable local storage (MinIO) from a repo clone:
+just dev-up
+s4ctl put ./data.csv ingest/data.csv --bucket s4-local
+
+# End-to-end validation:
+just e2e
+```
+
+**Encryption — per-field envelope encryption, decryptable only by you**
+
+```bash
+# Round-trip against any S3-compatible bucket: pre-encrypt fixture →
+# encrypted bytes fetched straight from the bucket → decrypted through S4:
+export B2_S3_ENDPOINT=https://s3.us-east-005.backblazeb2.com
+export B2_REGION=us-east-005
+export B2_BUCKET=your-bucket
+export B2_ACCESS_KEY_ID=your-key-id
+export B2_SECRET_ACCESS_KEY=your-application-key
+bash examples/b2-encrypt-demo.sh
+```
+
+**Plugins — bring your own transform**
+
+```bash
+s4ctl plugin list                              # pipeline order
+s4ctl plugin upload my-filter.component.wasm   # runtime import, no rebuild
+s4ctl plugin enable <id>
+s4ctl plugin reorder pii-default my-filter     # output of one feeds the next
+```
+
+**SDKs — Python**
+
+```python
+from s4_client import S4Client
+client = S4Client(gateway="http://localhost:8080")
+pub, priv = client.generate_keypair()                  # RSA-2048
+client.attach_public_key(pub)                          # bind to your API key
+client.put_object("bucket", "key", b"jane@example.com 4111111111111111")
+blob = client.get_object("bucket", "key")
+assert "jane@example.com" not in blob.decode()          # stored encrypted
+print(client.decrypt_payload(blob, priv))              # you hold the key
+```
+
+Full details: [examples/README.md](examples/README.md) and
+[docs/plugins.md](docs/plugins.md).
+
 ## How it works
 
 ```
@@ -98,6 +156,7 @@ See `CONTRIBUTING.md`.
 
 ## Documentation
 
+- `examples/` — runnable end-to-end demos (B2 encryption round-trip).
 - `docs/plugins.md` — create and consume your own plugins.
 - `docs/adr/` — architecture decision records.
 - `AGENTS.md` — development conventions.

--- a/crates/s4ctl/src/main.rs
+++ b/crates/s4ctl/src/main.rs
@@ -763,7 +763,6 @@ async fn main() -> anyhow::Result<()> {
         Command::Local { cmd } => {
             const LOCAL_GATEWAY_NAME: &str = "s4-local-gateway";
             const LOCAL_GATEWAY_IMAGE: &str = "ghcr.io/231self/s4/s4:latest";
-            const LOCAL_GATEWAY_PORT: u16 = 8080;
 
             match cmd {
                 LocalCmd::Init => {
@@ -780,8 +779,16 @@ async fn main() -> anyhow::Result<()> {
                         bail!("docker is not running — start Docker/colima first");
                     }
 
+                    // Pick a free host port (8080 is commonly taken) and
+                    // publish on the loopback interface only.
+                    let port = (8080u16..=8180u16)
+                        .find(|p| std::net::TcpListener::bind(("127.0.0.1", *p)).is_ok())
+                        .expect("no free port in 8080..8180");
+
                     let _ = std::process::Command::new("docker")
                         .args(["rm", "-f", LOCAL_GATEWAY_NAME])
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
                         .status();
                     let run_status = std::process::Command::new("docker")
                         .args([
@@ -790,7 +797,7 @@ async fn main() -> anyhow::Result<()> {
                             "--name",
                             LOCAL_GATEWAY_NAME,
                             "-p",
-                            &format!("{LOCAL_GATEWAY_PORT}:8080"),
+                            &format!("127.0.0.1:{port}:8080"),
                             "-v",
                             "s4-local-keys:/app/data",
                             "-e",
@@ -806,7 +813,7 @@ async fn main() -> anyhow::Result<()> {
                         );
                     }
 
-                    let url = format!("http://localhost:{LOCAL_GATEWAY_PORT}");
+                    let url = format!("http://127.0.0.1:{port}");
                     let mut healthy = false;
                     for _ in 0..30 {
                         if reqwest::get(format!("{url}/health"))
@@ -820,6 +827,15 @@ async fn main() -> anyhow::Result<()> {
                         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                     }
                     if !healthy {
+                        // Surface the container logs so a broken image is easy to diagnose.
+                        let logs = std::process::Command::new("docker")
+                            .args(["logs", LOCAL_GATEWAY_NAME])
+                            .output()
+                            .map(|o| String::from_utf8_lossy(&o.stderr).trim().to_string())
+                            .unwrap_or_default();
+                        if !logs.is_empty() {
+                            eprintln!("gateway logs:\n{logs}");
+                        }
                         bail!("gateway did not become healthy at {url}/health");
                     }
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,27 @@
+# Examples
+
+## B2 envelope-encryption demo (`b2-encrypt-demo.sh`)
+
+Shows the full encryption round-trip against a real Backblaze B2 bucket:
+1. **Pre-encrypt** — the fixture as you have it
+2. **Encrypted at rest** — the bytes stored in B2, fetched directly from the
+   bucket (bypassing S4), so you can see what actually leaves your writer
+3. **Decrypted** — GET through S4 + client-side decryption with the private key
+
+```bash
+export B2_S3_ENDPOINT=https://s3.us-east-005.backblazeb2.com
+export B2_REGION=us-east-005
+export B2_BUCKET=your-bucket
+export B2_ACCESS_KEY_ID=your-key-id
+export B2_SECRET_ACCESS_KEY=your-application-key
+bash examples/b2-encrypt-demo.sh
+```
+
+The B2 application key needs `readFiles`/`writeFiles`/`deleteFiles` on the bucket.
+The demo uses the repo's public fixtures (`tests/fixtures/pii/crypto/`) as the
+encryption keypair; in production you'd bind your own public key to the API key.
+
+## Redaction
+
+`scripts/e2e-local.sh` runs the redaction pipeline against a local MinIO
+(no external account needed).

--- a/examples/b2-encrypt-demo.sh
+++ b/examples/b2-encrypt-demo.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# B2 envelope-encryption demo:
+#   1. PRE-ENCRYPT  — the PII fixture as you have it
+#   2. ENCRYPTED AT REST — the bytes stored in B2, fetched DIRECTLY from the
+#      bucket (bypassing S4) so you can see what leaves your writer
+#   3. DECRYPTED — GET through S4 + client-side decryption with the private key
+#
+# Credentials come from the environment (never committed):
+#   B2_S3_ENDPOINT=https://s3.us-east-005.backblazeb2.com
+#   B2_REGION=us-east-005
+#   B2_BUCKET=<bucket>
+#   B2_ACCESS_KEY_ID=<keyId>
+#   B2_SECRET_ACCESS_KEY=<applicationKey>
+# The B2 application key needs readFiles/writeFiles/deleteFiles on the bucket.
+#
+# Requirements: docker (for the mc client), python3 + cryptography (decrypt),
+# Rust toolchain + wasm-tools (first run only, to build the gateway).
+#
+# Usage:
+#   export B2_S3_ENDPOINT=... B2_REGION=... B2_BUCKET=... \
+#          B2_ACCESS_KEY_ID=... B2_SECRET_ACCESS_KEY=...
+#   bash examples/b2-encrypt-demo.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PORT="${S4_TEST_PORT:-9012}"
+GATEWAY_URL="http://127.0.0.1:${PORT}"
+INPUT="$ROOT/tests/fixtures/pii/sample1.txt"
+OBJ_KEY="demo/encrypted-sample.txt"
+CERT="$ROOT/tests/fixtures/pii/crypto/cert.pem"
+KEY="$ROOT/tests/fixtures/pii/crypto/key.pem"
+MC_CONF="s4-mc-demo"
+GW_LOG="/tmp/s4-b2-enc-demo.log"
+RAW="/tmp/s4-b2-enc-raw.txt"
+THROUGH="/tmp/s4-b2-enc-through.txt"
+DECRYPTED="/tmp/s4-b2-decrypted.txt"
+
+for v in B2_S3_ENDPOINT B2_REGION B2_BUCKET B2_ACCESS_KEY_ID B2_SECRET_ACCESS_KEY; do
+  [ -n "${!v:-}" ] || { echo "ERROR: $v is not set (see script header)" >&2; exit 1; }
+done
+
+GW_PID=""
+cleanup() {
+  [ -n "$GW_PID" ] && kill "$GW_PID" 2>/dev/null || true
+  docker volume rm "$MC_CONF" >/dev/null 2>&1 || true
+  rm -f "$RAW" "$THROUGH" "$DECRYPTED"
+}
+trap cleanup EXIT
+
+echo "=== B2 envelope-encryption demo ==="
+
+echo "--- Building filters + gateway (first run only) ---"
+(cd "$ROOT" && bash scripts/build-filters.sh >/dev/null 2>&1)
+[ -x "$ROOT/target/debug/s4-gateway" ] || (cd "$ROOT" && cargo build -p s4-gateway)
+
+SERVICE_BUCKETS="b2|${B2_S3_ENDPOINT}|${B2_REGION}|${B2_BUCKET}|${B2_ACCESS_KEY_ID}|${B2_SECRET_ACCESS_KEY}"
+
+echo "--- Starting gateway on ${GATEWAY_URL} ---"
+LISTEN_ADDR="127.0.0.1:${PORT}" S4_SERVICE_BUCKETS="$SERVICE_BUCKETS" \
+  "$ROOT/target/debug/s4-gateway" >"$GW_LOG" 2>&1 &
+GW_PID=$!
+for _ in $(seq 1 30); do
+  curl -fsS "$GATEWAY_URL/health" >/dev/null 2>&1 && break
+  sleep 1
+done
+curl -fsS "$GATEWAY_URL/health" >/dev/null 2>&1 || { echo "gateway failed:"; tail -5 "$GW_LOG"; exit 1; }
+
+echo "--- Pipeline: pii-default OFF, envelope-encrypt ON ---"
+PII_ID="$(curl -fsS "$GATEWAY_URL/dashboard/api/plugins" | python3 -c \
+  "import json,sys; print([p['id'] for p in json.load(sys.stdin) if p['name']=='pii-default'][0])")"
+curl -fsS -X PUT "$GATEWAY_URL/dashboard/api/plugins/$PII_ID" -H "Content-Type: application/json" -d '{"enabled":false}' -o /dev/null
+curl -fsS -X POST "$GATEWAY_URL/dashboard/api/plugins" -H "x-s4-plugin-name: envelope-encrypt" \
+  --data-binary "@$ROOT/target/components/envelope-encrypt.component.wasm" -o /dev/null
+
+CERT_JSON="$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$(cat "$CERT")")"
+read -r AK SK < <(curl -fsS -X POST "$GATEWAY_URL/dashboard/api/keys" -H "Content-Type: application/json" \
+  -d "{\"label\":\"b2-demo\",\"public_key_pem\":$CERT_JSON}" \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['key_id'], d['secret'])")
+
+echo
+echo "===== STAGE 1: PRE-ENCRYPT — the fixture as you have it ====="
+cat "$INPUT"
+
+echo
+echo "===== PUT through S4 (envelope-encrypt) -> B2 ====="
+curl -fsS -X PUT "$GATEWAY_URL/$OBJ_KEY" \
+  -H "x-s4-access-key: $AK" -H "x-s4-secret-key: $SK" \
+  -H "Content-Type: text/plain" --data-binary "@$INPUT" \
+  -o /dev/null -w "PUT status: %{http_code}\n"
+
+echo
+echo "===== STAGE 2: ENCRYPTED AT REST — fetched DIRECTLY from B2 (bypassing S4) ====="
+docker run --rm -v "$MC_CONF:/root/.mc" minio/mc --no-color alias set b2 "$B2_S3_ENDPOINT" "$B2_ACCESS_KEY_ID" "$B2_SECRET_ACCESS_KEY" >/dev/null
+docker run --rm -v "$MC_CONF:/root/.mc" minio/mc --no-color cat "b2/$B2_BUCKET/$OBJ_KEY" | tee "$RAW"
+echo "(raw object: $(wc -c < "$RAW") bytes in bucket '$B2_BUCKET', key '$OBJ_KEY')"
+
+echo
+echo "===== STAGE 3: GET through S4 ====="
+curl -fsS "$GATEWAY_URL/$OBJ_KEY" -H "x-s4-access-key: $AK" -H "x-s4-secret-key: $SK" -o "$THROUGH"
+echo "returned $(wc -c < "$THROUGH") bytes (envelopes pass through unchanged)"
+
+echo
+echo "===== STAGE 4: DECRYPTED — client-side with the private key ====="
+python3 - "$KEY" "$THROUGH" > "$DECRYPTED" <<'EOF'
+import json, re, base64, sys
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+key_path, readback = sys.argv[1], sys.argv[2]
+priv = serialization.load_pem_private_key(open(key_path, 'rb').read(), None)
+s = open(readback).read()
+for obj in re.findall(r'\{[^{}]*"alg"[^{}]*\}', s):
+    env = json.loads(obj)
+    dek = priv.decrypt(base64.b64decode(env['enc_dek']),
+        padding.OAEP(mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                     algorithm=hashes.SHA256(), label=None))
+    pt = AESGCM(dek).decrypt(base64.b64decode(env['iv']),
+        base64.b64decode(env['ct']) + base64.b64decode(env['tag']), None)
+    print(pt.decode())
+EOF
+cat "$DECRYPTED"
+
+echo
+echo "===== VERIFY ====="
+python3 - "$INPUT" "$DECRYPTED" <<'EOF'
+import re, sys
+orig = open(sys.argv[1]).read()
+dec = open(sys.argv[2]).read()
+want = (set(re.findall(r'[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+', orig))
+        | set(re.findall(r'\b\d{3}-\d{2}-\d{4}\b', orig))
+        | set(re.findall(r'\b\d{13,19}\b', orig)))
+got = set(dec.splitlines())
+missing = want - got
+if missing:
+    print(f"FAIL: missing from decrypted: {missing}")
+    sys.exit(1)
+print(f"PASS: all {len(want)} PII values recovered by decryption")
+EOF
+
+curl -fsS -X DELETE "$GATEWAY_URL/$OBJ_KEY" -H "x-s4-access-key: $AK" -H "x-s4-secret-key: $SK" -o /dev/null 2>/dev/null || true
+echo "Demo complete."

--- a/examples/b2-encrypt-demo.sh
+++ b/examples/b2-encrypt-demo.sh
@@ -126,11 +126,23 @@ echo
 echo "===== VERIFY ====="
 python3 - "$INPUT" "$DECRYPTED" <<'EOF'
 import re, sys
+
+def luhn(n):
+    digits = [int(d) for d in str(n)]
+    checksum = 0
+    for i, d in enumerate(reversed(digits)):
+        if i % 2 == 1:
+            d *= 2
+            if d > 9:
+                d -= 9
+        checksum += d
+    return checksum % 10 == 0
+
 orig = open(sys.argv[1]).read()
 dec = open(sys.argv[2]).read()
 want = (set(re.findall(r'[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+', orig))
         | set(re.findall(r'\b\d{3}-\d{2}-\d{4}\b', orig))
-        | set(re.findall(r'\b\d{13,19}\b', orig)))
+        | {c for c in re.findall(r'\b\d{13,19}\b', orig) if luhn(c)})
 got = set(dec.splitlines())
 missing = want - got
 if missing:

--- a/skills/s4/SKILL.md
+++ b/skills/s4/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: s4
+description: S4 — pluggable processing gateway for S3-compatible object storage. Use when working in the S4 codebase: building/testing, the Wasm plugin pipeline, the S3 data plane, envelope encryption, SDKs, or the CI/release pipeline.
+---
+
+# S4 — pluggable processing gateway for object storage
+
+S4 is an S3-compatible gateway that runs WebAssembly plugins over every object in
+transit. Point any S3 SDK/tool at S4; each object passes through an ordered plugin
+pipeline (filter, redact, encrypt, convert, validate, route) and the result is
+forwarded to any S3-compatible backend (MinIO, AWS, GCS, B2, R2, …).
+
+## Core concepts
+
+- **Plugin pipeline** — enabled plugins run in order; output of plugin N feeds
+  plugin N+1. Each plugin is a Wasm component (`wit/s4-filter/world.wit`):
+  `begin(Context)`, `transform(Vec<u8>) -> Decision`, `finish()`.
+  Decision variants: `Emit`, `Drop`, `Reject`.
+- **Sandbox** — wasmtime, 64 MiB memory, 10K table entries, 512 KiB stack, no host
+  imports. Fuel: `S4_WASM_FUEL` (default 1B; crypto filters need the pipeline
+  budget, ~25M per RSA-OAEP wrap).
+- **Plugins are BYO** — write in any Wasm-capable language, `wasm-tools component
+  new`, then runtime import via `s4ctl plugin upload` (no gateway rebuild/restart).
+  `S4_PLUGINS_DIR` auto-loads a directory at startup. Default filter:
+  `filters/pii-default/` (redact emails / Luhn-valid cards / validated SSNs).
+- **Envelope encryption** — `filters/envelope-encrypt/` replaces each PII field
+  with `{"alg":"RSA-OAEP/AES-256-GCM","iv","enc_dek","ct","tag"}` using the API
+  key's bound X.509 public key. S4 never holds the private key; clients decrypt
+  (`s4_client.decrypt_payload`). Falls back to redaction without a key.
+  `filters/stable-encrypt/` is AES-SIV deterministic encryption for JOIN keys
+  (opt-in via stable-key/stable-fields context).
+- **Auth** — API keys (`x-s4-access-key`/`x-s4-secret-key` headers or
+  `Authorization: Bearer <ak>:<sk>`). Key stores: in-memory `KeyStore`,
+  `FileKeyStore` (`S4_KEYS_FILE`, default in local mode), `PostgresKeyStore`
+  (`DATABASE_URL`). Secrets stored SHA-256-hashed. `AUTH_DISABLED=true` = demo
+  bypass.
+- **Storage** — tiered: presigned-URL proxy (`x-s4-backend-url`), per-user
+  backend config (`BackendRegistry`), service storage (`S4_SERVICE_BUCKETS`,
+  consistent-hash ring + dual-write + read fail-over), global `S3_ENDPOINT`,
+  in-memory `MemoryStore` (local default).
+
+## Commands
+
+```bash
+just check            # fmt + clippy (-D warnings) + build filters + workspace tests
+just e2e              # MinIO data-plane e2e (Docker) — gateway server + s4ctl test upload
+just build-sdks       # regenerate Python/TypeScript SDKs (docker openapi-generator)
+just ci-local         # run the real ci.yml locally via act (colima)
+just image-local      # dagger: build the deploy image (cargo-cached)
+just publish-local TAG=x  # dagger: push ghcr.io/231self/s4/s4:<tag>
+s4ctl local init      # run the published gateway image standalone (Docker, in-memory)
+s4ctl put/get         # S3 data plane through the pipeline
+bash examples/b2-encrypt-demo.sh   # B2 encryption round-trip (needs B2_* env vars)
+```
+
+## Layout
+
+- `crates/gateway/` — the server: S3 data plane + dashboard API (axum, utoipa).
+- `crates/s4ctl/` — the CLI.
+- `crates/wasm-runtime/` — wasmtime sandbox (`FilterEngine`).
+- `crates/policy/`, `crates/error/` — shared policy/error types.
+- `filters/*/` — 7 Wasm filter crates (wasm32, wit-bindgen).
+- `wit/s4-filter/world.wit` — the plugin interface.
+- `sdks/{python,typescript}/` — generated clients + `overlay/` hand-written
+  high-level client (`S4Client`).
+- `migrations/` — sqlx migrations (run by the gateway at startup via `migrate!`).
+- `scripts/` — build-filters.sh, e2e-local.sh, generate-sdks.sh, check.sh.
+- `docs/plugins.md`, `docs/adr/` — plugin guide and architecture decisions.
+
+## Gotchas
+
+- **CI/release**: `ci.yml` splits fmt/lint/test/sdk/e2e into parallel jobs plus an
+  aggregate `check` (branch protection requires `check`). `release.yml` builds a
+  multi-arch image (`linux/amd64,linux/arm64`); the arm64 leg cross-compiles with
+  `gcc-aarch64-linux-gnu`. Cargo registry/target ride BuildKit cache mounts, and
+  binaries/components are copied OUT of the cache mount in the same RUN — never
+  `COPY --from=build .../target/...` without the mount.
+- **`.dockerignore` excludes `target/`** — without it, the host runner's binaries
+  leak into the image.
+- **act/colima**: act can't bind-mount the colima docker socket
+  (`.actrc` sets `--container-daemon-socket=-`); docker-dependent steps are guarded
+  with `if: ${{ !env.ACT }}`; `CARGO_BUILD_JOBS=2` keeps shared-VM memory bounded.
+- **Local mode keys**: with `AUTH_DISABLED=true` and no `DATABASE_URL`, keys persist
+  to `~/.config/s4/keys.json` (`FileKeyStore`).
+- **wasm-tools**: pinned to a version (1.255.0 in the Dockerfile; `cargo install
+  --locked wasm-tools` elsewhere). Rust 2024 edition via `rust-toolchain.toml`.
+- **jj repo**: never use git for mutations (`jj commit -m`, `jj git push -b <bk>`).


### PR DESCRIPTION
Runnable demo showing the full encryption round-trip against a real B2 bucket: pre-encrypt fixture, encrypted bytes fetched DIRECTLY from the bucket (bypassing S4), then client-side decryption through S4. Credentials via env vars — never committed.