### PR TITLE
fix(s3): force path-style addressing for custom S3 endpoints

### DIFF
--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -5564,7 +5564,10 @@ pub async fn build_state(
                         .credentials_provider(creds)
                         .load()
                         .await;
-                    Some(Client::new(&config))
+                    let s3_config = aws_sdk_s3::config::Builder::from(&config)
+                        .force_path_style(true)
+                        .build();
+                    Some(Client::from_conf(s3_config))
                 }
                 _ => {
                     warn!(


### PR DESCRIPTION
## Problem

Release run #27 boot-smoke fails: the smoke script's data-plane PUT returns
HTTP 503 (`curl: (22)` at `scripts/release-image-smoke.sh`). The gateway boots
and passes `/health`, then the S3 write fails.

Root cause: `build_state` builds the global S3 client from `S3_ENDPOINT`
without `force_path_style(true)`. aws-sdk-rust defaults to virtual-hosted
addressing, so against MinIO (`http://minio:9000`) the request goes to
`http://<bucket>.minio:9000/...`, which does not resolve on the smoke network →
backend error → `StreamingPutError::Transaction` → 503. MinIO has never been
exercised by the smoke before (run #26 failed earlier at the durable-journal
501), so this latent bug went unseen.

The existing test helper already sets `.force_path_style(true)` for local
endpoints (`s3_frontdoor_test.rs`).

## Fix

Build the S3 client config from the shared config via
`aws_sdk_s3::config::Builder` and enable `force_path_style(true)`. Custom
endpoints (MinIO, IP:port, S3-compatible stores) universally accept
path-style; cloud endpoints that support virtual-host style also accept
path-style, so this is interoperable.

## Verification

- `cargo check -p s4-gateway --lib` and `cargo clippy -p s4-gateway --lib` pass.
- The tag-push release workflow's boot-smoke (MinIO + Postgres) is the
  regression guard; a green run after merge/re-tag is the final proof.