### PR TITLE
fix(security): restrict global admin routes

### DIFF
--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -6413,7 +6413,7 @@ pub async fn build_state(
 /// Build the axum router for the engine. The SaaS crate merges its own
 /// control-plane routes (workspaces, billing, dashboard) onto this.
 pub fn build_router(state: Arc<AppState>) -> Router {
-    Router::new()
+    let mut router = Router::new()
         .route("/health", get(health))
         .route("/", get(root))
         .route("/dashboard/api/keys", get(get_keys))
@@ -6429,12 +6429,6 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/dashboard/api/demo/read", get(demo_read))
         .route("/dashboard/api/backend", get(get_backend))
         .route("/dashboard/api/backend", put(put_backend))
-        .route("/dashboard/api/plugins", get(get_plugins))
-        .route("/dashboard/api/plugins", post(create_plugin))
-        .route("/dashboard/api/plugins/reorder", put(reorder_plugins))
-        .route("/dashboard/api/plugins/{id}", put(update_plugin))
-        .route("/dashboard/api/plugins/{id}", delete(delete_plugin))
-        .route("/dashboard/api/objects", get(list_objects))
         .route("/{bucket}", get(s3_list_objects))
         .route("/{bucket}", put(s3_bucket_put))
         .route("/{bucket}", delete(s3_bucket_delete))
@@ -6442,7 +6436,17 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/{bucket}/{*key}", get(s3_get))
         .route("/{bucket}/{*key}", head(s3_head))
         .route("/{bucket}/{*key}", delete(s3_delete))
-        .route("/{bucket}/{*key}", post(s3_post))
+        .route("/{bucket}/{*key}", post(s3_post));
+    if state.auth_disabled {
+        router = router
+            .route("/dashboard/api/plugins", get(get_plugins))
+            .route("/dashboard/api/plugins", post(create_plugin))
+            .route("/dashboard/api/plugins/reorder", put(reorder_plugins))
+            .route("/dashboard/api/plugins/{id}", put(update_plugin))
+            .route("/dashboard/api/plugins/{id}", delete(delete_plugin))
+            .route("/dashboard/api/objects", get(list_objects));
+    }
+    router
         .layer(CorsLayer::permissive())
         .with_state(state)
         .merge(SwaggerUi::new("/docs").url("/openapi.json", ApiDoc::openapi()))

--- a/crates/gateway/tests/s3_frontdoor_test.rs
+++ b/crates/gateway/tests/s3_frontdoor_test.rs
@@ -381,6 +381,58 @@ fn add_headers(req: Request<Body>, hdrs: &[(&'static str, String)]) -> Request<B
 }
 
 #[tokio::test]
+async fn global_admin_routes_only_mount_in_local_auth_disabled_mode() {
+    let state = test_state().await;
+    let (access_key, secret_key) = make_key(&state).await;
+    let headers = auth_headers(&access_key, &secret_key);
+    let app = build_router(state.clone());
+    let plugin_count = state.plugins.list().len();
+
+    let import = add_headers(
+        Request::builder()
+            .method("POST")
+            .uri("/dashboard/api/plugins")
+            .header(header::CONTENT_TYPE, "application/wasm")
+            .body(Body::from("not a wasm component"))
+            .unwrap(),
+        &headers,
+    );
+    assert_eq!(
+        app.clone().oneshot(import).await.unwrap().status(),
+        StatusCode::NOT_IMPLEMENTED
+    );
+    assert_eq!(state.plugins.list().len(), plugin_count);
+
+    let objects = add_headers(
+        Request::builder()
+            .uri("/dashboard/api/objects")
+            .body(Body::empty())
+            .unwrap(),
+        &headers,
+    );
+    assert_eq!(
+        app.oneshot(objects).await.unwrap().status(),
+        StatusCode::NOT_FOUND
+    );
+
+    let mut local_state = test_state().await;
+    Arc::get_mut(&mut local_state)
+        .expect("test state is uniquely owned")
+        .auth_disabled = true;
+    let local_app = build_router(local_state);
+    let response = local_app
+        .oneshot(
+            Request::builder()
+                .uri("/dashboard/api/plugins")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
 async fn put_get_roundtrip_filters_pii() {
     let (app, state) = router().await;
     let (ak, sk) = make_key(&state).await;


### PR DESCRIPTION
## Security impact
Authenticated production no longer mounts process-global plugin mutation or object-administration handlers. Those routes remain available only in explicit local `AUTH_DISABLED` mode.

Before this change, an unauthenticated internet caller could import, reorder, update, or delete global Wasm filters for all tenants.

## Validation
- `cargo test -p s4-gateway --test s3_frontdoor_test global_admin_routes_only_mount_in_local_auth_disabled_mode -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p s4-gateway --all-targets -- -D warnings`
- independent local review: no blocking findings