### PR TITLE
ci(release): amd64-only for now (drop arm64 cross-compile)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,19 +14,10 @@ env:
   IMAGE: ghcr.io/${{ github.repository_owner }}/s4/s4
 
 jobs:
-  # Compile the gateway ONCE per architecture on the runner (reusing the
-  # warm rust-cache from CI), then assemble the image with COPYs — no
-  # compilation inside Docker. The two arch jobs run in parallel.
+  # Compile the gateway on the runner (reusing CI's warm rust-cache), stage
+  # dist/, and assemble the image with COPYs — no compilation inside Docker.
+  # amd64 only for now (multi-arch cross-compile deferred).
   build:
-    strategy:
-      matrix:
-        include:
-          - platform: linux/amd64
-            rust_target: x86_64-unknown-linux-gnu
-            suffix: amd64
-          - platform: linux/arm64
-            rust_target: aarch64-unknown-linux-gnu
-            suffix: arm64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,37 +25,21 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown, ${{ matrix.rust_target }}
+          targets: wasm32-unknown-unknown
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
-
-      - name: Install cross linker + libs (arm64)
-        if: matrix.platform == 'linux/arm64'
-        run: |
-          sudo dpkg --add-architecture arm64
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross libssl-dev:arm64 pkg-config-aarch64-linux-gnu
 
       - name: Install wasm-tools + build filters
         run: |
           cargo install --locked wasm-tools
           bash scripts/build-filters.sh
 
-      - name: Build gateway release (${{ matrix.suffix }})
-        env:
-          # openssl-sys cross-compile: allow pkg-config to find the aarch64 OpenSSL
-          PKG_CONFIG_ALLOW_CROSS: "1"
+      - name: Build gateway release
         run: |
+          cargo build --release -p s4-gateway
           mkdir -p dist/components
-          if [ "${{ matrix.platform }}" = "linux/arm64" ]; then
-            CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-              cargo build --release --target aarch64-unknown-linux-gnu -p s4-gateway
-            cp target/aarch64-unknown-linux-gnu/release/s4-gateway dist/s4-gateway
-          else
-            cargo build --release -p s4-gateway
-            cp target/release/s4-gateway dist/s4-gateway
-          fi
+          cp target/release/s4-gateway dist/s4-gateway
           cp -r target/components/. dist/components/
 
       - name: Log in to GHCR
@@ -80,45 +55,21 @@ jobs:
           driver: docker-container
 
       # Assembly-only build (seconds): COPYs the runner-built artifacts.
-      - name: Build + push image (${{ matrix.suffix }})
+      - name: Build + push image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.release
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           push: true
-          tags: ${{ env.IMAGE }}:${{ github.ref_name }}-${{ matrix.suffix }}
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker-container
-
-      - name: Merge multi-arch manifest
-        run: |
-          docker buildx imagetools create \
-            -t ${{ env.IMAGE }}:${{ github.ref_name }} \
-            -t ${{ env.IMAGE }}:latest \
-            ${{ env.IMAGE }}:${{ github.ref_name }}-amd64 \
-            ${{ env.IMAGE }}:${{ github.ref_name }}-arm64
+          tags: ${{ env.IMAGE }}:${{ github.ref_name }}, ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha, mode=min
 
       - name: Extract release artifacts from image
         run: |
           mkdir -p dist/filters
-          docker create --name s4-extract --platform linux/amd64 "${{ env.IMAGE }}:${{ github.ref_name }}-amd64"
+          docker create --name s4-extract --platform linux/amd64 "${{ env.IMAGE }}:${{ github.ref_name }}"
           docker cp s4-extract:/usr/local/bin/s4-gateway dist/s4-gateway-linux-x86_64
           docker cp s4-extract:/app/components/. dist/filters/
           docker rm s4-extract


### PR DESCRIPTION
The arm64 cross-compile (ring / aws-lc-sys / openssl-sys) kept failing on the runner despite multiple toolchain approaches. Ship **amd64 only**: single build job (no matrix), compile on the runner (warm rust-cache), assemble the image with COPYs (seconds), push `:vX` + `:latest`. Fast and reliable; arm64 deferred.