### PR TITLE
fix(security): harden object response headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4305,6 +4305,7 @@ dependencies = [
  "uuid",
  "wasmtime",
  "x509-parser",
+ "xmlparser",
 ]
 
 [[package]]

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -67,3 +67,4 @@ x509-parser = "0.16"
 aes-siv = { version = "0.7", default-features = false, features = ["alloc"] }
 hmac = "0.12"
 wasmtime = "47"
+xmlparser = "0.13"

--- a/crates/gateway/src/backend.rs
+++ b/crates/gateway/src/backend.rs
@@ -297,7 +297,7 @@ impl PresignedHttpPolicy {
             .resolver
             .resolve(&host, port)
             .await
-            .map_err(|error| format!("presigned URL DNS resolution failed: {error}"))?;
+            .map_err(|_| "presigned URL DNS resolution failed".to_string())?;
         if addresses.is_empty() {
             return Err("presigned URL DNS resolution returned no addresses".to_string());
         }
@@ -312,7 +312,7 @@ impl PresignedHttpPolicy {
             .no_proxy()
             .resolve(&host, pinned)
             .build()
-            .map_err(|error| format!("presigned HTTP client construction failed: {error}"))
+            .map_err(|_| "presigned HTTP client construction failed".to_string())
     }
 
     fn host_allowed(&self, host: &str) -> bool {

--- a/crates/gateway/src/object.rs
+++ b/crates/gateway/src/object.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context, Poll};
 
 use axum::body::Body;
-use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
+use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode, header};
 use axum::response::Response;
 use bytes::Bytes;
 use http_body::{Frame, SizeHint};
@@ -13,6 +13,142 @@ use s4_wasm_runtime::CancellationToken;
 
 pub const DEFAULT_MAX_SOURCE_FRAME_BYTES: usize = 8 * 1024 * 1024;
 pub const DEFAULT_MAX_SOURCE_BYTES: u64 = 5 * 1024 * 1024 * 1024;
