### PR TITLE
ci(release): cache-to mode=min — releases drop from ~3h to ~1h

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
       # Single build: the Dockerfile compiles the wasm filters once (arch
       # independent) and the gateway per-arch. No separate runner-side Rust
       # builds — the release artifacts below are extracted from the image.
+      # mode=min: export only the final image layers, not the multi-GB cargo
+      # cache mounts. mode=max made releases take ~3h on the free runner
+      # (2h+ uploading the cargo target dirs to the GHA cache). The build
+      # itself (~40-50 min cold) is the floor; releases now finish in ~1h.
       - name: Build and push image to GHCR
         uses: docker/build-push-action@v6
         with:
@@ -44,7 +48,7 @@ jobs:
           push: true
           tags: ${{ env.IMAGE }}:${{ github.ref_name }}, ${{ env.IMAGE }}:latest
           cache-from: type=gha
-          cache-to: type=gha, mode=max
+          cache-to: type=gha, mode=min
 
       - name: Extract release artifacts from image
         run: |


### PR DESCRIPTION
The 3h release was entirely the image build: `cache-to: type=gha, mode=max` exports the multi-GB cargo target dirs (both arches) to the GHA cache — a 2h+ upload. `mode=min` exports only final image layers. Parallel-per-arch was rejected: an arm64 job on an x86 runner builds under QEMU emulation (slower than the Dockerfile's native cross-compile).