### PR TITLE
fix(gateway): PII truncation in query-string/plain records; TSV format; per-user managed-storage namespace

### DIFF
--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -21,6 +21,7 @@ pub enum Format {
     Jsonl,
     Json,
     Csv,
+    Tsv,
     Text,
 }
 
@@ -30,6 +31,7 @@ impl Format {
             Format::Jsonl => "jsonl",
             Format::Json => "json",
             Format::Csv => "csv",
+            Format::Tsv => "tsv",
             Format::Text => "text",
         }
     }
@@ -39,6 +41,7 @@ impl Format {
             "jsonl" => Some(Self::Jsonl),
             "json" => Some(Self::Json),
             "csv" => Some(Self::Csv),
+            "tsv" => Some(Self::Tsv),
             "text" => Some(Self::Text),
             _ => None,
         }
@@ -123,6 +126,7 @@ pub fn split_records(input: &[u8], format: Format) -> Result<Vec<Vec<u8>>, S4Err
     match format {
         Format::Jsonl => split_lines(input),
         Format::Text => split_lines(input),
+        Format::Tsv => split_lines(input),
         Format::Json => {
             let s = std::str::from_utf8(input)
                 .map_err(|e| S4Error::new(codes::DECODE_ENCODING, e.to_string()))?;
@@ -192,7 +196,10 @@ fn is_empty_or_whitespace(b: &[u8]) -> bool {
 }
 
 fn needs_newline(format: Format) -> bool {
-    matches!(format, Format::Jsonl | Format::Text | Format::Csv)
+    matches!(
+        format,
+        Format::Jsonl | Format::Text | Format::Csv | Format::Tsv
+    )
 }
 
 #[cfg(test)]
@@ -238,10 +245,12 @@ mod tests {
         assert_eq!(Format::parse("jsonl"), Some(Format::Jsonl));
         assert_eq!(Format::parse("json"), Some(Format::Json));
         assert_eq!(Format::parse("csv"), Some(Format::Csv));
+        assert_eq!(Format::parse("tsv"), Some(Format::Tsv));
     }
 
     #[test]
     fn format_parse_invalid() {
         assert_eq!(Format::parse("pdf"), None);
+        assert_eq!(Format::parse("parquet"), None);
     }
 }

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -149,6 +149,7 @@ fn detect_format(headers: &HeaderMap) -> Format {
         "application/x-ndjson" | "application/jsonlines" => Format::Jsonl,
         "application/json" => Format::Json,
         "text/csv" => Format::Csv,
+        "text/tab-separated-values" => Format::Tsv,
         _ => Format::Text,
     }
 }
@@ -402,7 +403,7 @@ async fn s3_put(
         match state
             .service_storage
             .put(
-                &format!("{}/{}", bucket, key),
+                &format!("{}/{}/{}", uid, bucket, key),
                 output.bytes.to_vec(),
                 "text/plain",
             )
@@ -528,7 +529,7 @@ async fn s3_get(
     } else if !state.service_storage.is_empty() {
         match state
             .service_storage
-            .get(&format!("{}/{}", bucket, key))
+            .get(&format!("{}/{}/{}", auth.user_id, bucket, key))
             .await
         {
             Some((data, content_type)) => {

--- a/filters/pii-shared/src/lib.rs
+++ b/filters/pii-shared/src/lib.rs
@@ -224,26 +224,19 @@ fn find_digit_token(bytes: &[u8], start: usize, len: usize) -> Option<(usize, us
 }
 
 fn find_email_boundary(bytes: &[u8], at_pos: usize, len: usize) -> Option<(usize, usize)> {
+    // Terminate the email token at whitespace / quote / comma / `&` (the
+    // query-string separator). `=` and `;` stay greedy on both sides so the
+    // original adversarial redaction semantics hold (e.g. SQL injection
+    // payloads like `email='admin@example.com'; DROP` redact as one span).
+    // `&` must be a boundary on the RIGHT so `email=alice@example.com&card=...`
+    // redacts just the address instead of swallowing the whole line.
+    let is_boundary = |b: u8| matches!(b, b' ' | b'\n' | b'\r' | b'\t' | b',' | b'"' | b'&');
     let mut s = at_pos;
-    while s > 0
-        && bytes[s - 1] != b' '
-        && bytes[s - 1] != b'\n'
-        && bytes[s - 1] != b'\r'
-        && bytes[s - 1] != b'\t'
-        && bytes[s - 1] != b','
-        && bytes[s - 1] != b'"'
-    {
+    while s > 0 && !is_boundary(bytes[s - 1]) {
         s -= 1;
     }
     let mut e = at_pos + 1;
-    while e < len
-        && bytes[e] != b' '
-        && bytes[e] != b'\n'
-        && bytes[e] != b'\r'
-        && bytes[e] != b'\t'
-        && bytes[e] != b','
-        && bytes[e] != b'"'
-    {
+    while e < len && !is_boundary(bytes[e]) {
         e += 1;
     }
     if s < at_pos && e > at_pos + 1 {
@@ -503,6 +496,18 @@ mod tests {
     #[test]
     fn email_on_word_boundary() {
         assert_eq!(redact_pii("a@b.co is email"), "[REDACTED_EMAIL] is email");
+    }
+
+    #[test]
+    fn query_string_multiple_fields_preserved() {
+        // Regression: `&` must terminate the email token, otherwise the whole
+        // line becomes one email span (no spaces) and card/ssn/note are lost.
+        let input = "email=alice@example.com&card=4111-1111-1111-1111&ssn=078-05-1120&note=hi";
+        let result = redact_pii(input);
+        assert_eq!(
+            result,
+            "[REDACTED_EMAIL]&card=[REDACTED_CARD]&ssn=[REDACTED_SSN]&note=hi"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Three changes to the OSS engine:

### 1. PII truncation fix (data loss bug)
`find_email_boundary` only terminated emails at whitespace/comma/quote. In query-string or plain records with no whitespace (`email=alice@example.com&card=4111-1111-1111-1111`), the email span extended across the entire line — the whole record redacted to one `[REDACTED_EMAIL]` and every field after the first was dropped.

Adds `&` as a boundary (both sides) so the address terminates at the query separator. `=` and `;` stay greedy to preserve adversarial redaction semantics (SQL injection payloads still redact as one span).

Regression test: `query_string_multiple_fields_preserved`.

### 2. TSV format support
`Format::Tsv`, `text/tab-separated-values` detection, record split by newlines, `needs_newline` includes Tsv. Tests added.

### 3. Per-user managed-storage namespace
Service-storage PUT/GET keys are now `{uid}/{bucket}/{key}` instead of `{bucket}/{key}`, isolating each user in a shared S4-managed backend (the managed-storage offering configures one bucket for many users).

## Testing
`cargo test -p s4-gateway -p pii-shared` — all pass (unit, fixtures, encrypt roundtrip, pipeline, stable-encrypt).