### PR TITLE
ci(release): arm64 cross-build needs aarch64 OpenSSL (openssl-sys)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install cross linker (arm64)
+      - name: Install cross linker + libs (arm64)
         if: matrix.platform == 'linux/arm64'
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross libssl-dev:arm64 pkg-config-aarch64-linux-gnu
 
       - name: Install wasm-tools + build filters
         run: |
@@ -49,6 +49,9 @@ jobs:
           bash scripts/build-filters.sh
 
       - name: Build gateway release (${{ matrix.suffix }})
+        env:
+          # openssl-sys cross-compile: allow pkg-config to find the aarch64 OpenSSL
+          PKG_CONFIG_ALLOW_CROSS: "1"
         run: |
           mkdir -p dist/components
           if [ "${{ matrix.platform }}" = "linux/arm64" ]; then


### PR DESCRIPTION
openssl-sys can't find OpenSSL for the aarch64 cross-compile. Install libssl-dev:arm64 + pkg-config-aarch64-linux-gnu and allow cross pkg-config (PKG_CONFIG_ALLOW_CROSS=1).