+
+const OBJECT_DOWNLOAD_CSP: &str =
+    "sandbox; default-src 'none'; base-uri 'none'; form-action 'none'";
+
+pub(crate) fn harden_object_response_headers(headers: &mut HeaderMap) {
+    headers.remove(header::AGE);
+    headers.remove(header::EXPIRES);
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("private, no-store"),
+    );
+    headers.insert(
+        header::CONTENT_DISPOSITION,
+        HeaderValue::from_static("attachment"),
+    );
+    headers.insert(
+        HeaderName::from_static("x-content-type-options"),
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        HeaderName::from_static("content-security-policy"),
+        HeaderValue::from_static(OBJECT_DOWNLOAD_CSP),
+    );
+}
+
+/// Keep only object representation and S3-compatible response metadata from an
+/// untrusted presigned HTTP backend.
+pub(crate) fn filter_presigned_response_headers(headers: &mut HeaderMap) {
+    strip_hop_by_hop_headers(headers);
+    let blocked: Vec<HeaderName> = headers
+        .keys()
+        .filter(|name| !is_allowed_presigned_response_header(name))
+        .cloned()
+        .collect();
+    for name in blocked {
+        headers.remove(name);
+    }
+}
+
+fn is_allowed_presigned_response_header(name: &HeaderName) -> bool {
+    let name = name.as_str();
+    name.starts_with("x-amz-meta-")
+        || name.starts_with("x-goog-meta-")
+        || matches!(
+            name,
+            // Representation, range, and validator metadata. Backend cache
+            // policy is intentionally excluded and replaced at the boundary.
+            "accept-ranges"
+                | "content-encoding"
+                | "content-language"
+                | "content-length"
+                | "content-range"
+                | "content-type"
+                | "etag"
+                | "last-modified"
+                // S3 object metadata surfaced by GetObject/HeadObject.
+                | "x-amz-archive-status"
+                | "x-amz-checksum-crc32"
+                | "x-amz-checksum-crc32c"
+                | "x-amz-checksum-crc64nvme"
+                | "x-amz-checksum-md5"
+                | "x-amz-checksum-sha1"
+                | "x-amz-checksum-sha256"
+                | "x-amz-checksum-sha512"
+                | "x-amz-checksum-type"
+                | "x-amz-checksum-xxhash3"
+                | "x-amz-checksum-xxhash64"
+                | "x-amz-checksum-xxhash128"
+                | "x-amz-delete-marker"
+                | "x-amz-expiration"
+                | "x-amz-missing-meta"
+                | "x-amz-mp-parts-count"
+                | "x-amz-object-lock-legal-hold"
+                | "x-amz-object-lock-mode"
+                | "x-amz-object-lock-retain-until-date"
+                | "x-amz-replication-status"
+                | "x-amz-request-charged"
+                | "x-amz-restore"
+                | "x-amz-server-side-encryption"
+                | "x-amz-server-side-encryption-aws-kms-key-id"
+                | "x-amz-server-side-encryption-bucket-key-enabled"
+                | "x-amz-server-side-encryption-customer-algorithm"
+                | "x-amz-server-side-encryption-customer-key-md5"
+                | "x-amz-storage-class"
+                | "x-amz-tagging-count"
+                | "x-amz-version-id"
+                | "x-amz-website-redirect-location"
+                // GCS representation, version, and checksum metadata.
+                | "x-goog-component-count"
+                | "x-goog-custom-time"
+                | "x-goog-encryption-algorithm"
+                | "x-goog-encryption-key-sha256"
+                | "x-goog-expiration"
+                | "x-goog-generation"
+                | "x-goog-hash"
+                | "x-goog-metageneration"
+                | "x-goog-object-lock-mode"
+                | "x-goog-object-lock-retain-until-date"
+                | "x-goog-storage-class"
+                | "x-goog-stored-content-encoding"
+                | "x-goog-stored-content-length"
+        )
+}
+
+fn filter_object_response_trailers(trailers: &mut HeaderMap) {
+    let blocked: Vec<HeaderName> = trailers
+        .keys()
+        .filter(|name| !is_allowed_object_response_trailer(name))
+        .cloned()
+        .collect();
+    for name in blocked {
+        trailers.remove(name);
+    }
+}
+
+fn is_allowed_object_response_trailer(name: &HeaderName) -> bool {
+    matches!(
+        name.as_str(),
+        "content-digest"
+            | "content-md5"
+            | "digest"
+            | "repr-digest"
+            | "x-amz-checksum-crc32"
+            | "x-amz-checksum-crc32c"
+            | "x-amz-checksum-crc64nvme"
+            | "x-amz-checksum-md5"
+            | "x-amz-checksum-sha1"
+            | "x-amz-checksum-sha256"
+            | "x-amz-checksum-sha512"
+            | "x-amz-checksum-type"
+            | "x-amz-checksum-xxhash3"
+            | "x-amz-checksum-xxhash64"
+            | "x-amz-checksum-xxhash128"
+            | "x-goog-hash"
+    )
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct ObjectMetadata {
@@ -225,8 +361,45 @@ impl OpenedObject {
         let mut response = Response::builder().status(self.status);
         if let Some(headers) = response.headers_mut() {
             headers.extend(self.metadata.headers);
+            harden_object_response_headers(headers);
         }
-        response.body(self.body).expect("valid object response")
+        response
+            .body(Body::new(ObjectResponseBody { inner: self.body }))
+            .expect("valid object response")
+    }
+}
+
+#[derive(Debug)]
+struct ObjectResponseBody {
+    inner: Body,
+}
+
+impl http_body::Body for ObjectResponseBody {
+    type Data = Bytes;
+    type Error = axum::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match Pin::new(&mut self.inner).poll_frame(cx) {
+            Poll::Ready(Some(Ok(frame))) => match frame.into_trailers() {
+                Ok(mut trailers) => {
+                    filter_object_response_trailers(&mut trailers);
+                    Poll::Ready(Some(Ok(Frame::trailers(trailers))))
+                }
+                Err(frame) => Poll::Ready(Some(Ok(frame))),
+            },
+            result => result,
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
     }
 }
 
@@ -371,32 +544,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trailers_and_exact_size_hint_are_preserved() {
+    async fn response_trailers_keep_only_integrity_fields_and_preserve_size_hint() {
         let mut trailers = HeaderMap::new();
-        trailers.insert("x-checksum", HeaderValue::from_static("done"));
+        trailers.insert(
+            "x-amz-checksum-sha256",
+            HeaderValue::from_static("checksum"),
+        );
+        trailers.insert("x-goog-hash", HeaderValue::from_static("crc32c=abcd"));
+        trailers.insert("set-cookie", HeaderValue::from_static("attacker=1"));
+        trailers.insert("access-control-allow-origin", HeaderValue::from_static("*"));
+        trailers.insert("www-authenticate", HeaderValue::from_static("Basic"));
+        trailers.insert("x-unknown", HeaderValue::from_static("attacker"));
         let body = ScriptedBody {
             polls: Arc::new(AtomicUsize::new(0)),
             frames: VecDeque::from([
                 Ok(Frame::data(Bytes::from_static(b"data"))),
-                Ok(Frame::trailers(trailers.clone())),
+                Ok(Frame::trailers(trailers)),
             ]),
             hint: SizeHint::with_exact(4),
         };
-        let mut body = opened(body).body;
+        let mut body = opened(body).into_response().into_body();
         assert_eq!(body.size_hint().exact(), Some(4));
         assert_eq!(
             body.frame().await.unwrap().unwrap().into_data().unwrap(),
             Bytes::from_static(b"data")
         );
-        assert_eq!(
-            body.frame()
-                .await
-                .unwrap()
-                .unwrap()
-                .into_trailers()
-                .unwrap(),
-            trailers
-        );
+        let trailers = body
+            .frame()
+            .await
+            .unwrap()
+            .unwrap()
+            .into_trailers()
+            .unwrap();
+        assert_eq!(trailers["x-amz-checksum-sha256"], "checksum");
+        assert_eq!(trailers["x-goog-hash"], "crc32c=abcd");
+        for dropped in [
+            "set-cookie",
+            "access-control-allow-origin",
+            "www-authenticate",
+            "x-unknown",
+        ] {
+            assert!(
+                !trailers.contains_key(dropped),
+                "trailer {dropped} survived"
+            );
+        }
     }
 
     #[tokio::test]
@@ -526,5 +718,103 @@ mod tests {
         assert!(!headers.contains_key("keep-alive"));
         assert!(!headers.contains_key("x-private"));
         assert_eq!(headers["content-type"], "text/plain");
+    }
+
+    #[test]
+    fn presigned_response_headers_use_a_strict_allowlist() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", HeaderValue::from_static("text/html"));
+        headers.insert("etag", HeaderValue::from_static("\"safe\""));
+        headers.insert("cache-control", HeaderValue::from_static("public"));
+        headers.insert("age", HeaderValue::from_static("600"));
+        headers.insert(
+            "expires",
+            HeaderValue::from_static("Wed, 19 Aug 2026 10:00:00 GMT"),
+        );
+        headers.insert(
+            "x-amz-meta-project",
+            HeaderValue::from_static("safe-metadata"),
+        );
+        headers.insert("x-amz-version-id", HeaderValue::from_static("version-1"));
+        headers.insert(
+            "x-goog-meta-project",
+            HeaderValue::from_static("safe-gcs-metadata"),
+        );
+        headers.insert("x-goog-generation", HeaderValue::from_static("123"));
+        headers.insert(
+            "x-goog-stored-content-length",
+            HeaderValue::from_static("4"),
+        );
+        headers.insert("set-cookie", HeaderValue::from_static("attacker=1"));
+        headers.insert("access-control-allow-origin", HeaderValue::from_static("*"));
+        headers.insert(
+            "location",
+            HeaderValue::from_static("https://attacker.example"),
+        );
+        headers.insert("report-to", HeaderValue::from_static("attacker"));
+        headers.insert("x-unknown-extension", HeaderValue::from_static("attacker"));
+        headers.insert("connection", HeaderValue::from_static("x-amz-meta-project"));
+
+        filter_presigned_response_headers(&mut headers);
+
+        assert_eq!(headers["content-type"], "text/html");
+        assert_eq!(headers["etag"], "\"safe\"");
+        assert_eq!(headers["x-amz-version-id"], "version-1");
+        assert_eq!(headers["x-goog-meta-project"], "safe-gcs-metadata");
+        assert_eq!(headers["x-goog-generation"], "123");
+        assert_eq!(headers["x-goog-stored-content-length"], "4");
+        assert!(!headers.contains_key("x-amz-meta-project"));
+        for dropped in [
+            "cache-control",
+            "age",
+            "expires",
+            "set-cookie",
+            "access-control-allow-origin",
+            "location",
+            "report-to",
+            "x-unknown-extension",
+            "connection",
+        ] {
+            assert!(!headers.contains_key(dropped), "header {dropped} survived");
+        }
+    }
+
+    #[test]
+    fn opened_object_hardens_non_success_and_overrides_backend_values() {
+        let mut metadata = ObjectMetadata::default();
+        metadata.insert(header::CONTENT_TYPE, "text/html");
+        metadata.insert(header::CONTENT_RANGE, "bytes 0-3/10");
+        metadata.insert(
+            header::CONTENT_DISPOSITION,
+            "inline; filename=attacker.html",
+        );
+        metadata.insert(header::CACHE_CONTROL, "public, max-age=3600");
+        metadata.insert(header::AGE, "600");
+        metadata.insert(header::EXPIRES, "Wed, 19 Aug 2026 10:00:00 GMT");
+        metadata.insert(HeaderName::from_static("x-content-type-options"), "off");
+        metadata.insert(
+            HeaderName::from_static("content-security-policy"),
+            "default-src *",
+        );
+        let response = OpenedObject::new(
+            StatusCode::NOT_FOUND,
+            metadata,
+            Body::from("data"),
+            BodyLimits::default(),
+        )
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(response.headers()["content-type"], "text/html");
+        assert_eq!(response.headers()["content-range"], "bytes 0-3/10");
+        assert_eq!(response.headers()["cache-control"], "private, no-store");
+        assert!(!response.headers().contains_key("age"));
+        assert!(!response.headers().contains_key("expires"));
+        assert_eq!(response.headers()["content-disposition"], "attachment");
+        assert_eq!(response.headers()["x-content-type-options"], "nosniff");
+        assert_eq!(
+            response.headers()["content-security-policy"],
+            OBJECT_DOWNLOAD_CSP
+        );
     }
 }

