### PR TITLE
fix(ci): enable streaming write mode in release image smoke

### DIFF
--- a/scripts/release-image-smoke.sh
+++ b/scripts/release-image-smoke.sh
@@ -53,6 +53,7 @@ docker run --rm --network "$NETWORK" -v "$MC_CONF:/root/.mc" "$MC_IMAGE" --no-co
 docker run -d --name "$GATEWAY_NAME" --network "$NETWORK" \
   -p "127.0.0.1:${GATEWAY_PORT}:8080" \
   -e AUTH_DISABLED=true \
+  -e S4_STREAMING_WRITE_MODE=all \
   -e S4_KEYS_FILE=/tmp/keys.json \
   -e S3_ENDPOINT="http://${MINIO_NAME}:9000" \
   -e S3_ACCESS_KEY_ID=minioadmin \


### PR DESCRIPTION
## Problem
The `release-image-smoke.sh` boot-smoke failed on the v0.3.6 release build: the gateway PUT returned **501** (`curl exit 22`), so the arm64 leg failed and the release was skipped.

## Root cause
The gateway defaults fail-closed — with no `S4_STREAMING_WRITE_MODE`, `streaming_write_mode()` is `Off` and the PUT gate returns `not_implemented` (501) before reading the body. The smoke gateway only set `AUTH_DISABLED=true` + legacy `S3_ENDPOINT`, so every smoke PUT was rejected.

## Fix
Set `S4_STREAMING_WRITE_MODE=all` on the smoke gateway container (matching production config). The write path then streams through the pipeline into MinIO as before.

## Note
v0.3.6 was tagged but never published (release job skipped). After this merges, v0.3.6 will be re-tagged at the fix and re-run.