### PR TITLE
fix(s3): decode JSON multipart parts as independent documents

### DIFF
--- a/crates/gateway/src/record.rs
+++ b/crates/gateway/src/record.rs
@@ -158,6 +158,31 @@ impl RecordDecoder {
                 .unwrap_or(0)
     }
 
+    /// Signals the end of a discrete source segment (e.g. one multipart part).
+    ///
+    /// Whole-document formats (JSON) emit a complete document immediately and
+    /// reset so the next segment decodes independently; a document that spans
+    /// segment boundaries stays buffered until it completes. Line/TSV/CSV
+    /// formats emit incrementally and need no per-segment handling.
+    pub fn end_of_segment(&mut self) -> Result<(), S4Error> {
+        if self.format != Format::Json || self.pending.is_empty() || self.ready.is_some() {
+            return Ok(());
+        }
+        match serde_json::from_slice::<serde_json::Value>(&self.pending) {
+            Ok(_) => {
+                self.ready = Some(Record::new(
+                    Bytes::from(std::mem::take(&mut self.pending)),
+                    Bytes::new(),
+                ));
+                self.input_seen = true;
+                self.scan_offset = 0;
+            }
+            Err(error) if error.is_eof() => {}
+            Err(error) => return Err(S4Error::new(codes::DECODE_JSON, error.to_string())),
+        }
+        Ok(())
+    }
+
     fn prepare_next(&mut self, at_eof: bool) -> Result<(), S4Error> {
         if self.ready.is_some() || self.complete {
             return Ok(());
@@ -202,6 +227,10 @@ impl RecordDecoder {
     fn prepare_json(&mut self, at_eof: bool) -> Result<(), S4Error> {
         self.ensure_pending_limit(self.limits.max_json_document_bytes, "JSON document")?;
         if !at_eof {
+            return Ok(());
+        }
+        if self.pending.is_empty() {
+            self.complete = true;
             return Ok(());
         }
         validate_utf8(&self.pending, codes::DECODE_ENCODING)?;
@@ -433,4 +462,49 @@ fn validate_utf8(input: &[u8], code: &'static str) -> Result<(), S4Error> {
 
 fn limit_error(code: &'static str, kind: &str, actual: usize, limit: usize) -> S4Error {
     S4Error::new(code, format!("{kind} size {actual} exceeds limit {limit}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_segments_emit_one_document_each() {
+        let mut decoder = RecordDecoder::new(Format::Json, DecoderLimits::default()).unwrap();
+        decoder.push(br#"{"a":1}"#).unwrap();
+        assert!(decoder.next_record().unwrap().is_none());
+        decoder.end_of_segment().unwrap();
+        let record = decoder.next_record().unwrap().expect("first document");
+        assert_eq!(record.payload.as_ref(), br#"{"a":1}"#);
+        assert_eq!(record.separator.as_ref(), b"");
+
+        decoder.push(br#"{"b":2}"#).unwrap();
+        assert!(decoder.next_record().unwrap().is_none());
+        decoder.end_of_segment().unwrap();
+        let record = decoder.next_record().unwrap().expect("second document");
+        assert_eq!(record.payload.as_ref(), br#"{"b":2}"#);
+
+        decoder.finish().unwrap();
+        assert!(decoder.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn json_document_spanning_segments_stays_buffered_until_complete() {
+        let mut decoder = RecordDecoder::new(Format::Json, DecoderLimits::default()).unwrap();
+        decoder.push(br#"{"a":"#).unwrap();
+        decoder.end_of_segment().unwrap();
+        assert!(decoder.next_record().unwrap().is_none());
+        decoder.push(br#"1}"#).unwrap();
+        decoder.finish().unwrap();
+        let record = decoder.next_record().unwrap().expect("completed document");
+        assert_eq!(record.payload.as_ref(), br#"{"a":1}"#);
+        assert!(decoder.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn json_empty_stream_finishes_cleanly() {
+        let mut decoder = RecordDecoder::new(Format::Json, DecoderLimits::default()).unwrap();
+        decoder.finish().unwrap();
+        assert!(decoder.next_record().unwrap().is_none());
+    }
 }

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -2650,6 +2650,29 @@ async fn complete_staged_multipart(
                     "staged multipart artifact does not match its committed part".to_string(),
                 ));
             }
+            // JSON is a whole-document format: parts carry independent
+            // documents, so flush a completed document at each part boundary
+            // instead of concatenating every part into one JSON value.
+            decoder.end_of_segment()?;
+            while let Some(record) = decoder.next_record()? {
+                if let Some(record) = pipeline
+                    .as_mut()
+                    .expect("pipeline is present until finish")
+                    .process(record)
+                    .await?
+                {
+                    write_completed_record(
+                        staging,
+                        identity,
+                        lease,
+                        &mut sink,
+                        record,
+                        &mut output_hasher,
+                        &mut output_bytes,
+                    )
+                    .await?;
+                }
+            }
         }
         decoder.finish()?;
         while let Some(record) = decoder.next_record()? {
@@ -5976,6 +5999,16 @@ mod multipart_completion_tests {
             br#"<!DOCTYPE x [<!ENTITY boom "boom">]><CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>&boom;</ETag></Part></CompleteMultipartUpload>"#,
         )
         .is_err());
+    }
+
+    #[test]
+    fn complete_xml_accepts_quoted_hex_etags() {
+        let parts = parse_complete_multipart_xml(
+            br#"<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>"c56e589acfa9d79113ff4c36f72d0228"</ETag></Part><Part><PartNumber>2</PartNumber><ETag>"cde8de78ea9269548adfcd9f7505ae9b"</ETag></Part></CompleteMultipartUpload>"#,
+        )
+        .expect("two-part complete XML with quoted hex ETags must parse");
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0].etag, "\"c56e589acfa9d79113ff4c36f72d0228\"");
     }
 }
 


### PR DESCRIPTION
## Problem
Multi-part `CompleteMultipartUpload` fails live for 2+ parts (1-part works): the complete returns `400 InvalidRequest: trailing characters at line 1 column 26`.

## Root cause
`RecordDecoder::prepare_json` (`Format::Json`) buffers the whole stream and parses it as **one** JSON document at EOF. Multipart completion concatenates the parts' bytes, so two self-contained JSON records become `{...}{...}` — serde_json reports the second `{` as \*trailing characters\* at the exact column where the first record ends.

## Fix
- `RecordDecoder::end_of_segment()`: at each multipart part boundary, if the buffered bytes form a complete JSON document, emit it and reset for the next part. Documents that span part boundaries stay buffered (serde_json `is_eof()`).
- `prepare_json` now finishes cleanly on an empty stream (needed after per-part flush).
- Multipart completion calls `end_of_segment()` after each staged part.

## Validation
- New unit tests: independent JSON segments emit one record each; spanning documents buffer until complete; empty JSON stream finishes cleanly.
- `cargo test -p s4-gateway --lib`: 131 passed. `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.
- Live pre-fix repro: 1-part complete 200, 2-part 400 (trailing characters). Will re-verify after deploy.