### PR TITLE
fix(ci): give release smoke a durable journal (Postgres) + S3 provider

### DIFF
--- a/scripts/release-image-smoke.sh
+++ b/scripts/release-image-smoke.sh
@@ -10,14 +10,16 @@ IMAGE_REF="$1"
 RUN_ID="${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-0}-${RANDOM}"
 NETWORK="s4-release-smoke-${RUN_ID}"
 MINIO_NAME="s4-minio-${RUN_ID}"
+POSTGRES_NAME="s4-postgres-${RUN_ID}"
 GATEWAY_NAME="s4-gateway-${RUN_ID}"
 MINIO_IMAGE="minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
+POSTGRES_IMAGE="postgres:17-trixie@sha256:e38411452a464af89e5adadb8d223bf53b898d47d6ef918b2d58c08707350449"
 MC_IMAGE="minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"
 MC_CONF="s4-release-smoke-mc-${RUN_ID}"
 GATEWAY_PORT="${S4_RELEASE_SMOKE_PORT:-18080}"
 
 cleanup() {
-  docker rm -f "$GATEWAY_NAME" "$MINIO_NAME" >/dev/null 2>&1 || true
+  docker rm -f "$GATEWAY_NAME" "$MINIO_NAME" "$POSTGRES_NAME" >/dev/null 2>&1 || true
   docker network rm "$NETWORK" >/dev/null 2>&1 || true
   docker volume rm "$MC_CONF" >/dev/null 2>&1 || true
 }
@@ -45,6 +47,25 @@ if [ "$ready" -ne 1 ]; then
   exit 1
 fi
 
+# Release builds have no in-memory operation journal, so the gateway needs a
+# Postgres for the durable journal the streaming S3 sink requires.
+docker run -d --name "$POSTGRES_NAME" --network "$NETWORK" \
+  -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=s4 \
+  "$POSTGRES_IMAGE" >/dev/null
+pg_ready=0
+for _ in $(seq 1 30); do
+  if docker exec "$POSTGRES_NAME" pg_isready -U postgres -d s4 >/dev/null 2>&1; then
+    pg_ready=1
+    break
+  fi
+  sleep 1
+done
+if [ "$pg_ready" -ne 1 ]; then
+  docker logs "$POSTGRES_NAME" || true
+  echo "ERROR: release-smoke Postgres did not become ready" >&2
+  exit 1
+fi
+
 docker run --rm --network "$NETWORK" -v "$MC_CONF:/root/.mc" "$MC_IMAGE" --no-color \
   alias set local "http://${MINIO_NAME}:9000" minioadmin minioadmin >/dev/null
 docker run --rm --network "$NETWORK" -v "$MC_CONF:/root/.mc" "$MC_IMAGE" --no-color \
@@ -54,6 +75,8 @@ docker run -d --name "$GATEWAY_NAME" --network "$NETWORK" \
   -p "127.0.0.1:${GATEWAY_PORT}:8080" \
   -e AUTH_DISABLED=true \
   -e S4_STREAMING_WRITE_MODE=all \
+  -e S4_STREAMING_S3_PROVIDER=minio \
+  -e DATABASE_URL="postgres://postgres:postgres@${POSTGRES_NAME}:5432/s4" \
   -e S4_KEYS_FILE=/tmp/keys.json \
   -e S3_ENDPOINT="http://${MINIO_NAME}:9000" \
   -e S3_ACCESS_KEY_ID=minioadmin \


### PR DESCRIPTION
## Problem
The v0.3.6 release boot-smoke still fails with `curl 22 / 501` even after enabling `S4_STREAMING_WRITE_MODE=all`.

## Root cause
Release builds compile out the in-memory operation journal (`#[cfg(any(test, debug_assertions))]`), so with no `DATABASE_URL` the `begin_streaming_sink` S3 branch rejects the write: `direct S3 streaming needs a durable operation journal`. The S3 capability gate also needs `S4_STREAMING_S3_PROVIDER`.

## Fix
- Spin up a pinned `postgres:17-trixie` container; gateway `DATABASE_URL` points at it → `PostgresOperationJournal` (migrations run at startup).
- `S4_STREAMING_S3_PROVIDER=minio` enables the direct-streaming capability.

## Validation
`bash -n` syntax OK. Docker not available locally to run the smoke; relies on the release run's boot-smoke step (which previously caught both failures).