### PR TITLE
fix(gateway): gate debug-only operation journal behind cfg for release builds

### DIFF
--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -5658,7 +5658,8 @@ pub async fn build_state(
         info!("Key store: in-memory (set DATABASE_URL or S4_KEYS_FILE for persistence)");
         Arc::new(KeyStore::with_cipher(cipher))
     };
-    if operation_journal.is_none() && auth_disabled && cfg!(debug_assertions) {
+    #[cfg(debug_assertions)]
+    if operation_journal.is_none() && auth_disabled {
         info!(
             "Operation journal: in-memory (dev local mode; streaming S3 PUT uses a non-durable journal)"
         );

--- a/crates/gateway/src/transaction/journal.rs
+++ b/crates/gateway/src/transaction/journal.rs
@@ -1,4 +1,6 @@
+#[cfg(any(test, debug_assertions))]
 use std::collections::HashMap;
+#[cfg(any(test, debug_assertions))]
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -7,6 +9,7 @@ use sea_orm::{
     ActiveModelTrait, ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter,
     QueryOrder, QuerySelect, Set, SqlxPostgresConnector,
 };
+#[cfg(any(test, debug_assertions))]
 use tokio::sync::Mutex;
 use uuid::Uuid;
 


### PR DESCRIPTION
Release builds fail because `InMemoryOperationJournal` is gated behind `#[cfg(any(test, debug_assertions))]` but was referenced under a runtime `cfg!(debug_assertions)` check (still compiled in release), and its `journal.rs` imports (`HashMap`, `Arc`, `Mutex`) were left ungated.

- `server.rs`: `cfg!(debug_assertions)` -> compile-time `#[cfg(debug_assertions)]` on the in-memory journal fallback block.
- `journal.rs`: gate the three debug-only imports.

Verified with `cargo check --release --workspace` and `cargo check -p s4-gateway --tests`. Caught by the s4-control release deploy; public CI only builds debug.