### PR TITLE
fix(gateway): implement demo safe/join read modes (streaming disclosure)

### DIFF
--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -1501,12 +1501,8 @@ async fn demo_store(
 }
 
 /// Demo read: fetch a stored demo record and run the requested disclosure mode.
-/// `mode`:
-/// - `raw`  -> the bytes at rest (as your app sees them)
-/// - `safe` -> the record run through the PII pipeline (detect + redact)
-/// - `join` -> the record run through the pipeline with stable-encrypt on
-///             `email` (same ciphertext for the same email, so the records
-///             remain joinable without exposing plaintext)
+/// `mode` is `raw` (bytes at rest), `safe` (PII redacted), or `join` (`email`
+/// stable-encrypted so records stay joinable without exposing plaintext).
 #[derive(Deserialize, ToSchema)]
 struct DemoReadQuery {
     id: Option<u32>,      // 1-based record number; default 1
@@ -1552,7 +1548,9 @@ async fn demo_read(
                 }
             }
         }
-        other => return (StatusCode::BAD_REQUEST, format!("unknown mode: {other}")).into_response(),
+        other => {
+            return (StatusCode::BAD_REQUEST, format!("unknown mode: {other}")).into_response();
+        }
     };
     Json(serde_json::json!({
         "mode": mode,

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -1500,11 +1500,13 @@ async fn demo_store(
     Json(serde_json::json!({ "stored": body.records.len(), "namespace": "__demo" })).into_response()
 }
 
-/// Demo read: fetch a stored demo record in raw mode. Transformed modes remain
-/// unavailable until the streaming disclosure model is implemented.
+/// Demo read: fetch a stored demo record and run the requested disclosure mode.
 /// `mode`:
 /// - `raw`  -> the bytes at rest (as your app sees them)
-/// - `safe` / `join` -> rejected
+/// - `safe` -> the record run through the PII pipeline (detect + redact)
+/// - `join` -> the record run through the pipeline with stable-encrypt on
+///             `email` (same ciphertext for the same email, so the records
+///             remain joinable without exposing plaintext)
 #[derive(Deserialize, ToSchema)]
 struct DemoReadQuery {
     id: Option<u32>,      // 1-based record number; default 1
@@ -1517,16 +1519,45 @@ async fn demo_read(
 ) -> impl IntoResponse {
     let id = q.id.unwrap_or(1);
     let mode = q.mode.as_deref().unwrap_or("raw");
-    if mode != "raw" {
-        return s3_error::transformed_read_not_supported(&format!("record-{id}.json"));
-    }
     let Some(obj) = state.store.get("__demo", &format!("record-{id}.json")) else {
         return (StatusCode::NOT_FOUND, "no demo record stored yet").into_response();
+    };
+    let body = match mode {
+        "raw" => String::from_utf8_lossy(&obj.data).into_owned(),
+        "safe" | "join" => {
+            let stable_key: Option<Vec<u8>> = if mode == "join" {
+                Some(derive_stable_key("s4-demo"))
+            } else {
+                None
+            };
+            let stable_fields: Option<&str> = if mode == "join" { Some("email") } else { None };
+            match run_demo_streaming(
+                &state,
+                &obj.data,
+                Format::Json,
+                "application/json",
+                None,
+                stable_key.as_deref(),
+                stable_fields,
+            )
+            .await
+            {
+                Ok((bytes, _)) => String::from_utf8_lossy(&bytes).into_owned(),
+                Err(error) => {
+                    return (
+                        StatusCode::UNPROCESSABLE_ENTITY,
+                        format!("pipeline error: {error}"),
+                    )
+                        .into_response();
+                }
+            }
+        }
+        other => return (StatusCode::BAD_REQUEST, format!("unknown mode: {other}")).into_response(),
     };
     Json(serde_json::json!({
         "mode": mode,
         "record": id,
-        "body": String::from_utf8_lossy(&obj.data),
+        "body": body,
     }))
     .into_response()
 }

--- a/crates/gateway/tests/s3_frontdoor_test.rs
+++ b/crates/gateway/tests/s3_frontdoor_test.rs
@@ -2374,7 +2374,7 @@ async fn empty_prefix_safe_snapshot_streams_without_length_or_staging() {
 }
 
 #[tokio::test]
-async fn demo_transformed_read_modes_are_rejected() {
+async fn demo_read_safe_and_join_modes() {
     let (app, _state) = router().await;
 
     // 1. Store two records sharing an email.
@@ -2418,7 +2418,7 @@ async fn demo_transformed_read_modes_are_rejected() {
         "raw keeps PII: {raw_text}"
     );
 
-    // 3. Safe and join modes are rejected before reading stored data.
+    // 3. Safe read runs the PII pipeline (detect + redact).
     let safe = app
         .clone()
         .oneshot(
@@ -2430,58 +2430,49 @@ async fn demo_transformed_read_modes_are_rejected() {
         )
         .await
         .unwrap();
-    assert_eq!(safe.status(), StatusCode::NOT_IMPLEMENTED);
-    let safe_body = axum::body::to_bytes(safe.into_body(), usize::MAX)
+    assert_eq!(safe.status(), StatusCode::OK);
+    let safe_bytes = axum::body::to_bytes(safe.into_body(), usize::MAX)
         .await
         .unwrap();
-    let safe_text = String::from_utf8_lossy(&safe_body);
+    let safe_text = String::from_utf8_lossy(&safe_bytes);
     assert!(
-        safe_text.contains("<Code>NotImplemented</Code>")
-            && !safe_text.contains("alice@example.com"),
-        "safe mode must fail without disclosure: {safe_text}"
+        safe_text.contains("REDACTED_EMAIL") && !safe_text.contains("alice@example.com"),
+        "safe must redact PII: {safe_text}"
     );
 
-    // 4. Joinable reads are also unavailable until Phase 8.
-    let j1 = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("GET")
-                .uri("/dashboard/api/demo/read?id=1&mode=join")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(j1.status(), StatusCode::NOT_IMPLEMENTED);
-    let j2 = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("GET")
-                .uri("/dashboard/api/demo/read?id=2&mode=join")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(j2.status(), StatusCode::NOT_IMPLEMENTED);
-    let t1 = String::from_utf8_lossy(
-        &axum::body::to_bytes(j1.into_body(), usize::MAX)
-            .await
-            .unwrap(),
-    )
-    .to_string();
-    let t2 = String::from_utf8_lossy(
-        &axum::body::to_bytes(j2.into_body(), usize::MAX)
-            .await
-            .unwrap(),
-    )
-    .to_string();
-    assert!(
-        !t1.contains("alice@example.com") && !t2.contains("alice@example.com"),
-        "join leaks PII"
+    // 4. Join read stable-encrypts `email`; the same email yields identical
+    //    ciphertext across records (joinable without plaintext).
+    let read_join = |id: u32| {
+        let app = app.clone();
+        async move {
+            let resp = app
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri(format!("/dashboard/api/demo/read?id={id}&mode=join"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            let text = String::from_utf8_lossy(
+                &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap(),
+            )
+            .to_string();
+            let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+            let body: serde_json::Value =
+                serde_json::from_str(value["body"].as_str().unwrap()).unwrap();
+            body["email"].as_str().unwrap().to_string()
+        }
+    };
+    let email1 = read_join(1).await;
+    let email2 = read_join(2).await;
+    assert_ne!(email1, "alice@example.com", "join leaks plaintext email");
+    assert_eq!(
+        email1, email2,
+        "join must produce identical ciphertext for the same email"
     );
-    assert!(t1.contains("<Code>NotImplemented</Code>"), "{t1}");
-    assert!(t2.contains("<Code>NotImplemented</Code>"), "{t2}");
 }


### PR DESCRIPTION
The landing-page demo's `read safe` and `read join` steps returned 501 because `demo_read` still hardcoded them to `transformed_read_not_supported` with a stale "streaming disclosure model not implemented" comment. That model is now live.

Fixes:
- `demo_read` now runs the stored demo record through the streaming pipeline:
  - `safe` -> detect + redact (PII replaced with `[REDACTED_*]`)
  - `join` -> stable-encrypt the `email` field (same email -> identical ciphertext, so records stay joinable)
- Updated `demo_transformed_read_modes_are_rejected` -> `demo_read_safe_and_join_modes` to assert redaction and identical join ciphertext.

Verified with `cargo check --release -p s4-gateway` and the updated integration test.