--- a/crates/gateway/src/s3_error.rs
+++ b/crates/gateway/src/s3_error.rs
@@ -1,29 +1,63 @@
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::http::{HeaderValue, StatusCode, header};
 use uuid::Uuid;
+
+use crate::object::harden_object_response_headers;
+
+fn push_xml_text(output: &mut String, value: &str) {
+    for character in value.chars() {
+        match character {
+            '&' => output.push_str("&amp;"),
+            '<' => output.push_str("&lt;"),
+            '>' => output.push_str("&gt;"),
+            '"' => output.push_str("&quot;"),
+            '\'' => output.push_str("&apos;"),
+            '\t'
+            | '\n'
+            | '\r'
+            | '\u{20}'..='\u{d7ff}'
+            | '\u{e000}'..='\u{fffd}'
+            | '\u{10000}'..='\u{10ffff}' => output.push(character),
+            _ => output.push('\u{fffd}'),
+        }
+    }
+}
+
+fn push_xml_element(output: &mut String, name: &'static str, value: &str) {
+    output.push_str("  <");
+    output.push_str(name);
+    output.push('>');
+    push_xml_text(output, value);
+    output.push_str("</");
+    output.push_str(name);
+    output.push_str(">\n");
+}
+
+fn s3_error_body(code: &str, message: &str, resource: &str, request_id: &str) -> String {
+    let mut body = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n");
+    push_xml_element(&mut body, "Code", code);
+    push_xml_element(&mut body, "Message", message);
+    push_xml_element(&mut body, "Key", resource);
+    push_xml_element(&mut body, "RequestId", request_id);
+    body.push_str("</Error>");
+    body
+}
 
 fn s3_error_xml(
     code: &str,
     message: &str,
-    key: &str,
+    resource: &str,
     status: StatusCode,
 ) -> axum::response::Response {
-    let request_id = Uuid::new_v4();
-    let body = format!(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
-<Error>
-  <Code>{code}</Code>
-  <Message>{message}</Message>
-  <Key>{key}</Key>
-  <RequestId>{request_id}</RequestId>
-</Error>"#
+    let request_id = Uuid::new_v4().to_string();
+    let body = s3_error_body(code, message, resource, &request_id);
+    let mut response = axum::response::Response::new(axum::body::Body::from(body));
+    *response.status_mut() = status;
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/xml"),
     );
-    axum::response::Response::builder()
-        .status(status)
-        .header("Content-Type", "application/xml")
-        .body(axum::body::Body::from(body))
-        .unwrap()
-        .into_response()
+    harden_object_response_headers(response.headers_mut());
+    response
 }
 
 pub fn no_such_key(key: &str) -> axum::response::Response {
@@ -36,9 +70,11 @@ pub fn no_such_key(key: &str) -> axum::response::Response {
 }
 
 pub fn internal_error(key: &str, detail: &str) -> axum::response::Response {
+    let mut message = String::from("We encountered an internal error: ");
+    message.push_str(detail);
     s3_error_xml(
         "InternalError",
-        &format!("We encountered an internal error: {detail}"),
+        &message,
         key,
         StatusCode::INTERNAL_SERVER_ERROR,
     )
@@ -127,6 +163,19 @@ pub fn invalid_request(key: &str, detail: &str) -> axum::response::Response {
     s3_error_xml("InvalidRequest", detail, key, StatusCode::BAD_REQUEST)
 }
 
+pub fn invalid_range(key: &str, object_length: u64) -> axum::response::Response {
+    let mut response = s3_error_xml(
+        "InvalidRange",
+        "The requested range is not satisfiable.",
+        key,
+        StatusCode::RANGE_NOT_SATISFIABLE,
+    );
+    let value = HeaderValue::from_str(&format!("bytes */{object_length}"))
+        .expect("numeric object length is a valid Content-Range");
+    response.headers_mut().insert(header::CONTENT_RANGE, value);
+    response
+}
+
 pub fn slow_down(key: &str) -> axum::response::Response {
     s3_error_xml(
         "SlowDown",
@@ -152,4 +201,35 @@ pub fn bucket_not_allowed(bucket: &str) -> axum::response::Response {
         bucket,
         StatusCode::FORBIDDEN,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::s3_error_body;
+
+    #[test]
+    fn every_dynamic_error_field_is_xml_text_not_markup() {
+        let body = s3_error_body(
+            "Bad</Code><Injected code=\"1\">",
+            "message & </Message><Injected message='1'>",
+            "bucket/<Injected>resource</Injected>&\"'\u{1}",
+            "request</RequestId><Injected request=\"1\">",
+        );
+        let elements: Vec<_> = xmlparser::Tokenizer::from(body.as_str())
+            .map(|token| token.expect("generated error must be well-formed XML"))
+            .filter_map(|token| match token {
+                xmlparser::Token::ElementStart { local, .. } => Some(local.as_str().to_string()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(elements, ["Error", "Code", "Message", "Key", "RequestId"]);
+        assert!(!body.contains("<Injected"));
+        assert!(body.contains("Bad&lt;/Code&gt;&lt;Injected code=&quot;1&quot;&gt;"));
+        assert!(body.contains("message &amp; &lt;/Message&gt;"));
+        assert!(
+            body.contains("bucket/&lt;Injected&gt;resource&lt;/Injected&gt;&amp;&quot;&apos;�")
+        );
+        assert!(body.contains("request&lt;/RequestId&gt;&lt;Injected request=&quot;1&quot;&gt;"));
+    }
 }

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -52,7 +52,8 @@ use crate::multipart_staging::{
     completion_fingerprint, now_ms,
 };
 use crate::object::{
-    BodyLimits, ChunkedBytesBody, ObjectMetadata, OpenedObject, strip_hop_by_hop_headers,
+    BodyLimits, ChunkedBytesBody, ObjectMetadata, OpenedObject, filter_presigned_response_headers,
+    harden_object_response_headers,
 };
 use crate::plugin_registry::{PluginCapabilities, PluginRegistry, StreamingPipelineSession};
 use crate::read_spool::EncryptedReadSpool;
@@ -551,18 +552,45 @@ async fn resolve_backend(
 #[derive(Debug)]
 enum OpenObjectError {
     NotFound,
-    InvalidRange,
+    InvalidRange { object_length: u64 },
     Rejected(String),
     Backend(String),
+    PresignedTransport(PresignedTransportFailure),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PresignedTransportFailure {
+    Timeout,
+    Connect,
+    Request,
+}
+
+impl PresignedTransportFailure {
+    fn from_reqwest(error: &reqwest::Error) -> Self {
+        if error.is_timeout() {
+            Self::Timeout
+        } else if error.is_connect() {
+            Self::Connect
+        } else {
+            Self::Request
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Timeout => "timeout",
+            Self::Connect => "connect",
+            Self::Request => "request",
+        }
+    }
 }
 
 fn open_error_response(key: &str, error: OpenObjectError) -> axum::response::Response {
     match error {
         OpenObjectError::NotFound => s3_error::no_such_key(key),
-        OpenObjectError::InvalidRange => axum::response::Response::builder()
-            .status(StatusCode::RANGE_NOT_SATISFIABLE)
-            .body(axum::body::Body::empty())
-            .expect("valid range response"),
+        OpenObjectError::InvalidRange { object_length } => {
+            s3_error::invalid_range(key, object_length)
+        }
         OpenObjectError::Rejected(detail) => {
             warn!("presigned source rejected for {key}: {detail}");
             s3_error::access_denied(key)
@@ -570,6 +598,14 @@ fn open_error_response(key: &str, error: OpenObjectError) -> axum::response::Res
         OpenObjectError::Backend(detail) => {
             warn!("backend read failed for {key}: {detail}");
             s3_error::internal_error(key, &detail)
+        }
+        OpenObjectError::PresignedTransport(failure) => {
+            warn!(
+                key,
+                category = failure.as_str(),
+                "presigned source transport failed"
+            );
+            s3_error::internal_error(key, "presigned backend request failed")
         }
     }
 }
@@ -776,6 +812,7 @@ fn forwarded_read_headers(headers: &HeaderMap) -> HeaderMap {
         header::IF_NONE_MATCH,
         header::IF_MODIFIED_SINCE,
         header::IF_UNMODIFIED_SINCE,
+        HeaderName::from_static("x-amz-checksum-mode"),
     ] {
         for value in headers.get_all(&name) {
             forwarded.append(name.clone(), value.clone());
@@ -805,7 +842,9 @@ async fn open_http_object(
         .headers(forwarded_read_headers(headers))
         .send()
         .await
-        .map_err(|error| OpenObjectError::Backend(error.to_string()))?;
+        .map_err(|error| {
+            OpenObjectError::PresignedTransport(PresignedTransportFailure::from_reqwest(&error))
+        })?;
     if response.status().is_redirection() {
         return Err(OpenObjectError::Rejected(
             "presigned HTTP source redirects are forbidden".to_string(),
@@ -814,7 +853,7 @@ async fn open_http_object(
     let response: axum::http::Response<reqwest::Body> = response.into();
     let (parts, body) = response.into_parts();
     let mut response_headers = parts.headers;
-    strip_hop_by_hop_headers(&mut response_headers);
+    filter_presigned_response_headers(&mut response_headers);
     let version_id = response_headers
         .get("x-amz-version-id")
         .or_else(|| response_headers.get("x-goog-generation"))
@@ -841,38 +880,36 @@ fn memory_range(
     data: &bytes::Bytes,
     range: Option<&str>,
 ) -> Result<(bytes::Bytes, Option<String>), OpenObjectError> {
+    let length = data.len();
+    let invalid_range = || OpenObjectError::InvalidRange {
+        object_length: length as u64,
+    };
     let Some(range) = range else {
         return Ok((data.clone(), None));
     };
     let spec = range
         .strip_prefix("bytes=")
         .filter(|spec| !spec.contains(','))
-        .ok_or(OpenObjectError::InvalidRange)?;
-    let (start, end) = spec.split_once('-').ok_or(OpenObjectError::InvalidRange)?;
-    let length = data.len();
+        .ok_or_else(invalid_range)?;
+    let (start, end) = spec.split_once('-').ok_or_else(invalid_range)?;
     if length == 0 {
-        return Err(OpenObjectError::InvalidRange);
+        return Err(invalid_range());
     }
     let (start, end) = if start.is_empty() {
-        let suffix = end
-            .parse::<usize>()
-            .map_err(|_| OpenObjectError::InvalidRange)?;
+        let suffix = end.parse::<usize>().map_err(|_| invalid_range())?;
         if suffix == 0 {
-            return Err(OpenObjectError::InvalidRange);
+            return Err(invalid_range());
         }
         (length.saturating_sub(suffix), length - 1)
     } else {
-        let start = start
-            .parse::<usize>()
-            .map_err(|_| OpenObjectError::InvalidRange)?;
+        let start = start.parse::<usize>().map_err(|_| invalid_range())?;
         let end = if end.is_empty() {
             length - 1
         } else {
-            end.parse::<usize>()
-                .map_err(|_| OpenObjectError::InvalidRange)?
+            end.parse::<usize>().map_err(|_| invalid_range())?
         };
         if start >= length || start > end {
-            return Err(OpenObjectError::InvalidRange);
+            return Err(invalid_range());
         }
         (start, end.min(length - 1))
     };
@@ -1722,11 +1759,13 @@ async fn demo_read(
 }
 
 fn s3_xml_ok(xml: String) -> axum::response::Response {
-    axum::response::Response::builder()
-        .status(StatusCode::OK)
-        .header("Content-Type", "application/xml")
-        .body(axum::body::Body::from(xml))
-        .unwrap()
+    let mut response = axum::response::Response::new(axum::body::Body::from(xml));
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        "application/xml".parse().expect("static content type"),
+    );
+    harden_object_response_headers(response.headers_mut());
+    response
 }
 
 fn wants_transformed_read(headers: &HeaderMap) -> bool {
@@ -1786,7 +1825,14 @@ impl CompatibilitySpoolUploader for PresignedSpoolUploader {
                         response.status()
                     ));
                 }
-                Err(error) => last_error = Some(error.to_string()),
+                Err(error) => {
+                    let failure = PresignedTransportFailure::from_reqwest(&error);
+                    warn!(
+                        category = failure.as_str(),
+                        "presigned destination transport failed"
+                    );
+                    last_error = Some("presigned destination request failed".to_string());
+                }
             }
         }
         Err(TransactionError::Spool(last_error.unwrap_or_else(|| {
@@ -3386,12 +3432,12 @@ fn transformed_response_headers(
             headers.append(name.clone(), value.clone());
         }
     }
-    headers.insert(header::CACHE_CONTROL, "private, no-store".parse().unwrap());
     if let Some(content_length) = content_length
         && let Ok(value) = content_length.to_string().parse()
     {
         headers.insert(header::CONTENT_LENGTH, value);
     }
+    harden_object_response_headers(&mut headers);
     headers
 }
 
@@ -3467,10 +3513,7 @@ fn transformed_source_matches_preflight(
             .is_some_and(|(left, right)| left == right)
 }
 
-fn conditional_read_response(
-    headers: &HeaderMap,
-    metadata: &ObjectMetadata,
-) -> Option<axum::response::Response> {
+fn conditional_read_status(headers: &HeaderMap, metadata: &ObjectMetadata) -> Option<StatusCode> {
     let etag = metadata.headers.get(header::ETAG)?.to_str().ok()?;
     let matches = |condition: &str| {
         condition
@@ -3478,7 +3521,7 @@ fn conditional_read_response(
             .map(str::trim)
             .any(|candidate| candidate == "*" || candidate == etag)
     };
-    let status = if let Some(condition) = headers
+    if let Some(condition) = headers
         .get(header::IF_MATCH)
         .and_then(|value| value.to_str().ok())
     {
@@ -3490,22 +3533,26 @@ fn conditional_read_response(
         matches(condition).then_some(StatusCode::NOT_MODIFIED)
     } else {
         None
-    }?;
-    let mut response = axum::response::Response::builder().status(status);
-    let response_headers = response
-        .headers_mut()
-        .expect("response builder has headers");
-    response_headers.insert(header::ETAG, metadata.headers[header::ETAG].clone());
-    if let Some(version_id) = &metadata.version_id
+    }
+}
+
+fn conditional_read_response(
+    mut object: OpenedObject,
+    status: StatusCode,
+) -> axum::response::Response {
+    let etag = object.metadata.headers[header::ETAG].clone();
+    let version_id = object.metadata.version_id.clone();
+    object.status = status;
+    object.metadata.headers.clear();
+    object.metadata.headers.insert(header::ETAG, etag);
+    if let Some(version_id) = version_id
         && let Ok(value) = version_id.parse()
     {
-        response_headers.insert("x-amz-version-id", value);
+        object.metadata.headers.insert("x-amz-version-id", value);
     }
-    Some(
-        response
-            .body(axum::body::Body::empty())
-            .expect("valid conditional response"),
-    )
+    object.cancellation.cancel();
+    object.body = axum::body::Body::empty();
+    object.into_response()
 }
 
 fn is_immutable_version_id(version_id: Option<&str>) -> bool {
@@ -4004,8 +4051,8 @@ async fn s3_get(
                 ),
             );
         }
-        if let Some(response) = conditional_read_response(&headers, &object.metadata) {
-            object.cancellation.cancel();
+        if let Some(status) = conditional_read_status(&headers, &object.metadata) {
+            let response = conditional_read_response(object, status);
             state
                 .control
                 .record(&auth.context, &bucket, RequestKind::Read, 0)
@@ -4030,8 +4077,8 @@ async fn s3_get(
             Ok(object) => object,
             Err(error) => return open_error_response(&key, error),
         };
-    if let Some(response) = conditional_read_response(&headers, &object.metadata) {
-        object.cancellation.cancel();
+    if let Some(status) = conditional_read_status(&headers, &object.metadata) {
+        let response = conditional_read_response(object, status);
         state
             .control
             .record(&auth.context, &bucket, RequestKind::Read, 0)
@@ -4478,19 +4525,17 @@ async fn s3_head(
     };
     match open_backend_object(&state, backend, &auth, &bucket, &key, &headers, true).await {
         Ok(object) => {
-            if let Some(response) = conditional_read_response(&headers, &object.metadata) {
-                object.cancellation.cancel();
-                state
-                    .control
-                    .record(&auth.context, &bucket, RequestKind::Read, 0)
-                    .await;
-                return response;
-            }
+            let response = if let Some(status) = conditional_read_status(&headers, &object.metadata)
+            {
+                conditional_read_response(object, status)
+            } else {
+                object.into_response()
+            };
             state
                 .control
                 .record(&auth.context, &bucket, RequestKind::Read, 0)
                 .await;
-            object.into_response()
+            response
         }
         Err(error) => open_error_response(&key, error),
     }
@@ -4592,7 +4637,15 @@ async fn s3_delete(
                     &key,
                     &format!("presigned DELETE returned {}", response.status()),
                 ),
-                Err(error) => s3_error::internal_error(&key, &error.to_string()),
+                Err(error) => {
+                    let failure = PresignedTransportFailure::from_reqwest(&error);
+                    warn!(
+                        key,
+                        category = failure.as_str(),
+                        "presigned DELETE transport failed"
+                    );
+                    s3_error::internal_error(&key, "presigned backend request failed")
+                }
             }
         }
         ResolvedBackend::S3 { client, .. } => match client

--- a/crates/gateway/tests/s3_frontdoor_test.rs
+++ b/crates/gateway/tests/s3_frontdoor_test.rs
@@ -380,6 +380,29 @@ fn add_headers(req: Request<Body>, hdrs: &[(&'static str, String)]) -> Request<B
     Request::from_parts(parts, body)
 }
 
+fn assert_hardened_object_headers(headers: &axum::http::HeaderMap) {
+    assert_eq!(headers[header::CACHE_CONTROL], "private, no-store");
+    assert!(!headers.contains_key(header::AGE));
+    assert!(!headers.contains_key(header::EXPIRES));
+    assert_eq!(headers[header::CONTENT_DISPOSITION], "attachment");
+    assert_eq!(headers["x-content-type-options"], "nosniff");
+    assert_eq!(
+        headers["content-security-policy"],
+        "sandbox; default-src 'none'; base-uri 'none'; form-action 'none'"
+    );
+}
+
+fn assert_s3_error_has_only_expected_xml_elements(document: &str) {
+    let elements: Vec<_> = xmlparser::Tokenizer::from(document)
+        .map(|token| token.expect("generated error must be well-formed XML"))
+        .filter_map(|token| match token {
+            xmlparser::Token::ElementStart { local, .. } => Some(local.as_str().to_string()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(elements, ["Error", "Code", "Message", "Key", "RequestId"]);
+}
+
 #[tokio::test]
 async fn global_admin_routes_only_mount_in_local_auth_disabled_mode() {
     let state = test_state().await;
@@ -762,6 +785,7 @@ async fn list_objects_returns_keys_and_prefixes() {
     );
     let resp = app.clone().oneshot(list).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
+    assert_hardened_object_headers(resp.headers());
     let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
         .await
         .unwrap();
@@ -1073,6 +1097,7 @@ async fn conditional_get_and_head_preserve_object_identity_without_a_body() {
     let response = app.clone().oneshot(not_modified).await.unwrap();
     assert_eq!(response.status(), StatusCode::NOT_MODIFIED);
     assert_eq!(response.headers()[header::ETAG], etag);
+    assert_hardened_object_headers(response.headers());
     assert!(
         axum::body::to_bytes(response.into_body(), 1024)
             .await
@@ -1092,6 +1117,7 @@ async fn conditional_get_and_head_preserve_object_identity_without_a_body() {
     let response = app.oneshot(failed_match).await.unwrap();
     assert_eq!(response.status(), StatusCode::PRECONDITION_FAILED);
     assert_eq!(response.headers()[header::ETAG], etag);
+    assert_hardened_object_headers(response.headers());
 }
 
 #[tokio::test]
@@ -1105,6 +1131,15 @@ async fn streaming_memory_get_preserves_range_and_head_metadata() {
         bytes::Bytes::from_static(b"0123456789"),
         "text/plain",
     );
+    state_mut.store.put(
+        "range",
+        "unsafe<name>&.txt",
+        bytes::Bytes::from_static(b"0123456789"),
+        "text/plain",
+    );
+    state_mut
+        .store
+        .put("range", "empty.txt", bytes::Bytes::new(), "text/plain");
     let (ak, sk) = make_key(&state).await;
     let headers = auth_headers(&ak, &sk);
     let app = build_router(state);
@@ -1123,12 +1158,76 @@ async fn streaming_memory_get_preserves_range_and_head_metadata() {
     assert_eq!(response.headers()[header::CONTENT_LENGTH], "4");
     assert_eq!(response.headers()[header::CONTENT_RANGE], "bytes 2-5/10");
     assert_eq!(response.headers()[header::ACCEPT_RANGES], "bytes");
+    assert_hardened_object_headers(response.headers());
     assert_eq!(
         axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap(),
         "2345"
     );
+
+    let suffix = add_headers(
+        Request::builder()
+            .method("GET")
+            .uri("/range/object.txt")
+            .header(header::RANGE, "bytes=-3")
+            .body(Body::empty())
+            .unwrap(),
+        &headers,
+    );
+    let response = app.clone().oneshot(suffix).await.unwrap();
+    assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
+    assert_eq!(response.headers()[header::CONTENT_LENGTH], "3");
+    assert_eq!(response.headers()[header::CONTENT_RANGE], "bytes 7-9/10");
+    assert_hardened_object_headers(response.headers());
+    assert_eq!(
+        axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+        "789"
+    );
+
+    for (uri, range, object_length, escaped_key) in [
+        (
+            "/range/unsafe%3Cname%3E%26.txt",
+            "bytes=20-30",
+            10,
+            "unsafe&lt;name&gt;&amp;.txt",
+        ),
+        ("/range/object.txt", "not-a-byte-range", 10, "object.txt"),
+        ("/range/empty.txt", "bytes=0-0", 0, "empty.txt"),
+    ] {
+        let invalid = add_headers(
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .header(header::RANGE, range)
+                .body(Body::empty())
+                .unwrap(),
+            &headers,
+        );
+        let response = app.clone().oneshot(invalid).await.unwrap();
+        assert_eq!(response.status(), StatusCode::RANGE_NOT_SATISFIABLE);
+        assert_eq!(
+            response.headers()[header::CONTENT_RANGE],
+            format!("bytes */{object_length}")
+        );
+        assert_hardened_object_headers(response.headers());
+        let body = String::from_utf8(
+            axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .to_vec(),
+        )
+        .unwrap();
+        assert_s3_error_has_only_expected_xml_elements(&body);
+        assert!(body.contains("<Code>InvalidRange</Code>"), "{body}");
+        assert!(
+            body.contains(&format!("<Key>{escaped_key}</Key>")),
+            "{body}"
+        );
+        assert!(!body.contains("<name>"), "{body}");
+    }
 
     let head = add_headers(
         Request::builder()
@@ -1142,12 +1241,93 @@ async fn streaming_memory_get_preserves_range_and_head_metadata() {
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(response.headers()[header::CONTENT_LENGTH], "10");
     assert_eq!(response.headers()[header::CONTENT_TYPE], "text/plain");
+    assert_hardened_object_headers(response.headers());
     assert!(
         axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap()
             .is_empty()
     );
+}
+
+#[tokio::test]
+async fn object_get_forces_browser_safe_download_headers_for_html() {
+    let mut state = test_state().await;
+    let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
+    state_mut.streaming_read_mode = StreamingReadMode::Passthrough;
+    state_mut.store.put(
+        "download",
+        "attacker-name.html",
+        bytes::Bytes::from_static(b"<script>document.cookie='stolen=1'</script>"),
+        "text/html; charset=utf-8",
+    );
+    let (ak, sk) = make_key(&state).await;
+    let response = build_router(state)
+        .oneshot(add_headers(
+            Request::builder()
+                .method("GET")
+                .uri("/download/attacker-name.html")
+                .body(Body::empty())
+                .unwrap(),
+            &auth_headers(&ak, &sk),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers()[header::CONTENT_TYPE],
+        "text/html; charset=utf-8"
+    );
+    assert_hardened_object_headers(response.headers());
+    assert_eq!(
+        axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+        "<script>document.cookie='stolen=1'</script>"
+    );
+}
+
+#[tokio::test]
+async fn percent_decoded_object_and_bucket_resources_cannot_inject_s3_error_xml() {
+    let (app, state) = router().await;
+    let (ak, sk) = make_key(&state).await;
+    let headers = auth_headers(&ak, &sk);
+    let encoded = "%3CInjected%3Eresource%3C%2FInjected%3E%26%22%27";
+
+    for (method, uri, status) in [
+        ("GET", format!("/escape/{encoded}"), StatusCode::NOT_FOUND),
+        ("PUT", format!("/{encoded}"), StatusCode::FORBIDDEN),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(add_headers(
+                Request::builder()
+                    .method(method)
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+                &headers,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), status);
+        assert_hardened_object_headers(response.headers());
+        let body = String::from_utf8(
+            axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .to_vec(),
+        )
+        .unwrap();
+
+        assert_s3_error_has_only_expected_xml_elements(&body);
+        assert!(!body.contains("<Injected>"));
+        assert!(
+            body.contains("&lt;Injected&gt;resource&lt;/Injected&gt;&amp;&quot;&apos;"),
+            "escaped resource missing from {body}"
+        );
+    }
 }
 
 async fn spawn_presigned_upstream() -> (String, tokio::task::JoinHandle<()>) {
@@ -1169,17 +1349,53 @@ async fn spawn_presigned_upstream() -> (String, tokio::task::JoinHandle<()>) {
             .header(header::CONTENT_ENCODING, "identity")
             .header(
                 header::CONTENT_DISPOSITION,
-                "attachment; filename=object.txt",
+                "inline; filename=attacker-controlled.html",
             )
+            .header("content-security-policy", "default-src * 'unsafe-inline'")
+            .header("x-content-type-options", "off")
             .header(header::CONTENT_LANGUAGE, "en")
-            .header(header::CACHE_CONTROL, "private, max-age=60")
+            .header(header::CACHE_CONTROL, "public, max-age=3600")
+            .header(header::AGE, "600")
+            .header(header::EXPIRES, "Wed, 19 Aug 2026 10:00:00 GMT")
             .header(header::ETAG, "\"upstream-etag\"")
             .header(header::LAST_MODIFIED, "Wed, 19 Aug 2026 09:00:00 GMT")
             .header("x-amz-checksum-sha256", "checksum")
+            .header("x-amz-meta-project", "safe-metadata")
             .header("x-amz-version-id", "version-7")
+            .header("x-goog-component-count", "2")
+            .header("x-goog-custom-time", "2026-08-19T09:00:00Z")
+            .header("x-goog-encryption-algorithm", "AES256")
+            .header("x-goog-encryption-key-sha256", "key-checksum")
+            .header("x-goog-expiration", "Wed, 19 Aug 2026 10:00:00 GMT")
+            .header("x-goog-generation", "123456")
+            .header("x-goog-hash", "crc32c=abcd")
+            .header("x-goog-meta-project", "safe-gcs-metadata")
+            .header("x-goog-metageneration", "9")
+            .header("x-goog-object-lock-mode", "GOVERNANCE")
+            .header(
+                "x-goog-object-lock-retain-until-date",
+                "2027-08-19T09:00:00Z",
+            )
+            .header("x-goog-storage-class", "STANDARD")
+            .header("x-goog-stored-content-encoding", "identity")
+            .header("x-goog-stored-content-length", "10")
+            .header(header::SET_COOKIE, "session=attacker; Secure")
+            .header("access-control-allow-origin", "https://attacker.example")
+            .header(header::LOCATION, "https://attacker.example/redirect")
+            .header("refresh", "0;url=https://attacker.example/redirect")
+            .header("report-to", r#"{"group":"attacker"}"#)
+            .header(
+                "reporting-endpoints",
+                "attacker=\"https://attacker.example\"",
+            )
+            .header(header::WWW_AUTHENTICATE, "Basic realm=attacker")
+            .header("authentication-info", "nextnonce=attacker")
             .header("connection", "x-upstream-private")
             .header("x-upstream-private", "remove-me")
             .header(header::ACCEPT_RANGES, "bytes");
+        if let Some(checksum_mode) = headers.get("x-amz-checksum-mode") {
+            response = response.header("x-amz-meta-request-checksum-mode", checksum_mode.clone());
+        }
         if let Some(content_range) = content_range {
             response = response.header(header::CONTENT_RANGE, content_range);
         }
@@ -1200,8 +1416,24 @@ async fn spawn_presigned_upstream() -> (String, tokio::task::JoinHandle<()>) {
             .unwrap()
     }
 
+    async fn html_error() -> axum::response::Response {
+        axum::response::Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .header(header::CONTENT_TYPE, "text/html")
+            .header(header::CONTENT_DISPOSITION, "inline; filename=error.html")
+            .header(header::CACHE_CONTROL, "public, max-age=3600")
+            .header(header::AGE, "600")
+            .header(header::EXPIRES, "Wed, 19 Aug 2026 10:00:00 GMT")
+            .header("content-security-policy", "default-src * 'unsafe-inline'")
+            .header("x-content-type-options", "off")
+            .header(header::SET_COOKIE, "error=attacker")
+            .body(Body::from("<script>attack()</script>"))
+            .unwrap()
+    }
+
     let app = axum::Router::new()
         .route("/object", axum::routing::get(object).head(object))
+        .route("/not-found", axum::routing::get(html_error))
         .route("/redirect", axum::routing::get(redirect));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
@@ -1212,7 +1444,71 @@ async fn spawn_presigned_upstream() -> (String, tokio::task::JoinHandle<()>) {
 }
 
 #[tokio::test]
-async fn real_router_streams_presigned_http_range_headers_and_rejects_redirects() {
+async fn presigned_transport_failure_never_discloses_signed_url_material() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    drop(listener);
+
+    let mut state = test_state().await;
+    let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
+    state_mut.streaming_read_mode = StreamingReadMode::Passthrough;
+    state_mut.presigned_http_policy = PresignedHttpPolicy::new(
+        ["127.0.0.1".to_string()],
+        ["127.0.0.1".to_string()],
+        true,
+        Duration::ZERO,
+        Arc::new(TokioAddressResolver),
+    );
+    let (ak, sk) = make_key(&state).await;
+    let expires = std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 3600;
+    let signed_url = format!(
+        "http://{address}/object?X-Amz-Credential=AKIA_TEST%2F20260828%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=DO_NOT_DISCLOSE&Expires={expires}"
+    );
+    let response = build_router(state)
+        .oneshot(add_headers(
+            Request::builder()
+                .method("GET")
+                .uri("/proxy/transport-failure")
+                .header("x-s4-backend-url", &signed_url)
+                .body(Body::empty())
+                .unwrap(),
+            &auth_headers(&ak, &sk),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_hardened_object_headers(response.headers());
+    let body = String::from_utf8(
+        axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .to_vec(),
+    )
+    .unwrap();
+    assert!(body.contains("presigned backend request failed"), "{body}");
+    let address = address.to_string();
+    for sensitive in [
+        signed_url.as_str(),
+        "AKIA_TEST",
+        "X-Amz-Credential",
+        "X-Amz-Signature",
+        "DO_NOT_DISCLOSE",
+        address.as_str(),
+    ] {
+        assert!(
+            !body.contains(sensitive),
+            "response leaked {sensitive}: {body}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn presigned_http_responses_are_hardened_without_losing_object_semantics() {
     let (upstream, task) = spawn_presigned_upstream().await;
     let mut state = test_state().await;
     let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
@@ -1238,6 +1534,7 @@ async fn real_router_streams_presigned_http_range_headers_and_rejects_redirects(
             .method("GET")
             .uri("/proxy/object")
             .header(header::RANGE, "bytes=2-5")
+            .header("x-amz-checksum-mode", "ENABLED")
             .header(
                 "x-s4-backend-url",
                 format!("{upstream}/object?Expires={expires}"),
@@ -1254,15 +1551,57 @@ async fn real_router_streams_presigned_http_range_headers_and_rejects_redirects(
         (header::CONTENT_TYPE.as_str(), "text/plain"),
         (header::CONTENT_ENCODING.as_str(), "identity"),
         (header::CONTENT_LANGUAGE.as_str(), "en"),
-        (header::CACHE_CONTROL.as_str(), "private, max-age=60"),
         (header::ETAG.as_str(), "\"upstream-etag\""),
+        (
+            header::LAST_MODIFIED.as_str(),
+            "Wed, 19 Aug 2026 09:00:00 GMT",
+        ),
         ("x-amz-checksum-sha256", "checksum"),
+        ("x-amz-meta-project", "safe-metadata"),
+        ("x-amz-meta-request-checksum-mode", "ENABLED"),
         ("x-amz-version-id", "version-7"),
+        ("x-goog-component-count", "2"),
+        ("x-goog-custom-time", "2026-08-19T09:00:00Z"),
+        ("x-goog-encryption-algorithm", "AES256"),
+        ("x-goog-encryption-key-sha256", "key-checksum"),
+        ("x-goog-expiration", "Wed, 19 Aug 2026 10:00:00 GMT"),
+        ("x-goog-generation", "123456"),
+        ("x-goog-hash", "crc32c=abcd"),
+        ("x-goog-meta-project", "safe-gcs-metadata"),
+        ("x-goog-metageneration", "9"),
+        ("x-goog-object-lock-mode", "GOVERNANCE"),
+        (
+            "x-goog-object-lock-retain-until-date",
+            "2027-08-19T09:00:00Z",
+        ),
+        ("x-goog-storage-class", "STANDARD"),
+        ("x-goog-stored-content-encoding", "identity"),
+        ("x-goog-stored-content-length", "10"),
     ] {
         assert_eq!(response.headers()[name], expected, "header {name}");
     }
-    assert!(!response.headers().contains_key("connection"));
-    assert!(!response.headers().contains_key("x-upstream-private"));
+    assert_hardened_object_headers(response.headers());
+    assert_eq!(
+        response.headers()["access-control-allow-origin"],
+        "*",
+        "the gateway CORS policy must replace the untrusted upstream value"
+    );
+    for dropped in [
+        "set-cookie",
+        "location",
+        "refresh",
+        "report-to",
+        "reporting-endpoints",
+        "www-authenticate",
+        "authentication-info",
+        "connection",
+        "x-upstream-private",
+    ] {
+        assert!(
+            !response.headers().contains_key(dropped),
+            "untrusted upstream header {dropped} was forwarded"
+        );
+    }
     assert_eq!(
         axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
@@ -1286,11 +1625,58 @@ async fn real_router_streams_presigned_http_range_headers_and_rejects_redirects(
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(response.headers()[header::CONTENT_LENGTH], "10");
     assert_eq!(response.headers()[header::ETAG], "\"upstream-etag\"");
+    assert_hardened_object_headers(response.headers());
     assert!(
         axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap()
             .is_empty()
+    );
+
+    let list = add_headers(
+        Request::builder()
+            .method("GET")
+            .uri("/proxy?list-type=2")
+            .header(
+                "x-s4-backend-url",
+                format!("{upstream}/object?Expires={expires}"),
+            )
+            .body(Body::empty())
+            .unwrap(),
+        &headers,
+    );
+    let response = app.clone().oneshot(list).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_hardened_object_headers(response.headers());
+    assert_eq!(
+        axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+        "0123456789"
+    );
+
+    let non_success = add_headers(
+        Request::builder()
+            .method("GET")
+            .uri("/proxy/missing")
+            .header(
+                "x-s4-backend-url",
+                format!("{upstream}/not-found?Expires={expires}"),
+            )
+            .body(Body::empty())
+            .unwrap(),
+        &headers,
+    );
+    let response = app.clone().oneshot(non_success).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(response.headers()[header::CONTENT_TYPE], "text/html");
+    assert_hardened_object_headers(response.headers());
+    assert!(!response.headers().contains_key(header::SET_COOKIE));
+    assert_eq!(
+        axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+        "<script>attack()</script>"
     );
 
     let redirect = add_headers(
@@ -2310,13 +2696,10 @@ async fn unsafe_transformed_read_stages_then_sanitizes_source_headers() {
 
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.headers()[header::CACHE_CONTROL],
-        "private, no-store"
-    );
-    assert_eq!(
         response.headers()[header::CONTENT_TYPE],
         "text/plain; charset=utf-8"
     );
+    assert_hardened_object_headers(response.headers());
     assert!(!response.headers().contains_key(header::ETAG));
     assert!(!response.headers().contains_key(header::ACCEPT_RANGES));
     assert!(!response.headers().contains_key(header::CONTENT_RANGE));

--- a/crates/gateway/tests/s3_protocol.rs
+++ b/crates/gateway/tests/s3_protocol.rs
@@ -1,4 +1,4 @@
-use axum::http::StatusCode;
+use axum::http::{StatusCode, header};
 use s4_gateway::s3_error;
 
 fn body_of(resp: axum::response::Response) -> String {
@@ -9,6 +9,16 @@ fn body_of(resp: axum::response::Response) -> String {
 
 fn status_of(resp: &axum::response::Response) -> StatusCode {
     resp.status()
+}
+
+fn xml_element_names(document: &str) -> Vec<String> {
+    xmlparser::Tokenizer::from(document)
+        .map(|token| token.expect("generated error must be well-formed XML"))
+        .filter_map(|token| match token {
+            xmlparser::Token::ElementStart { local, .. } => Some(local.as_str().to_string()),
+            _ => None,
+        })
+        .collect()
 }
 
 #[test]
@@ -82,12 +92,59 @@ fn s3_error_has_content_type_header() {
             .and_then(|v| v.to_str().ok()),
         Some("application/xml")
     );
+    assert_eq!(resp.headers()[header::CACHE_CONTROL], "private, no-store");
+    assert!(!resp.headers().contains_key(header::AGE));
+    assert!(!resp.headers().contains_key(header::EXPIRES));
+    assert_eq!(resp.headers()[header::CONTENT_DISPOSITION], "attachment");
+    assert_eq!(resp.headers()["x-content-type-options"], "nosniff");
+    assert_eq!(
+        resp.headers()["content-security-policy"],
+        "sandbox; default-src 'none'; base-uri 'none'; form-action 'none'"
+    );
 }
 
 #[test]
 fn s3_error_contains_key_in_xml() {
     let body = body_of(s3_error::internal_error("key-name-123", "detail"));
     assert!(body.contains("<Key>key-name-123</Key>"));
+}
+
+#[test]
+fn adversarial_decoded_resource_and_message_cannot_inject_xml_nodes() {
+    let decoded_resource = "bucket/<Injected>resource</Injected>&\"'";
+    let body = body_of(s3_error::invalid_request(
+        decoded_resource,
+        "bad </Message><Injected>message</Injected> & value",
+    ));
+
+    assert_eq!(
+        xml_element_names(&body),
+        ["Error", "Code", "Message", "Key", "RequestId"]
+    );
+    assert!(!body.contains("<Injected>"));
+    assert!(body.contains("bucket/&lt;Injected&gt;resource&lt;/Injected&gt;&amp;&quot;&apos;"));
+    assert!(
+        body.contains("bad &lt;/Message&gt;&lt;Injected&gt;message&lt;/Injected&gt; &amp; value")
+    );
+}
+
+#[test]
+fn s3_invalid_range_is_hardened_xml_with_complete_length() {
+    let resp = s3_error::invalid_range("unsafe<range>&.txt", 10);
+    assert_eq!(resp.status(), StatusCode::RANGE_NOT_SATISFIABLE);
+    assert_eq!(resp.headers()[header::CONTENT_RANGE], "bytes */10");
+    assert_eq!(resp.headers()[header::CACHE_CONTROL], "private, no-store");
+    let body = body_of(resp);
+    assert_eq!(
+        xml_element_names(&body),
+        ["Error", "Code", "Message", "Key", "RequestId"]
+    );
+    assert!(body.contains("<Code>InvalidRange</Code>"), "{body}");
+    assert!(
+        body.contains("<Key>unsafe&lt;range&gt;&amp;.txt</Key>"),
+        "{body}"
+    );
+    assert!(!body.contains("<range>"), "{body}");
 }
 
 #[test]


### PR DESCRIPTION
## Security impact
- prevents stored active content from executing under the gateway origin
- prevents presigned backends from injecting cookies, redirects, auth challenges, CORS policy, or arbitrary headers
- prevents shared-cache leakage of tenant object/list/error responses
- redacts presigned URL material from transport errors
- XML-escapes generated S3 errors and returns hardened InvalidRange responses

## Behavior
- object/list/error responses force `Content-Disposition: attachment`, sandbox CSP, `nosniff`, and `Cache-Control: private, no-store`
- AWS/GCS metadata, validators, versions, ranges, and checksums remain supported
- backend filenames, cache directives, unknown extension headers, and upstream CORS are intentionally discarded

## Validation
- full gateway suite: 292 passed, 1 soak test ignored
- strict clippy and rustfmt passed
- three independent review rounds completed; final verdict has no blockers