### PR TITLE
fix(security): authenticate public key mutation

### DIFF
--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -5857,20 +5857,118 @@ struct SetPublicKeyRequest {
     public_key_pem: String,
 }
 
+enum PublicKeyMutationActor {
+    ApiKey { access_key: String, user_id: String },
+    DashboardUser(String),
+}
+
+fn unique_header<'a>(headers: &'a HeaderMap, name: &str) -> Result<Option<&'a str>, StatusCode> {
+    let mut values = headers.get_all(name).iter();
+    let value = values.next();
+    if values.next().is_some() {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    value
+        .map(|value| value.to_str().map_err(|_| StatusCode::UNAUTHORIZED))
+        .transpose()
+}
+
+async fn authenticate_public_key_mutation(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<PublicKeyMutationActor, StatusCode> {
+    let authorization = unique_header(headers, "authorization")?;
+    let access_key = unique_header(headers, "x-s4-access-key")?;
+    let secret_key = unique_header(headers, "x-s4-secret-key")?;
+    let mcp_token = unique_header(headers, "x-s4-mcp-token")?;
+    let api_headers_supplied = access_key.is_some() || secret_key.is_some();
+    if (api_headers_supplied && authorization.is_some())
+        || (mcp_token.is_some() && (api_headers_supplied || authorization.is_some()))
+    {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    if mcp_token.is_some() {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    if access_key.is_some() || secret_key.is_some() {
+        let access_key = access_key
+            .filter(|value| !value.is_empty())
+            .ok_or(StatusCode::UNAUTHORIZED)?;
+        let secret_key = secret_key
+            .filter(|value| !value.is_empty())
+            .ok_or(StatusCode::UNAUTHORIZED)?;
+        let (user_id, _) = state
+            .keys
+            .resolve_credentials(access_key, secret_key)
+            .await
+            .ok_or(StatusCode::UNAUTHORIZED)?;
+        return Ok(PublicKeyMutationActor::ApiKey {
+            access_key: access_key.to_string(),
+            user_id,
+        });
+    }
+
+    let token = authorization
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .filter(|value| !value.is_empty())
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+    if let Some((access_key, secret_key)) = token.split_once(':') {
+        if access_key.is_empty() || secret_key.is_empty() {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+        let (user_id, _) = state
+            .keys
+            .resolve_credentials(access_key, secret_key)
+            .await
+            .ok_or(StatusCode::UNAUTHORIZED)?;
+        return Ok(PublicKeyMutationActor::ApiKey {
+            access_key: access_key.to_string(),
+            user_id,
+        });
+    }
+
+    if state.auth_disabled || token.starts_with("s4m_") {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    require_user_id(headers, state)
+        .await
+        .map(PublicKeyMutationActor::DashboardUser)
+        .ok_or(StatusCode::UNAUTHORIZED)
+}
+
 async fn set_public_key(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Json(body): Json<SetPublicKeyRequest>,
 ) -> impl IntoResponse {
-    let uid = get_user_id(&headers, &state);
-    if state
+    let actor = match authenticate_public_key_mutation(&state, &headers).await {
+        Ok(actor) => actor,
+        Err(status) => return status.into_response(),
+    };
+    let uid = match actor {
+        PublicKeyMutationActor::ApiKey {
+            access_key,
+            user_id,
+        } => {
+            if body.key_id != access_key {
+                return (StatusCode::NOT_FOUND, "key not found").into_response();
+            }
+            user_id
+        }
+        PublicKeyMutationActor::DashboardUser(user_id) => user_id,
+    };
+    match state
         .keys
         .set_public_key(&body.key_id, &uid, &body.public_key_pem)
         .await
     {
-        StatusCode::OK.into_response()
-    } else {
-        (StatusCode::NOT_FOUND, "key not found or not owned by user").into_response()
+        Ok(true) => StatusCode::OK.into_response(),
+        Ok(false) => (StatusCode::NOT_FOUND, "key not found").into_response(),
+        Err(_) => {
+            tracing::error!(user_id = uid, "public key persistence failed");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
     }
 }
 

--- a/crates/gateway/src/store.rs
+++ b/crates/gateway/src/store.rs
@@ -23,7 +23,7 @@ pub struct StoredObject {
     pub etag: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ApiKey {
     pub key_id: String,
     pub secret_hash: String,
@@ -38,7 +38,7 @@ pub struct ApiKey {
 
 /// MCP bearer token (`s4m_...`). The full token is the credential; only its
 /// SHA-256 hash is stored.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct McpToken {
     pub token_hash: String,
     pub user_id: String,
@@ -198,7 +198,12 @@ pub trait KeyRepository: Send + Sync {
         public_key_pem: Option<String>,
     ) -> anyhow::Result<(String, String)>;
 
-    async fn set_public_key(&self, key_id: &str, user_id: &str, public_key_pem: &str) -> bool;
+    async fn set_public_key(
+        &self,
+        key_id: &str,
+        user_id: &str,
+        public_key_pem: &str,
+    ) -> anyhow::Result<bool>;
 
     async fn get_key(&self, key_id: &str) -> Option<ApiKey>;
 
@@ -470,8 +475,18 @@ impl KeyRepository for KeyStore {
         Ok((key_id, secret))
     }
 
-    async fn set_public_key(&self, key_id: &str, user_id: &str, public_key_pem: &str) -> bool {
-        set_public_key_in(&self.keys, key_id, user_id, public_key_pem)
+    async fn set_public_key(
+        &self,
+        key_id: &str,
+        user_id: &str,
+        public_key_pem: &str,
+    ) -> anyhow::Result<bool> {
+        Ok(set_public_key_in(
+            &self.keys,
+            key_id,
+            user_id,
+            public_key_pem,
+        ))
     }
 
     async fn get_key(&self, key_id: &str) -> Option<ApiKey> {
@@ -577,10 +592,19 @@ impl KeyRepository for KeyStore {
 pub struct FileKeyStore {
     keys: RwLock<HashMap<String, ApiKey>>,
     mcp_tokens: RwLock<HashMap<String, McpToken>>,
-    // Keep v1 replacement and disk commit atomic from concurrent readers' view.
-    rewrap_lock: Mutex<()>,
+    // Every state mutation shares one snapshot file and must commit in order.
+    mutation_lock: Mutex<()>,
+    #[cfg(test)]
+    persist_hook: Mutex<Option<PersistTestHook>>,
     path: PathBuf,
     cipher: Option<Arc<SecretCipher>>,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct PersistTestHook {
+    entered: std::sync::mpsc::SyncSender<()>,
+    resume: std::sync::mpsc::Receiver<()>,
 }
 
 impl FileKeyStore {
@@ -589,7 +613,9 @@ impl FileKeyStore {
         Self {
             keys: RwLock::new(keys),
             mcp_tokens: RwLock::new(mcp_tokens),
-            rewrap_lock: Mutex::new(()),
+            mutation_lock: Mutex::new(()),
+            #[cfg(test)]
+            persist_hook: Mutex::new(None),
             path,
             cipher: None,
         }
@@ -600,7 +626,9 @@ impl FileKeyStore {
         Self {
             keys: RwLock::new(keys),
             mcp_tokens: RwLock::new(mcp_tokens),
-            rewrap_lock: Mutex::new(()),
+            mutation_lock: Mutex::new(()),
+            #[cfg(test)]
+            persist_hook: Mutex::new(None),
             path,
             cipher: Some(cipher),
         }
@@ -616,6 +644,11 @@ impl FileKeyStore {
 
     /// Atomically write the current key set to disk (0600 on unix).
     fn persist(&self) -> anyhow::Result<()> {
+        #[cfg(test)]
+        if let Some(hook) = self.persist_hook.lock().unwrap().take() {
+            hook.entered.send(()).unwrap();
+            hook.resume.recv().unwrap();
+        }
         #[derive(serde::Serialize)]
         struct Persisted {
             keys: HashMap<String, ApiKey>,
@@ -667,7 +700,12 @@ impl KeyRepository for FileKeyStore {
             public_key_pem,
             self.cipher.as_deref(),
         )?;
+        let _mutation_guard = self
+            .mutation_lock
+            .lock()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore mutation lock poisoned"))?;
         let key_id = api_key.key_id.clone();
+        let inserted = api_key.clone();
         let previous = self
             .keys
             .write()
@@ -679,23 +717,56 @@ impl KeyRepository for FileKeyStore {
                     "FileKeyStore persist failed and API key rollback lock was poisoned: {error}"
                 )
             })?;
-            if let Some(previous) = previous {
-                keys.insert(key_id, previous);
-            } else {
-                keys.remove(&key_id);
+            if keys.get(&key_id) == Some(&inserted) {
+                if let Some(previous) = previous {
+                    keys.insert(key_id, previous);
+                } else {
+                    keys.remove(&key_id);
+                }
             }
             return Err(error.context("FileKeyStore persist failed"));
         }
         Ok((key_id, secret))
     }
 
-    async fn set_public_key(&self, key_id: &str, user_id: &str, public_key_pem: &str) -> bool {
-        let ok = set_public_key_in(&self.keys, key_id, user_id, public_key_pem);
-        if ok {
-            self.persist()
-                .unwrap_or_else(|e| tracing::warn!("FileKeyStore persist failed: {e}"));
+    async fn set_public_key(
+        &self,
+        key_id: &str,
+        user_id: &str,
+        public_key_pem: &str,
+    ) -> anyhow::Result<bool> {
+        let _mutation_guard = self
+            .mutation_lock
+            .lock()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore mutation lock poisoned"))?;
+        let previous = {
+            let mut keys = self
+                .keys
+                .write()
+                .map_err(|_| anyhow::anyhow!("FileKeyStore API key lock poisoned"))?;
+            let Some(key) = keys.get_mut(key_id) else {
+                return Ok(false);
+            };
+            if key.user_id != user_id {
+                return Ok(false);
+            }
+            key.public_key_pem.replace(public_key_pem.to_string())
+        };
+        if let Err(error) = self.persist() {
+            let mut keys = self.keys.write().map_err(|_| {
+                anyhow::anyhow!(
+                    "FileKeyStore public key persist failed and rollback lock was poisoned: {error}"
+                )
+            })?;
+            if let Some(key) = keys.get_mut(key_id)
+                && key.user_id == user_id
+                && key.public_key_pem.as_deref() == Some(public_key_pem)
+            {
+                key.public_key_pem = previous;
+            }
+            return Err(error.context("FileKeyStore public key persist failed"));
         }
-        ok
+        Ok(true)
     }
 
     async fn get_key(&self, key_id: &str) -> Option<ApiKey> {
@@ -711,7 +782,7 @@ impl KeyRepository for FileKeyStore {
         };
         let (secret, rewrapped) = decrypt_verified_secret(cipher, key_id, &secret_hash, &blob)?;
         if let Some(rewrapped) = rewrapped {
-            let _rewrap_guard = self.rewrap_lock.lock().ok()?;
+            let _mutation_guard = self.mutation_lock.lock().ok()?;
             match replace_or_accept_rewrapped_envelope(
                 &self.keys,
                 cipher,
@@ -722,12 +793,9 @@ impl KeyRepository for FileKeyStore {
                 rewrapped.clone(),
             )? {
                 EnvelopeUpdate::Replaced => {
-                    if let Err(error) = self.persist() {
+                    if self.persist().is_err() {
                         let _ = compare_and_swap_envelope(&self.keys, key_id, &rewrapped, blob);
-                        tracing::warn!(
-                            key_id = key_id,
-                            "FileKeyStore legacy secret rewrap persist failed: {error}"
-                        );
+                        tracing::warn!("FileKeyStore legacy secret rewrap persist failed");
                         return None;
                     }
                 }
@@ -750,12 +818,30 @@ impl KeyRepository for FileKeyStore {
     }
 
     async fn delete_key(&self, key_id: &str, user_id: &str) -> bool {
-        let ok = delete_key_in(&self.keys, key_id, user_id);
-        if ok {
-            self.persist()
-                .unwrap_or_else(|e| tracing::warn!("FileKeyStore persist failed: {e}"));
+        let Ok(_mutation_guard) = self.mutation_lock.lock() else {
+            tracing::warn!("FileKeyStore mutation lock poisoned");
+            return false;
+        };
+        let removed = {
+            let mut keys = self.keys.write().unwrap();
+            let Some(key) = keys.get(key_id) else {
+                return false;
+            };
+            if key.user_id != user_id {
+                return false;
+            }
+            keys.remove(key_id).expect("key existence checked")
+        };
+        if self.persist().is_err() {
+            self.keys
+                .write()
+                .unwrap()
+                .entry(key_id.to_string())
+                .or_insert(removed);
+            tracing::warn!("FileKeyStore key deletion persist failed");
+            return false;
         }
-        ok
+        true
     }
 
     async fn create_mcp_token(&self, user_id: &str, label: &str, expires_in: u64) -> String {
@@ -773,9 +859,27 @@ impl KeyRepository for FileKeyStore {
                 None
             },
         };
-        self.mcp_tokens.write().unwrap().insert(token_hash, mcp);
-        self.persist()
-            .unwrap_or_else(|e| tracing::warn!("FileKeyStore persist failed: {e}"));
+        let Ok(_mutation_guard) = self.mutation_lock.lock() else {
+            tracing::warn!("FileKeyStore mutation lock poisoned");
+            return token;
+        };
+        let inserted = mcp.clone();
+        let previous = self
+            .mcp_tokens
+            .write()
+            .unwrap()
+            .insert(token_hash.clone(), mcp);
+        if self.persist().is_err() {
+            let mut tokens = self.mcp_tokens.write().unwrap();
+            if tokens.get(&token_hash) == Some(&inserted) {
+                if let Some(previous) = previous {
+                    tokens.insert(token_hash, previous);
+                } else {
+                    tokens.remove(&token_hash);
+                }
+            }
+            tracing::warn!("FileKeyStore MCP token creation persist failed");
+        }
         token
     }
 
@@ -800,16 +904,30 @@ impl KeyRepository for FileKeyStore {
     }
 
     async fn delete_mcp_token(&self, token_hash: &str, user_id: &str) -> bool {
-        let mut tokens = self.mcp_tokens.write().unwrap();
-        if let Some(t) = tokens.get(token_hash)
-            && t.user_id == user_id
-        {
-            tokens.remove(token_hash);
-            self.persist()
-                .unwrap_or_else(|e| tracing::warn!("FileKeyStore persist failed: {e}"));
-            return true;
+        let Ok(_mutation_guard) = self.mutation_lock.lock() else {
+            tracing::warn!("FileKeyStore mutation lock poisoned");
+            return false;
+        };
+        let removed = {
+            let mut tokens = self.mcp_tokens.write().unwrap();
+            let Some(token) = tokens.get(token_hash) else {
+                return false;
+            };
+            if token.user_id != user_id {
+                return false;
+            }
+            tokens.remove(token_hash).expect("token existence checked")
+        };
+        if self.persist().is_err() {
+            self.mcp_tokens
+                .write()
+                .unwrap()
+                .entry(token_hash.to_string())
+                .or_insert(removed);
+            tracing::warn!("FileKeyStore MCP token deletion persist failed");
+            return false;
         }
-        false
+        true
     }
 }
 
@@ -871,7 +989,12 @@ impl KeyRepository for PostgresKeyStore {
         Ok((api_key.key_id, secret))
     }
 
-    async fn set_public_key(&self, key_id: &str, user_id: &str, public_key_pem: &str) -> bool {
+    async fn set_public_key(
+        &self,
+        key_id: &str,
+        user_id: &str,
+        public_key_pem: &str,
+    ) -> anyhow::Result<bool> {
         let result = api_key::Entity::update_many()
             .col_expr(
                 api_key::Column::PublicKeyPem,
@@ -880,8 +1003,9 @@ impl KeyRepository for PostgresKeyStore {
             .filter(api_key::Column::KeyId.eq(key_id.to_string()))
             .filter(api_key::Column::UserId.eq(user_id.to_string()))
             .exec(&self.db)
-            .await;
-        matches!(result, Ok(r) if r.rows_affected == 1)
+            .await
+            .context("Postgres public key update failed")?;
+        Ok(result.rows_affected == 1)
     }
 
     async fn get_key(&self, key_id: &str) -> Option<ApiKey> {
@@ -1367,8 +1491,8 @@ mod tests {
     async fn in_memory_public_key_and_delete() {
         let store = KeyStore::new();
         let (key_id, _secret) = store.create_key("u1", "enc", 0, None).await.unwrap();
-        assert!(store.set_public_key(&key_id, "u1", "pem").await);
-        assert!(!store.set_public_key(&key_id, "u2", "pem").await);
+        assert!(store.set_public_key(&key_id, "u1", "pem").await.unwrap());
+        assert!(!store.set_public_key(&key_id, "u2", "pem").await.unwrap());
         let key = store.get_key(&key_id).await.expect("key exists");
         assert_eq!(key.public_key_pem.as_deref(), Some("pem"));
         let keys = store.list_for_user("u1").await;
@@ -1423,6 +1547,289 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn file_key_store_rolls_back_public_key_when_persist_fails_and_restart_keeps_old_value() {
+        let parent = std::env::temp_dir().join(format!("s4-file-keys-{}", Uuid::new_v4()));
+        let durable_parent = parent.with_extension("durable");
+        std::fs::create_dir_all(&parent).unwrap();
+        let path = parent.join("keys.json");
+        let store = FileKeyStore::new(path.clone());
+        let (key_id, _) = store
+            .create_key("u1", "persisted-public-key", 0, Some("old-pem".to_string()))
+            .await
+            .unwrap();
+        std::fs::rename(&parent, &durable_parent).unwrap();
+        std::fs::write(&parent, "not a directory").unwrap();
+
+        let error = store
+            .set_public_key(&key_id, "u1", "new-pem")
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("public key persist failed"));
+        assert_eq!(
+            store
+                .get_key(&key_id)
+                .await
+                .unwrap()
+                .public_key_pem
+                .as_deref(),
+            Some("old-pem")
+        );
+        std::fs::remove_file(&parent).unwrap();
+        std::fs::rename(&durable_parent, &parent).unwrap();
+        drop(store);
+
+        let restarted = FileKeyStore::new(path);
+        assert_eq!(
+            restarted
+                .get_key(&key_id)
+                .await
+                .unwrap()
+                .public_key_pem
+                .as_deref(),
+            Some("old-pem")
+        );
+        std::fs::remove_dir_all(parent).unwrap();
+    }
+
+    #[tokio::test]
+    async fn file_key_store_rolls_back_key_delete_when_persist_fails() {
+        let parent = std::env::temp_dir().join(format!("s4-file-keys-{}", Uuid::new_v4()));
+        let durable_parent = parent.with_extension("durable");
+        std::fs::create_dir_all(&parent).unwrap();
+        let path = parent.join("keys.json");
+        let store = FileKeyStore::new(path.clone());
+        let (key_id, secret) = store.create_key("u1", "delete", 0, None).await.unwrap();
+        std::fs::rename(&parent, &durable_parent).unwrap();
+        std::fs::write(&parent, "not a directory").unwrap();
+
+        assert!(!store.delete_key(&key_id, "u1").await);
+        assert!(store.resolve_credentials(&key_id, &secret).await.is_some());
+        std::fs::remove_file(&parent).unwrap();
+        std::fs::rename(&durable_parent, &parent).unwrap();
+        drop(store);
+
+        let restarted = FileKeyStore::new(path);
+        assert!(
+            restarted
+                .resolve_credentials(&key_id, &secret)
+                .await
+                .is_some(),
+            "failed revocation must not be acknowledged only in memory"
+        );
+        std::fs::remove_dir_all(parent).unwrap();
+    }
+
+    #[tokio::test]
+    async fn file_key_store_rolls_back_mcp_mutations_when_persist_fails() {
+        let parent = std::env::temp_dir().join(format!("s4-file-keys-{}", Uuid::new_v4()));
+        let durable_parent = parent.with_extension("durable");
+        std::fs::create_dir_all(&parent).unwrap();
+        let path = parent.join("keys.json");
+        let store = FileKeyStore::new(path.clone());
+        let persisted_token = store.create_mcp_token("u1", "persisted", 0).await;
+        let persisted_hash = sha256_hash(&persisted_token);
+        std::fs::rename(&parent, &durable_parent).unwrap();
+        std::fs::write(&parent, "not a directory").unwrap();
+
+        let rejected_token = store.create_mcp_token("u1", "rejected", 0).await;
+        assert!(store.resolve_mcp_token(&rejected_token).await.is_none());
+        assert!(!store.delete_mcp_token(&persisted_hash, "u1").await);
+        assert_eq!(
+            store.resolve_mcp_token(&persisted_token).await.as_deref(),
+            Some("u1")
+        );
+        std::fs::remove_file(&parent).unwrap();
+        std::fs::rename(&durable_parent, &parent).unwrap();
+        drop(store);
+
+        let restarted = FileKeyStore::new(path);
+        assert_eq!(
+            restarted
+                .resolve_mcp_token(&persisted_token)
+                .await
+                .as_deref(),
+            Some("u1")
+        );
+        assert!(restarted.resolve_mcp_token(&rejected_token).await.is_none());
+        std::fs::remove_dir_all(parent).unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn file_key_store_serializes_public_key_set_before_successful_delete() {
+        let path = temp_keys_file();
+        let store = Arc::new(FileKeyStore::new(path.clone()));
+        let (key_id, secret) = store.create_key("u1", "race", 0, None).await.unwrap();
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let (resume_tx, resume_rx) = std::sync::mpsc::sync_channel(1);
+        *store.persist_hook.lock().unwrap() = Some(PersistTestHook {
+            entered: entered_tx,
+            resume: resume_rx,
+        });
+
+        let set_store = store.clone();
+        let set_key = key_id.clone();
+        let set_task = tokio::spawn(async move {
+            set_store
+                .set_public_key(&set_key, "u1", "concurrent-pem")
+                .await
+        });
+        entered_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        let delete_store = store.clone();
+        let delete_key = key_id.clone();
+        let delete_task =
+            tokio::spawn(async move { delete_store.delete_key(&delete_key, "u1").await });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            !delete_task.is_finished(),
+            "delete must wait for the in-flight snapshot"
+        );
+
+        resume_tx.send(()).unwrap();
+        assert!(set_task.await.unwrap().unwrap());
+        assert!(delete_task.await.unwrap());
+        assert!(store.resolve_credentials(&key_id, &secret).await.is_none());
+        drop(store);
+
+        let restarted = FileKeyStore::new(path.clone());
+        assert!(
+            restarted
+                .resolve_credentials(&key_id, &secret)
+                .await
+                .is_none(),
+            "a successfully revoked key must never reappear after restart"
+        );
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn file_key_store_serializes_api_key_and_mcp_creation_snapshots() {
+        let path = temp_keys_file();
+        let store = Arc::new(FileKeyStore::new(path.clone()));
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let (resume_tx, resume_rx) = std::sync::mpsc::sync_channel(1);
+        *store.persist_hook.lock().unwrap() = Some(PersistTestHook {
+            entered: entered_tx,
+            resume: resume_rx,
+        });
+
+        let key_store = store.clone();
+        let key_task =
+            tokio::spawn(async move { key_store.create_key("u1", "concurrent", 0, None).await });
+        entered_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        let mcp_store = store.clone();
+        let mcp_task = tokio::spawn(async move {
+            mcp_store
+                .create_mcp_token("u1", "concurrent-token", 0)
+                .await
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            !mcp_task.is_finished(),
+            "MCP creation must wait for the API key snapshot"
+        );
+
+        resume_tx.send(()).unwrap();
+        let (key_id, secret) = key_task.await.unwrap().unwrap();
+        let token = mcp_task.await.unwrap();
+        drop(store);
+
+        let restarted = FileKeyStore::new(path.clone());
+        assert!(
+            restarted
+                .resolve_credentials(&key_id, &secret)
+                .await
+                .is_some()
+        );
+        assert_eq!(
+            restarted.resolve_mcp_token(&token).await.as_deref(),
+            Some("u1")
+        );
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn file_key_store_serializes_secret_rewrap_and_mcp_creation() {
+        let path = temp_keys_file();
+        let cipher = test_cipher();
+        let store = Arc::new(FileKeyStore::with_cipher(path.clone(), cipher.clone()));
+        let (key_id, secret) = store.create_key("u1", "legacy", 0, None).await.unwrap();
+        let legacy = cipher.encrypt_v1(&secret).unwrap();
+        store
+            .keys
+            .write()
+            .unwrap()
+            .get_mut(&key_id)
+            .unwrap()
+            .secret_encrypted = Some(legacy);
+        store.persist().unwrap();
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let (resume_tx, resume_rx) = std::sync::mpsc::sync_channel(1);
+        *store.persist_hook.lock().unwrap() = Some(PersistTestHook {
+            entered: entered_tx,
+            resume: resume_rx,
+        });
+
+        let rewrap_store = store.clone();
+        let rewrap_key = key_id.clone();
+        let rewrap_task =
+            tokio::spawn(async move { rewrap_store.decrypt_secret(&rewrap_key).await });
+        entered_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        let mcp_store = store.clone();
+        let mcp_task =
+            tokio::spawn(async move { mcp_store.create_mcp_token("u1", "after-rewrap", 0).await });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            !mcp_task.is_finished(),
+            "MCP creation must wait for the rewrap snapshot"
+        );
+
+        resume_tx.send(()).unwrap();
+        assert_eq!(rewrap_task.await.unwrap().as_deref(), Some(secret.as_str()));
+        let token = mcp_task.await.unwrap();
+        drop(store);
+
+        let restarted = FileKeyStore::with_cipher(path.clone(), cipher);
+        assert_eq!(
+            restarted.decrypt_secret(&key_id).await.as_deref(),
+            Some(secret.as_str())
+        );
+        assert_eq!(
+            restarted.resolve_mcp_token(&token).await.as_deref(),
+            Some("u1")
+        );
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn file_key_store_mcp_delete_does_not_self_deadlock_and_persists() {
+        let path = temp_keys_file();
+        let store = FileKeyStore::new(path.clone());
+        let token = store.create_mcp_token("u1", "delete", 0).await;
+        let token_hash = sha256_hash(&token);
+
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                store.delete_mcp_token(&token_hash, "u1")
+            )
+            .await
+            .expect("MCP delete must not deadlock")
+        );
+        drop(store);
+
+        let restarted = FileKeyStore::new(path.clone());
+        assert!(restarted.resolve_mcp_token(&token).await.is_none());
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test]
     async fn configured_cipher_failure_does_not_create_or_persist_file_key() {
         let path = temp_keys_file();
         let store = FileKeyStore::with_cipher(path.clone(), failing_cipher());
@@ -1454,6 +1861,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn postgres_set_public_key_propagates_update_error() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(std::time::Duration::from_millis(50))
+            .connect_lazy("postgresql://postgres:postgres@127.0.0.1:1/s4")
+            .unwrap();
+        let store = PostgresKeyStore::new(pool);
+
+        let error = store
+            .set_public_key("missing-key", "u1", "pem")
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Postgres public key update failed")
+        );
+    }
+
+    #[tokio::test]
     async fn postgres_configured_cipher_failure_prevents_insert() {
         let pool = sqlx::postgres::PgPoolOptions::new()
             .acquire_timeout(std::time::Duration::from_millis(50))
@@ -1474,8 +1901,8 @@ mod tests {
         let path = temp_keys_file();
         let store = FileKeyStore::new(path.clone());
         let (key_id, _secret) = store.create_key("u1", "enc", 3600, None).await.unwrap();
-        assert!(store.set_public_key(&key_id, "u1", "pem").await);
-        assert!(!store.set_public_key(&key_id, "u2", "pem").await);
+        assert!(store.set_public_key(&key_id, "u1", "pem").await.unwrap());
+        assert!(!store.set_public_key(&key_id, "u2", "pem").await.unwrap());
         drop(store);
 
         let reloaded = FileKeyStore::new(path);

--- a/crates/gateway/tests/db_keys_test.rs
+++ b/crates/gateway/tests/db_keys_test.rs
@@ -1089,8 +1089,14 @@ fn postgres_public_key_binding() {
             store
                 .set_public_key(&key_id, &user, "-----BEGIN PUBLIC KEY-----\npem")
                 .await
+                .unwrap()
         );
-        assert!(!store.set_public_key(&key_id, "someone-else", "pem2").await);
+        assert!(
+            !store
+                .set_public_key(&key_id, "someone-else", "pem2")
+                .await
+                .unwrap()
+        );
 
         let (uid, pk) = store
             .resolve_credentials(&key_id, &secret)

--- a/crates/gateway/tests/s3_frontdoor_test.rs
+++ b/crates/gateway/tests/s3_frontdoor_test.rs
@@ -18,7 +18,7 @@ use s4_gateway::key_cipher::default_wrapping;
 use s4_gateway::object::BodyLimits;
 use s4_gateway::server::{AppState, StreamingReadMode, build_router, build_state};
 use s4_gateway::sigv4::SigV4Policy;
-use s4_gateway::store::FileKeyStore;
+use s4_gateway::store::{FileKeyStore, KeyRepository};
 use s4_gateway::transaction::SpoolQuota;
 use s4_gateway::workspace_storage::InMemoryWorkspaceStorageRepository;
 use std::collections::VecDeque;
@@ -305,12 +305,110 @@ async fn create_key_persistence_failure_returns_internal_error_without_secret() 
     std::fs::remove_file(blocking_parent).unwrap();
 }
 
+#[tokio::test]
+async fn public_key_persistence_failure_returns_generic_500_and_rolls_back() {
+    let mut state = test_state().await;
+    let parent =
+        std::env::temp_dir().join(format!("s4-public-key-handler-{}", uuid::Uuid::new_v4()));
+    let durable_parent = parent.with_extension("durable");
+    std::fs::create_dir_all(&parent).unwrap();
+    let path = parent.join("keys.json");
+    let file_store = Arc::new(FileKeyStore::new(path.clone()));
+    let (key_id, secret_key) = file_store
+        .create_key("test-user", "persist-failure", 0, None)
+        .await
+        .unwrap();
+    Arc::get_mut(&mut state)
+        .expect("test state is uniquely owned")
+        .keys = file_store.clone();
+    let app = build_router(state);
+    std::fs::rename(&parent, &durable_parent).unwrap();
+    std::fs::write(&parent, "not a directory").unwrap();
+
+    let request = add_headers(
+        public_key_request(&key_id, "must-not-persist"),
+        &auth_headers(&key_id, &secret_key),
+    );
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert!(body.is_empty(), "persistence failure body must be generic");
+    assert!(!String::from_utf8_lossy(&body).contains("must-not-persist"));
+    assert!(!String::from_utf8_lossy(&body).contains(&secret_key));
+    assert!(
+        file_store
+            .get_key(&key_id)
+            .await
+            .unwrap()
+            .public_key_pem
+            .is_none(),
+        "failed persistence must roll back the in-memory value"
+    );
+    std::fs::remove_file(&parent).unwrap();
+    std::fs::rename(&durable_parent, &parent).unwrap();
+    drop(file_store);
+
+    let restarted = FileKeyStore::new(path);
+    assert!(
+        restarted
+            .get_key(&key_id)
+            .await
+            .unwrap()
+            .public_key_pem
+            .is_none(),
+        "failed persistence must not appear after restart"
+    );
+    std::fs::remove_dir_all(parent).unwrap();
+}
+
 async fn make_key(state: &Arc<AppState>) -> (String, String) {
+    make_key_for(state, "test-user").await
+}
+
+async fn make_key_for(state: &Arc<AppState>, user_id: &str) -> (String, String) {
     state
         .keys
-        .create_key("test-user", "sigv4-test", 0, None)
+        .create_key(user_id, "sigv4-test", 0, None)
         .await
         .expect("create test API key")
+}
+
+fn configure_dashboard_jwt(state: &mut Arc<AppState>, user_id: &str) -> String {
+    let secret = b"public-key-dashboard-secret";
+    let issuer = "https://example.supabase.co/auth/v1";
+    let token = jsonwebtoken::encode(
+        &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256),
+        &serde_json::json!({
+            "sub": user_id,
+            "iss": issuer,
+            "aud": "authenticated",
+            "exp": u64::MAX,
+        }),
+        &jsonwebtoken::EncodingKey::from_secret(secret),
+    )
+    .unwrap();
+    let state_mut = Arc::get_mut(state).expect("test state is uniquely owned");
+    state_mut.supabase_url = "https://example.supabase.co".to_string();
+    state_mut.jwt_decoder = Some(Arc::new(jsonwebtoken::DecodingKey::from_secret(secret)));
+    token
+}
+
+fn public_key_request(key_id: &str, public_key_pem: &str) -> Request<Body> {
+    Request::builder()
+        .method("PUT")
+        .uri("/dashboard/api/keys/public-key")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(
+            serde_json::json!({
+                "key_id": key_id,
+                "public_key_pem": public_key_pem,
+            })
+            .to_string(),
+        ))
+        .unwrap()
 }
 
 fn test_filter_component() -> Vec<u8> {
@@ -380,6 +478,14 @@ fn add_headers(req: Request<Body>, hdrs: &[(&'static str, String)]) -> Request<B
     Request::from_parts(parts, body)
 }
 
+fn append_headers(req: Request<Body>, hdrs: &[(&'static str, String)]) -> Request<Body> {
+    let (mut parts, body) = req.into_parts();
+    for (name, value) in hdrs {
+        parts.headers.append(*name, value.parse().unwrap());
+    }
+    Request::from_parts(parts, body)
+}
+
 fn assert_hardened_object_headers(headers: &axum::http::HeaderMap) {
     assert_eq!(headers[header::CACHE_CONTROL], "private, no-store");
     assert!(!headers.contains_key(header::AGE));
@@ -401,6 +507,460 @@ fn assert_s3_error_has_only_expected_xml_elements(document: &str) {
         })
         .collect();
     assert_eq!(elements, ["Error", "Code", "Message", "Key", "RequestId"]);
+}
+
+#[tokio::test]
+async fn public_key_mutation_rejects_unauthenticated_requests_in_production_and_local_mode() {
+    for auth_disabled in [false, true] {
+        let mut state = test_state().await;
+        let (key_id, _) = make_key(&state).await;
+        Arc::get_mut(&mut state)
+            .expect("test state is uniquely owned")
+            .auth_disabled = auth_disabled;
+        let app = build_router(state.clone());
+
+        let response = app
+            .oneshot(public_key_request(&key_id, "rejected-pem"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(
+            state
+                .keys
+                .get_key(&key_id)
+                .await
+                .unwrap()
+                .public_key_pem
+                .is_none(),
+            "rejected request must not mutate the key"
+        );
+    }
+}
+
+#[tokio::test]
+async fn public_key_mutation_rejects_incomplete_or_invalid_api_key_credentials() {
+    let state = test_state().await;
+    let (key_id, secret_key) = make_key(&state).await;
+    let app = build_router(state.clone());
+    let requests = [
+        add_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &[("x-s4-access-key", key_id.clone())],
+        ),
+        add_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &[("x-s4-secret-key", secret_key.clone())],
+        ),
+        add_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &auth_headers(&key_id, "wrong-secret"),
+        ),
+        add_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &[("authorization", format!("Bearer {key_id}:wrong-secret"))],
+        ),
+    ];
+
+    for request in requests {
+        assert_eq!(
+            app.clone().oneshot(request).await.unwrap().status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert!(
+            state
+                .keys
+                .get_key(&key_id)
+                .await
+                .unwrap()
+                .public_key_pem
+                .is_none(),
+            "rejected credentials must not mutate the key"
+        );
+    }
+}
+
+#[tokio::test]
+async fn public_key_mutation_rejects_duplicate_security_headers_without_mutation() {
+    let state = test_state().await;
+    let (key_id, secret_key) = make_key(&state).await;
+    let mcp_token = state
+        .keys
+        .create_mcp_token("test-user", "duplicate-test", 0)
+        .await;
+    let app = build_router(state.clone());
+    let bearer = format!("Bearer {key_id}:{secret_key}");
+    let requests = [
+        append_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &[
+                ("authorization", bearer.clone()),
+                ("authorization", bearer.clone()),
+            ],
+        ),
+        append_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &[
+                ("x-s4-access-key", key_id.clone()),
+                ("x-s4-access-key", key_id.clone()),
+                ("x-s4-secret-key", secret_key.clone()),
+            ],
+        ),
+        append_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &[
+                ("x-s4-access-key", key_id.clone()),
+                ("x-s4-secret-key", secret_key.clone()),
+                ("x-s4-secret-key", secret_key.clone()),
+            ],
+        ),
+        append_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &[
+                ("x-s4-mcp-token", mcp_token.clone()),
+                ("x-s4-mcp-token", mcp_token.clone()),
+            ],
+        ),
+    ];
+
+    for request in requests {
+        assert_eq!(
+            app.clone().oneshot(request).await.unwrap().status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert!(
+            state
+                .keys
+                .get_key(&key_id)
+                .await
+                .unwrap()
+                .public_key_pem
+                .is_none(),
+            "duplicate credential headers must not mutate the key"
+        );
+    }
+}
+
+#[tokio::test]
+async fn public_key_mutation_rejects_mixed_credential_classes_without_mutation() {
+    let mut state = test_state().await;
+    let (key_id, secret_key) = make_key(&state).await;
+    let mcp_token = state
+        .keys
+        .create_mcp_token("test-user", "mixed-test", 0)
+        .await;
+    let jwt = configure_dashboard_jwt(&mut state, "test-user");
+    let app = build_router(state.clone());
+    let api_bearer = format!("Bearer {key_id}:{secret_key}");
+    let requests = [
+        append_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &[
+                ("x-s4-access-key", key_id.clone()),
+                ("x-s4-secret-key", secret_key.clone()),
+                ("authorization", api_bearer.clone()),
+            ],
+        ),
+        append_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &[
+                ("x-s4-access-key", key_id.clone()),
+                ("x-s4-secret-key", secret_key.clone()),
+                ("authorization", format!("Bearer {jwt}")),
+            ],
+        ),
+        append_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &[
+                ("x-s4-mcp-token", mcp_token.clone()),
+                ("x-s4-access-key", key_id.clone()),
+                ("x-s4-secret-key", secret_key.clone()),
+            ],
+        ),
+        append_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &[
+                ("x-s4-mcp-token", mcp_token.clone()),
+                ("authorization", format!("Bearer {jwt}")),
+            ],
+        ),
+        append_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &[("x-s4-mcp-token", mcp_token), ("authorization", api_bearer)],
+        ),
+    ];
+
+    for request in requests {
+        assert_eq!(
+            app.clone().oneshot(request).await.unwrap().status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert!(
+            state
+                .keys
+                .get_key(&key_id)
+                .await
+                .unwrap()
+                .public_key_pem
+                .is_none(),
+            "mixed credential classes must not mutate the key"
+        );
+    }
+}
+
+#[tokio::test]
+async fn public_key_mutation_accepts_own_key_via_headers_and_bearer() {
+    let state = test_state().await;
+    let (header_key, header_secret) = make_key(&state).await;
+    let (bearer_key, bearer_secret) = make_key(&state).await;
+    let app = build_router(state.clone());
+
+    let header_request = add_headers(
+        public_key_request(&header_key, "header-pem"),
+        &auth_headers(&header_key, &header_secret),
+    );
+    assert_eq!(
+        app.clone().oneshot(header_request).await.unwrap().status(),
+        StatusCode::OK
+    );
+
+    let bearer_request = add_headers(
+        public_key_request(&bearer_key, "bearer-pem"),
+        &[(
+            "authorization",
+            format!("Bearer {bearer_key}:{bearer_secret}"),
+        )],
+    );
+    assert_eq!(
+        app.oneshot(bearer_request).await.unwrap().status(),
+        StatusCode::OK
+    );
+
+    assert_eq!(
+        state
+            .keys
+            .get_key(&header_key)
+            .await
+            .unwrap()
+            .public_key_pem
+            .as_deref(),
+        Some("header-pem")
+    );
+    assert_eq!(
+        state
+            .keys
+            .get_key(&bearer_key)
+            .await
+            .unwrap()
+            .public_key_pem
+            .as_deref(),
+        Some("bearer-pem")
+    );
+}
+
+#[tokio::test]
+async fn local_public_key_mutation_accepts_real_target_credentials() {
+    let mut state = test_state().await;
+    let (key_id, secret_key) = make_key(&state).await;
+    Arc::get_mut(&mut state)
+        .expect("test state is uniquely owned")
+        .auth_disabled = true;
+    let app = build_router(state.clone());
+    let request = add_headers(
+        public_key_request(&key_id, "local-authenticated-pem"),
+        &auth_headers(&key_id, &secret_key),
+    );
+
+    assert_eq!(app.oneshot(request).await.unwrap().status(), StatusCode::OK);
+    assert_eq!(
+        state
+            .keys
+            .get_key(&key_id)
+            .await
+            .unwrap()
+            .public_key_pem
+            .as_deref(),
+        Some("local-authenticated-pem")
+    );
+}
+
+#[tokio::test]
+async fn api_key_public_key_mutation_hides_and_rejects_sibling_and_foreign_keys() {
+    let state = test_state().await;
+    let (credential_key, credential_secret) = make_key_for(&state, "owner-a").await;
+    let (sibling_key, _) = make_key_for(&state, "owner-a").await;
+    let (foreign_key, _) = make_key_for(&state, "owner-b").await;
+    let app = build_router(state.clone());
+    let mut rejection_bodies = Vec::new();
+
+    for target in [&sibling_key, &foreign_key] {
+        let request = add_headers(
+            public_key_request(target, "rejected-pem"),
+            &auth_headers(&credential_key, &credential_secret),
+        );
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        rejection_bodies.push(
+            axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        );
+    }
+    assert_eq!(rejection_bodies[0], rejection_bodies[1]);
+    assert_eq!(rejection_bodies[0].as_ref(), b"key not found");
+    for key_id in [&credential_key, &sibling_key, &foreign_key] {
+        assert!(
+            state
+                .keys
+                .get_key(key_id)
+                .await
+                .unwrap()
+                .public_key_pem
+                .is_none(),
+            "rejected cross-key request must not mutate any key"
+        );
+    }
+}
+
+#[tokio::test]
+async fn jwt_public_key_mutation_is_scoped_to_dashboard_user_ownership() {
+    let mut state = test_state().await;
+    let (owned_key, _) = make_key_for(&state, "dashboard-user").await;
+    let (second_owned_key, _) = make_key_for(&state, "dashboard-user").await;
+    let (foreign_key, _) = make_key_for(&state, "another-user").await;
+    let token = configure_dashboard_jwt(&mut state, "dashboard-user");
+    let app = build_router(state.clone());
+
+    for (key_id, pem) in [(&owned_key, "first-pem"), (&second_owned_key, "second-pem")] {
+        let request = add_headers(
+            public_key_request(key_id, pem),
+            &[("authorization", format!("Bearer {token}"))],
+        );
+        assert_eq!(
+            app.clone().oneshot(request).await.unwrap().status(),
+            StatusCode::OK
+        );
+    }
+
+    let foreign_request = add_headers(
+        public_key_request(&foreign_key, "rejected-pem"),
+        &[("authorization", format!("Bearer {token}"))],
+    );
+    assert_eq!(
+        app.oneshot(foreign_request).await.unwrap().status(),
+        StatusCode::NOT_FOUND
+    );
+
+    assert_eq!(
+        state
+            .keys
+            .get_key(&owned_key)
+            .await
+            .unwrap()
+            .public_key_pem
+            .as_deref(),
+        Some("first-pem")
+    );
+    assert_eq!(
+        state
+            .keys
+            .get_key(&second_owned_key)
+            .await
+            .unwrap()
+            .public_key_pem
+            .as_deref(),
+        Some("second-pem")
+    );
+    assert!(
+        state
+            .keys
+            .get_key(&foreign_key)
+            .await
+            .unwrap()
+            .public_key_pem
+            .is_none(),
+        "wrong-owner JWT must not mutate the target"
+    );
+}
+
+#[tokio::test]
+async fn mcp_tokens_cannot_mutate_public_keys() {
+    let state = test_state().await;
+    let (key_id, _) = make_key_for(&state, "mcp-user").await;
+    let token = state
+        .keys
+        .create_mcp_token("mcp-user", "mutation-test", 0)
+        .await;
+    let app = build_router(state.clone());
+    let requests = [
+        add_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &[("authorization", format!("Bearer {token}"))],
+        ),
+        add_headers(
+            public_key_request(&key_id, "rejected-pem"),
+            &[("x-s4-mcp-token", token)],
+        ),
+    ];
+
+    for request in requests {
+        assert_eq!(
+            app.clone().oneshot(request).await.unwrap().status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert!(
+            state
+                .keys
+                .get_key(&key_id)
+                .await
+                .unwrap()
+                .public_key_pem
+                .is_none(),
+            "MCP rejection must leave the target unchanged"
+        );
+    }
+}
+
+#[tokio::test]
+async fn create_key_still_accepts_an_initial_public_key() {
+    let mut state = test_state().await;
+    Arc::get_mut(&mut state)
+        .expect("test state is uniquely owned")
+        .auth_disabled = true;
+    let app = build_router(state.clone());
+    let request = Request::builder()
+        .method("POST")
+        .uri("/dashboard/api/keys")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(
+            serde_json::json!({
+                "label": "created-with-public-key",
+                "public_key_pem": "creation-pem",
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    let key_id = body["key_id"].as_str().unwrap();
+    assert_eq!(body["public_key_pem"], "creation-pem");
+    assert_eq!(
+        state
+            .keys
+            .get_key(key_id)
+            .await
+            .unwrap()
+            .public_key_pem
+            .as_deref(),
+        Some("creation-pem")
+    );
 }
 
 #[tokio::test]

--- a/sdks/overlay/python/s4_client/highlevel.py
+++ b/sdks/overlay/python/s4_client/highlevel.py
@@ -95,6 +95,7 @@ class S4Client:
         """
         resp = requests.put(
             f"{self.endpoint}/dashboard/api/keys/public-key",
+            headers=self._headers(),
             json={"key_id": self.access_key, "public_key_pem": public_key_pem},
             timeout=self.timeout,
         )

--- a/sdks/overlay/python/test/test_highlevel_attach.py
+++ b/sdks/overlay/python/test/test_highlevel_attach.py
@@ -1,0 +1,22 @@
+from unittest.mock import Mock, patch
+
+from s4_client.highlevel import S4Client
+
+
+def test_attach_public_key_sends_target_api_key_credentials():
+    response = Mock()
+    response.raise_for_status.return_value = None
+    with patch("s4_client.highlevel.requests.put", return_value=response) as put:
+        S4Client("https://gateway.example/", "test-access", "test-secret", timeout=7).attach_public_key(
+            "test-public-key"
+        )
+
+    put.assert_called_once_with(
+        "https://gateway.example/dashboard/api/keys/public-key",
+        headers={
+            "x-s4-access-key": "test-access",
+            "x-s4-secret-key": "test-secret",
+        },
+        json={"key_id": "test-access", "public_key_pem": "test-public-key"},
+        timeout=7,
+    )

--- a/sdks/overlay/typescript/highlevel.ts
+++ b/sdks/overlay/typescript/highlevel.ts
@@ -82,7 +82,7 @@ export class S4Client {
   async attachPublicKey(publicKeyPem: string): Promise<void> {
     const resp = await fetch(`${this.endpoint}/dashboard/api/keys/public-key`, {
       method: "PUT",
-      headers: { "Content-Type": "application/json" },
+      headers: { ...this.authHeaders(), "Content-Type": "application/json" },
       body: JSON.stringify({ key_id: this.accessKey, public_key_pem: publicKeyPem }),
       signal: AbortSignal.timeout(this.timeoutMs),
     });

--- a/sdks/overlay/typescript/test/highlevel-attach.test.cjs
+++ b/sdks/overlay/typescript/test/highlevel-attach.test.cjs
@@ -1,0 +1,37 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { S4Client } = require("../dist/highlevel.js");
+
+test("attachPublicKey sends target API key credentials", async () => {
+  const originalFetch = global.fetch;
+  let request;
+  global.fetch = async (url, options) => {
+    request = { url, options };
+    return { ok: true };
+  };
+
+  try {
+    const client = new S4Client({
+      endpoint: "https://gateway.example/",
+      accessKey: "test-access",
+      secretKey: "test-secret",
+      timeoutMs: 7,
+    });
+    await client.attachPublicKey("test-public-key");
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  assert.equal(request.url, "https://gateway.example/dashboard/api/keys/public-key");
+  assert.equal(request.options.method, "PUT");
+  assert.deepEqual(request.options.headers, {
+    "x-s4-access-key": "test-access",
+    "x-s4-secret-key": "test-secret",
+    "Content-Type": "application/json",
+  });
+  assert.deepEqual(JSON.parse(request.options.body), {
+    key_id: "test-access",
+    public_key_pem: "test-public-key",
+  });
+});

--- a/sdks/python/s4_client/highlevel.py
+++ b/sdks/python/s4_client/highlevel.py
@@ -95,6 +95,7 @@ class S4Client:
         """
         resp = requests.put(
             f"{self.endpoint}/dashboard/api/keys/public-key",
+            headers=self._headers(),
             json={"key_id": self.access_key, "public_key_pem": public_key_pem},
             timeout=self.timeout,
         )

--- a/sdks/python/test/test_highlevel_attach.py
+++ b/sdks/python/test/test_highlevel_attach.py
@@ -1,0 +1,22 @@
+from unittest.mock import Mock, patch
+
+from s4_client.highlevel import S4Client
+
+
+def test_attach_public_key_sends_target_api_key_credentials():
+    response = Mock()
+    response.raise_for_status.return_value = None
+    with patch("s4_client.highlevel.requests.put", return_value=response) as put:
+        S4Client("https://gateway.example/", "test-access", "test-secret", timeout=7).attach_public_key(
+            "test-public-key"
+        )
+
+    put.assert_called_once_with(
+        "https://gateway.example/dashboard/api/keys/public-key",
+        headers={
+            "x-s4-access-key": "test-access",
+            "x-s4-secret-key": "test-secret",
+        },
+        json={"key_id": "test-access", "public_key_pem": "test-public-key"},
+        timeout=7,
+    )

--- a/sdks/typescript/highlevel.ts
+++ b/sdks/typescript/highlevel.ts
@@ -82,7 +82,7 @@ export class S4Client {
   async attachPublicKey(publicKeyPem: string): Promise<void> {
     const resp = await fetch(`${this.endpoint}/dashboard/api/keys/public-key`, {
       method: "PUT",
-      headers: { "Content-Type": "application/json" },
+      headers: { ...this.authHeaders(), "Content-Type": "application/json" },
       body: JSON.stringify({ key_id: this.accessKey, public_key_pem: publicKeyPem }),
       signal: AbortSignal.timeout(this.timeoutMs),
     });

--- a/sdks/typescript/test/highlevel-attach.test.cjs
+++ b/sdks/typescript/test/highlevel-attach.test.cjs
@@ -1,0 +1,37 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { S4Client } = require("../dist/highlevel.js");
+
+test("attachPublicKey sends target API key credentials", async () => {
+  const originalFetch = global.fetch;
+  let request;
+  global.fetch = async (url, options) => {
+    request = { url, options };
+    return { ok: true };
+  };
+
+  try {
+    const client = new S4Client({
+      endpoint: "https://gateway.example/",
+      accessKey: "test-access",
+      secretKey: "test-secret",
+      timeoutMs: 7,
+    });
+    await client.attachPublicKey("test-public-key");
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  assert.equal(request.url, "https://gateway.example/dashboard/api/keys/public-key");
+  assert.equal(request.options.method, "PUT");
+  assert.deepEqual(request.options.headers, {
+    "x-s4-access-key": "test-access",
+    "x-s4-secret-key": "test-secret",
+    "Content-Type": "application/json",
+  });
+  assert.deepEqual(JSON.parse(request.options.body), {
+    key_id: "test-access",
+    public_key_pem: "test-public-key",
+  });
+});


### PR DESCRIPTION
## Security impact
- requires proof of API-key ownership or an authenticated owner JWT before attaching/replacing an encryption public key
- rejects duplicate, mixed, incomplete, MCP, and local unauthenticated credential paths
- prevents one API key from mutating a sibling key
- makes file/Postgres persistence failures explicit and prevents revoked file-backed keys from reappearing after restart

## SDK compatibility
Python and TypeScript high-level clients now send their API-key credentials when attaching a public key. Generated trees and overlays remain reproducible. Server and SDK changes are intentionally shipped together.

## Validation
- full gateway suite passed
- 11 auth/handler and 11 persistence/concurrency regressions passed
- Postgres error propagation passed
- Python/TypeScript request-shape tests and SDK regeneration passed
- strict clippy/rustfmt passed
- final independent review: approved with no blockers