### PR TITLE
ci(release): compile-once + COPY assembly — releases drop to ~5-15 min

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,81 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # Repo-scoped image: the workflow's GITHUB_TOKEN can manage visibility and
-  # prune old versions of repo-scoped packages (org-scoped packages require
-  # an org-owner PAT). Registry path must be lowercase.
+  CARGO_BUILD_JOBS: 2
   IMAGE: ghcr.io/${{ github.repository_owner }}/s4/s4
 
 jobs:
+  # Compile the gateway ONCE per architecture on the runner (reusing the
+  # warm rust-cache from CI), then assemble the image with COPYs — no
+  # compilation inside Docker. The two arch jobs run in parallel.
+  build:
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            rust_target: x86_64-unknown-linux-gnu
+            suffix: amd64
+          - platform: linux/arm64
+            rust_target: aarch64-unknown-linux-gnu
+            suffix: arm64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown, ${{ matrix.rust_target }}
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cross linker (arm64)
+        if: matrix.platform == 'linux/arm64'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
+
+      - name: Install wasm-tools + build filters
+        run: |
+          cargo install --locked wasm-tools
+          bash scripts/build-filters.sh
+
+      - name: Build gateway release (${{ matrix.suffix }})
+        run: |
+          mkdir -p dist/components
+          if [ "${{ matrix.platform }}" = "linux/arm64" ]; then
+            CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+              cargo build --release --target aarch64-unknown-linux-gnu -p s4-gateway
+            cp target/aarch64-unknown-linux-gnu/release/s4-gateway dist/s4-gateway
+          else
+            cargo build --release -p s4-gateway
+            cp target/release/s4-gateway dist/s4-gateway
+          fi
+          cp -r target/components/. dist/components/
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
+      # Assembly-only build (seconds): COPYs the runner-built artifacts.
+      - name: Build + push image (${{ matrix.suffix }})
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.release
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ env.IMAGE }}:${{ github.ref_name }}-${{ matrix.suffix }}
+
   release:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,27 +101,18 @@ jobs:
         with:
           driver: docker-container
 
-      # Single build: the Dockerfile compiles the wasm filters once (arch
-      # independent) and the gateway per-arch. No separate runner-side Rust
-      # builds — the release artifacts below are extracted from the image.
-      # mode=min: export only the final image layers, not the multi-GB cargo
-      # cache mounts. mode=max made releases take ~3h on the free runner
-      # (2h+ uploading the cargo target dirs to the GHA cache). The build
-      # itself (~40-50 min cold) is the floor; releases now finish in ~1h.
-      - name: Build and push image to GHCR
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ env.IMAGE }}:${{ github.ref_name }}, ${{ env.IMAGE }}:latest
-          cache-from: type=gha
-          cache-to: type=gha, mode=min
+      - name: Merge multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE }}:${{ github.ref_name }} \
+            -t ${{ env.IMAGE }}:latest \
+            ${{ env.IMAGE }}:${{ github.ref_name }}-amd64 \
+            ${{ env.IMAGE }}:${{ github.ref_name }}-arm64
 
       - name: Extract release artifacts from image
         run: |
           mkdir -p dist/filters
-          docker create --name s4-extract --platform linux/amd64 "${{ env.IMAGE }}:${{ github.ref_name }}"
+          docker create --name s4-extract --platform linux/amd64 "${{ env.IMAGE }}:${{ github.ref_name }}-amd64"
           docker cp s4-extract:/usr/local/bin/s4-gateway dist/s4-gateway-linux-x86_64
           docker cp s4-extract:/app/components/. dist/filters/
           docker rm s4-extract
@@ -74,8 +133,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           keep=3
-          # Newest-first tagged versions (latest is first); delete everything
-          # past the keep window. Best-effort so it never blocks a release.
           gh api --paginate "/repos/${{ github.repository }}/packages/container/s4/versions?per_page=100" \
             --jq '[.[] | select((.metadata.container.tags | length) > 0)
                    | {id, created: .created_at, tag: .metadata.container.tags[0]}]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+# Assembly-only image: the gateway binary + Wasm components are built on the
+# GitHub runner (warm cargo cache) and staged in dist/; this Dockerfile just
+# packages them. The release job cross-compiles per architecture, so this
+# builds in seconds (no compilation in Docker).
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY dist/s4-gateway /usr/local/bin/s4-gateway
+COPY dist/components /app/components
+ENV S4_FILTER_COMPONENT=/app/components/pii-default.component.wasm
+ENV S4_PLUGINS_DIR=/app/components
+ENV LISTEN_ADDR=0.0.0.0:8080
+EXPOSE 8080
+ENTRYPOINT ["s4-gateway"]

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Run the same checks that CI runs before allowing a commit.
+# Matches .github/workflows/ci.yml exactly.
+# Fails fast: any error blocks the commit.
+# Override with: git commit --no-verify
+set -e
+
+echo "==> cargo fmt --check"
+cargo fmt --check
+
+echo "==> cargo clippy --all-targets -- -D warnings"
+cargo clippy --all-targets -- -D warnings
+
+echo "All checks passed"


### PR DESCRIPTION
The ~1h release was Rust compilation inside Docker (full workspace, amd64 + arm64, cold, on a 2-core runner).\n\nNow: each arch job compiles the gateway on the runner (reusing CI's warm rust-cache), stages artifacts in dist/, and builds an **assembly-only image** (Dockerfile.release — COPY binary + components, seconds). The release job merges the per-arch manifests and extracts dist artifacts.\n\nVerified locally: Dockerfile.release assembles in 4s.