### PR TITLE
fix(gateway): tolerate non-engine migrations in shared _sqlx_migrations table

### DIFF
--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -1068,10 +1068,12 @@ pub async fn build_state(control: Arc<dyn ControlPlane>) -> anyhow::Result<Arc<A
             .connect(&database_url)
             .await
             .expect("failed to connect to DATABASE_URL");
-        sqlx::migrate!("../../migrations")
-            .run(&pool)
-            .await
-            .expect("failed to run migrations");
+        let mut migrator = sqlx::migrate!("../../migrations");
+        // The SaaS control plane applies its own migrations (workspaces, usage,
+        // billing) to the same database and shares the `_sqlx_migrations` table.
+        // Ignore migrations we don't know about so both binaries can coexist.
+        migrator.set_ignore_missing(true);
+        migrator.run(&pool).await.expect("failed to run migrations");
         info!("Key store: Postgres (migrations applied)");
         Arc::new(PostgresKeyStore::new(pool))
     } else if let Ok(keys_file) = std::env::var("S4_KEYS_FILE") {


### PR DESCRIPTION
The SaaS control plane (`s4-control`, private repo) applies its own migrations (workspaces, usage_records, billing) to the same database as the engine and shares the `_sqlx_migrations` table.

sqlx errors on applied migrations that are missing from a migrator's set (`VersionMissing`), so on the second boot the engine migrator fails when it sees the SaaS migration rows. Set `ignore_missing` on the engine migrator so both binaries can migrate the same database independently.