### PR TITLE
fix(security): add bounded stateless demo processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4306,6 +4306,7 @@ dependencies = [
  "wasmtime",
  "x509-parser",
  "xmlparser",
+ "zeroize",
 ]
 
 [[package]]
@@ -4331,6 +4332,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wit-bindgen 0.60.0",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "2"
 hex = "0.4"
 uuid = { version = "1", features = ["v7", "v4"] }
 rand = "0.8"
+zeroize = "1"
 bytes = "1"
 csv-core = "0.1"
 http-body = "1"

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -28,6 +28,7 @@ aws-smithy-types.workspace = true
 md-5.workspace = true
 aes-gcm.workspace = true
 rand.workspace = true
+zeroize.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/gateway/examples/gen-expected.rs
+++ b/crates/gateway/examples/gen-expected.rs
@@ -97,7 +97,9 @@ fn stream_process(
                 format: format.as_str().to_string(),
                 content_type: content_type.to_string(),
                 policy_version: 0,
-                ..Default::default()
+                public_key_pem: None,
+                stable_key: None,
+                stable_fields: None,
             };
             let cancellation = CancellationToken::new();
             let mut pipeline = snapshot

--- a/crates/gateway/src/plugin_registry.rs
+++ b/crates/gateway/src/plugin_registry.rs
@@ -160,6 +160,7 @@ pub struct PipelineSession {
 enum PipelineCommand {
     Process(Record, oneshot::Sender<Result<Option<Record>, S4Error>>),
     Finish(oneshot::Sender<Result<Vec<Record>, S4Error>>),
+    Cancel,
 }
 
 /// Async, backpressured handle to one object-scoped pipeline running on the
@@ -169,6 +170,8 @@ pub struct StreamingPipelineSession {
     sender: Option<mpsc::Sender<PipelineCommand>>,
     cancellation: CancellationToken,
     task: Option<tokio::task::JoinHandle<Result<(), S4Error>>>,
+    watchdog: Option<tokio::task::JoinHandle<()>>,
+    object_deadline: Instant,
 }
 
 impl Default for PluginRegistry {
@@ -397,6 +400,45 @@ impl PluginRegistry {
 }
 
 impl PipelineSnapshot {
+    /// Return a snapshot with endpoint-specific limits. Every field is merged
+    /// with `min`, so a caller can only tighten the registry configuration.
+    pub fn constrained(&self, constraints: PipelineLimits) -> Result<Self, S4Error> {
+        let constraints = constraints.validate()?;
+        let mut snapshot = self.clone();
+        snapshot.limits.max_intermediate_record_bytes = snapshot
+            .limits
+            .max_intermediate_record_bytes
+            .min(constraints.max_intermediate_record_bytes);
+        snapshot.limits.max_plugin_finish_bytes = snapshot
+            .limits
+            .max_plugin_finish_bytes
+            .min(constraints.max_plugin_finish_bytes);
+        snapshot.limits.max_input_bytes = snapshot
+            .limits
+            .max_input_bytes
+            .min(constraints.max_input_bytes);
+        snapshot.limits.max_output_bytes = snapshot
+            .limits
+            .max_output_bytes
+            .min(constraints.max_output_bytes);
+        snapshot.limits.max_expansion_factor = snapshot
+            .limits
+            .max_expansion_factor
+            .min(constraints.max_expansion_factor);
+        snapshot.limits.max_expansion_slack_bytes = snapshot
+            .limits
+            .max_expansion_slack_bytes
+            .min(constraints.max_expansion_slack_bytes);
+        snapshot.limits.max_plugins = snapshot.limits.max_plugins.min(constraints.max_plugins);
+        snapshot.limits.max_cumulative_fuel = snapshot
+            .limits
+            .max_cumulative_fuel
+            .min(constraints.max_cumulative_fuel);
+        snapshot.limits.max_wall_time =
+            snapshot.limits.max_wall_time.min(constraints.max_wall_time);
+        Ok(snapshot)
+    }
+
     pub fn plugin_infos(&self) -> Vec<PluginInfo> {
         self.plugins
             .iter()
@@ -436,6 +478,19 @@ impl PipelineSnapshot {
         session: &s4_wasm_runtime::Session,
         cancellation: CancellationToken,
     ) -> Result<PipelineSession, S4Error> {
+        self.start_session_with_deadline(
+            session,
+            cancellation,
+            Instant::now() + self.limits.max_wall_time,
+        )
+    }
+
+    pub fn start_session_with_deadline(
+        &self,
+        session: &s4_wasm_runtime::Session,
+        cancellation: CancellationToken,
+        requested_deadline: Instant,
+    ) -> Result<PipelineSession, S4Error> {
         if self.plugins.len() > self.limits.max_plugins {
             return Err(limit_error(
                 codes::LIMIT_PLUGIN_COUNT,
@@ -446,7 +501,7 @@ impl PipelineSnapshot {
         }
         let mut plugins = Vec::with_capacity(self.plugins.len());
         let mut fuel_consumed = 0u64;
-        let object_deadline = Instant::now() + self.limits.max_wall_time;
+        let object_deadline = requested_deadline.min(Instant::now() + self.limits.max_wall_time);
         for plugin in &self.plugins {
             let remaining_fuel = self.limits.max_cumulative_fuel - fuel_consumed;
             let filter = plugin
@@ -486,63 +541,111 @@ impl PipelineSnapshot {
         session: s4_wasm_runtime::Session,
         cancellation: CancellationToken,
     ) -> Result<StreamingPipelineSession, S4Error> {
+        let deadline = Instant::now() + self.limits.max_wall_time;
+        self.start_streaming_session_with_deadline(session, cancellation, deadline)
+            .await
+    }
+
+    pub async fn start_streaming_session_with_deadline(
+        self,
+        session: s4_wasm_runtime::Session,
+        cancellation: CancellationToken,
+        requested_deadline: Instant,
+    ) -> Result<StreamingPipelineSession, S4Error> {
+        let object_deadline = requested_deadline.min(Instant::now() + self.limits.max_wall_time);
         let reservation = self.guest_memory_reservation()?;
         let executor = Arc::clone(&self.executor);
         let task_cancellation = cancellation.clone();
+        let executor_cancellation = cancellation.clone();
         let (sender, mut receiver) = mpsc::channel(1);
         let (started_sender, started_receiver) = oneshot::channel();
         let task = tokio::task::spawn_blocking(move || {
-            executor.execute(reservation, &task_cancellation.clone(), move || {
-                let mut pipeline = match self.start_session(&session, task_cancellation) {
-                    Ok(pipeline) => {
-                        let _ = started_sender.send(Ok(()));
-                        pipeline
-                    }
-                    Err(error) => {
-                        let _ = started_sender.send(Err(error));
-                        return Ok(());
-                    }
-                };
-                while let Some(command) = receiver.blocking_recv() {
-                    match command {
-                        PipelineCommand::Process(record, response) => {
-                            match pipeline.process(record) {
-                                Ok(record) => {
-                                    let _ = response.send(Ok(record));
-                                }
-                                Err(error) => {
-                                    let _ = response.send(Err(error));
-                                    break;
+            executor.execute_until(
+                reservation,
+                &executor_cancellation,
+                object_deadline,
+                move || {
+                    let startup = self.start_session_with_deadline(
+                        &session,
+                        task_cancellation,
+                        object_deadline,
+                    );
+                    drop(session);
+                    let mut pipeline = match startup {
+                        Ok(pipeline) => {
+                            let _ = started_sender.send(Ok(()));
+                            pipeline
+                        }
+                        Err(error) => {
+                            let _ = started_sender.send(Err(error));
+                            return Ok(());
+                        }
+                    };
+                    while let Some(command) = receiver.blocking_recv() {
+                        match command {
+                            PipelineCommand::Process(record, response) => {
+                                match pipeline.process(record) {
+                                    Ok(record) => {
+                                        let _ = response.send(Ok(record));
+                                    }
+                                    Err(error) => {
+                                        let _ = response.send(Err(error));
+                                        break;
+                                    }
                                 }
                             }
-                        }
-                        PipelineCommand::Finish(response) => {
-                            let _ = response.send(pipeline.finish());
-                            break;
+                            PipelineCommand::Finish(response) => {
+                                let _ = response.send(pipeline.finish());
+                                break;
+                            }
+                            PipelineCommand::Cancel => break,
                         }
                     }
-                }
-                Ok(())
-            })?
+                    Ok(())
+                },
+            )?
         });
-        match started_receiver.await {
-            Ok(Ok(())) => Ok(StreamingPipelineSession {
-                sender: Some(sender),
-                cancellation,
-                task: Some(task),
-            }),
-            Ok(Err(error)) => {
+        let started = tokio::time::timeout_at(
+            tokio::time::Instant::from_std(object_deadline),
+            started_receiver,
+        )
+        .await;
+        match started {
+            Ok(Ok(Ok(()))) => {
+                let watchdog =
+                    spawn_deadline_watchdog(&sender, cancellation.clone(), object_deadline);
+                Ok(StreamingPipelineSession {
+                    sender: Some(sender),
+                    cancellation,
+                    task: Some(task),
+                    watchdog: Some(watchdog),
+                    object_deadline,
+                })
+            }
+            Ok(Ok(Err(error))) => {
+                cancellation.cancel();
+                drop(sender);
                 let _ = task.await;
                 Err(error)
             }
-            Err(_) => match task.await {
-                Ok(Err(error)) => Err(error),
-                Ok(Ok(())) => Err(S4Error::new(
-                    codes::INTERNAL,
-                    "Wasm pipeline stopped before session startup",
-                )),
-                Err(error) => Err(S4Error::new(codes::INTERNAL, error.to_string())),
-            },
+            Err(_) => {
+                cancellation.cancel();
+                drop(sender);
+                let _ = task.await;
+                Err(deadline_error())
+            }
+            Ok(Err(_)) => {
+                cancellation.cancel();
+                drop(sender);
+                match task.await {
+                    Ok(Err(error)) => Err(error),
+                    Ok(Ok(())) => Err(S4Error::new(
+                        codes::INTERNAL,
+                        "Wasm pipeline stopped before session startup",
+                    )),
+                    Err(error) => Err(S4Error::new(codes::INTERNAL, error.to_string())),
+                }
+            }
         }
     }
 }
@@ -550,40 +653,104 @@ impl PipelineSnapshot {
 impl StreamingPipelineSession {
     pub async fn process(&mut self, record: Record) -> Result<Option<Record>, S4Error> {
         let (response_sender, response_receiver) = oneshot::channel();
-        self.sender
-            .as_ref()
-            .ok_or_else(pipeline_stopped)?
-            .send(PipelineCommand::Process(record, response_sender))
-            .await
-            .map_err(|_| pipeline_stopped())?;
-        response_receiver.await.map_err(|_| pipeline_stopped())?
+        let sender = self.sender.as_ref().ok_or_else(pipeline_stopped)?;
+        let deadline = tokio::time::Instant::from_std(self.object_deadline);
+        let send = tokio::time::timeout_at(
+            deadline,
+            sender.send(PipelineCommand::Process(record, response_sender)),
+        )
+        .await;
+        let send_error = match send {
+            Ok(Ok(())) => None,
+            Ok(Err(_)) => Some(pipeline_stopped()),
+            Err(_) => Some(deadline_error()),
+        };
+        if let Some(error) = send_error {
+            let _ = self.abort_and_wait().await;
+            return Err(error);
+        }
+        let result = match tokio::time::timeout_at(deadline, response_receiver).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err(pipeline_stopped()),
+            Err(_) => Err(deadline_error()),
+        };
+        if result.is_err() {
+            let _ = self.abort_and_wait().await;
+        }
+        result
     }
 
     pub async fn finish(mut self) -> Result<Vec<Record>, S4Error> {
         let (response_sender, response_receiver) = oneshot::channel();
-        let sender = self.sender.take().ok_or_else(pipeline_stopped)?;
-        sender
-            .send(PipelineCommand::Finish(response_sender))
-            .await
-            .map_err(|_| pipeline_stopped())?;
+        let Some(sender) = self.sender.take() else {
+            let _ = self.abort_and_wait().await;
+            return Err(pipeline_stopped());
+        };
+        let deadline = tokio::time::Instant::from_std(self.object_deadline);
+        let send = tokio::time::timeout_at(
+            deadline,
+            sender.send(PipelineCommand::Finish(response_sender)),
+        )
+        .await;
+        let send_error = match send {
+            Ok(Ok(())) => None,
+            Ok(Err(_)) => Some(pipeline_stopped()),
+            Err(_) => Some(deadline_error()),
+        };
+        if let Some(error) = send_error {
+            drop(sender);
+            let _ = self.abort_and_wait().await;
+            return Err(error);
+        }
         drop(sender);
-        let result = response_receiver.await.map_err(|_| pipeline_stopped())?;
-        self.wait().await?;
+        let result = match tokio::time::timeout_at(deadline, response_receiver).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err(pipeline_stopped()),
+            Err(_) => Err(deadline_error()),
+        };
+        if result.is_err() {
+            self.cancellation.cancel();
+        }
+        let wait = self.wait().await;
+        if result.is_ok() {
+            wait?;
+        }
         result
     }
 
     pub async fn cancel_and_wait(mut self) -> Result<(), S4Error> {
+        self.abort_and_wait().await
+    }
+
+    async fn abort_and_wait(&mut self) -> Result<(), S4Error> {
         self.cancellation.cancel();
         self.sender.take();
-        self.wait().await
+        self.stop_watchdog().await;
+        match self.wait_task().await {
+            Err(error) if error.code() == codes::WASM_CANCELLED => Ok(()),
+            result => result,
+        }
     }
 
     async fn wait(&mut self) -> Result<(), S4Error> {
+        let result = self.wait_task().await;
+        self.stop_watchdog().await;
+        result
+    }
+
+    async fn wait_task(&mut self) -> Result<(), S4Error> {
         match self.task.take() {
             Some(task) => task
                 .await
                 .map_err(|error| S4Error::new(codes::INTERNAL, error.to_string()))?,
             None => Ok(()),
+        }
+    }
+
+    async fn stop_watchdog(&mut self) {
+        if let Some(watchdog) = self.watchdog.take() {
+            watchdog.abort();
+            let _ = watchdog.await;
         }
     }
 }
@@ -592,11 +759,33 @@ impl Drop for StreamingPipelineSession {
     fn drop(&mut self) {
         self.cancellation.cancel();
         self.sender.take();
+        if let Some(watchdog) = self.watchdog.take() {
+            watchdog.abort();
+        }
     }
+}
+
+fn spawn_deadline_watchdog(
+    sender: &mpsc::Sender<PipelineCommand>,
+    cancellation: CancellationToken,
+    object_deadline: Instant,
+) -> tokio::task::JoinHandle<()> {
+    let sender = sender.downgrade();
+    tokio::spawn(async move {
+        tokio::time::sleep_until(tokio::time::Instant::from_std(object_deadline)).await;
+        cancellation.cancel();
+        if let Some(sender) = sender.upgrade() {
+            let _ = sender.send(PipelineCommand::Cancel).await;
+        }
+    })
 }
 
 fn pipeline_stopped() -> S4Error {
     S4Error::new(codes::WASM_CANCELLED, "Wasm pipeline session stopped")
+}
+
+fn deadline_error() -> S4Error {
+    S4Error::new(codes::WASM_DEADLINE, "Wasm pipeline deadline exceeded")
 }
 
 impl PipelineSession {
@@ -825,7 +1014,9 @@ mod tests {
             format: "text".to_string(),
             content_type: "text/plain".to_string(),
             policy_version: 1,
-            ..Default::default()
+            public_key_pem: None,
+            stable_key: None,
+            stable_fields: None,
         }
     }
 
@@ -952,6 +1143,99 @@ mod tests {
             ["a", "b"]
         );
         assert!(registry.snapshot().plugin_infos().is_empty());
+    }
+
+    #[test]
+    fn constrained_snapshot_only_lowers_limits() {
+        let limits = PipelineLimits {
+            max_cumulative_fuel: 25,
+            max_wall_time: Duration::from_millis(25),
+            ..PipelineLimits::default()
+        };
+        let registry =
+            PluginRegistry::with_options(DEFAULT_PIPELINE_FUEL, limits, ExecutorConfig::default())
+                .unwrap();
+        let snapshot = registry.snapshot();
+
+        let unchanged = snapshot
+            .constrained(PipelineLimits {
+                max_cumulative_fuel: 50,
+                max_wall_time: Duration::from_millis(50),
+                ..PipelineLimits::default()
+            })
+            .unwrap();
+        assert_eq!(unchanged.limits.max_cumulative_fuel, 25);
+        assert_eq!(unchanged.limits.max_wall_time, Duration::from_millis(25));
+
+        let lowered = snapshot
+            .constrained(PipelineLimits {
+                max_intermediate_record_bytes: 64,
+                max_plugin_finish_bytes: 63,
+                max_input_bytes: 62,
+                max_output_bytes: 61,
+                max_expansion_factor: 8,
+                max_expansion_slack_bytes: 60,
+                max_plugins: 2,
+                max_cumulative_fuel: 10,
+                max_wall_time: Duration::from_millis(10),
+            })
+            .unwrap();
+        assert_eq!(lowered.limits.max_intermediate_record_bytes, 64);
+        assert_eq!(lowered.limits.max_plugin_finish_bytes, 63);
+        assert_eq!(lowered.limits.max_input_bytes, 62);
+        assert_eq!(lowered.limits.max_output_bytes, 61);
+        assert_eq!(lowered.limits.max_expansion_factor, 8);
+        assert_eq!(lowered.limits.max_expansion_slack_bytes, 60);
+        assert_eq!(lowered.limits.max_plugins, 2);
+        assert_eq!(lowered.limits.max_cumulative_fuel, 10);
+        assert_eq!(lowered.limits.max_wall_time, Duration::from_millis(10));
+        assert_eq!(
+            snapshot
+                .constrained(PipelineLimits {
+                    max_cumulative_fuel: 0,
+                    ..PipelineLimits::default()
+                })
+                .err()
+                .expect("zero fuel is invalid")
+                .code(),
+            codes::CONFIG_INVALID
+        );
+    }
+
+    #[test]
+    fn constrained_snapshot_enforces_fuel_and_wall_time() {
+        let registry = PluginRegistry::new();
+        registry.import("noop", &component()).unwrap();
+        let fuel_error = registry
+            .snapshot()
+            .constrained(PipelineLimits {
+                max_cumulative_fuel: 1,
+                max_wall_time: Duration::from_secs(1),
+                ..PipelineLimits::default()
+            })
+            .unwrap()
+            .start_session(&session(), CancellationToken::new())
+            .err()
+            .expect("one fuel unit cannot initialize the component");
+        assert_eq!(fuel_error.code(), codes::WASM_FUEL);
+
+        let registry = PluginRegistry::new();
+        let snapshot = registry
+            .snapshot()
+            .constrained(PipelineLimits {
+                max_cumulative_fuel: DEFAULT_PIPELINE_FUEL,
+                max_wall_time: Duration::from_millis(1),
+                ..PipelineLimits::default()
+            })
+            .unwrap();
+        let mut pipeline = snapshot
+            .start_session(&session(), CancellationToken::new())
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(5));
+        assert_eq!(
+            pipeline.process(Record::new("x", "")).unwrap_err().code(),
+            codes::WASM_DEADLINE
+        );
     }
 
     #[test]
@@ -1167,6 +1451,215 @@ mod tests {
             Ok(_) => panic!("admission must reject an over-budget pipeline"),
             Err(error) => assert_eq!(error.code(), codes::WASM_ADMISSION),
         }
+    }
+
+    #[tokio::test]
+    async fn queued_startup_deadline_cancels_without_leaking_executor_work() {
+        let registry = PluginRegistry::with_options(
+            DEFAULT_PIPELINE_FUEL,
+            PipelineLimits::default(),
+            ExecutorConfig {
+                workers: 1,
+                queue_capacity: 1,
+                guest_memory_budget_bytes: 2 * 64 * 1024 * 1024,
+            },
+        )
+        .unwrap();
+        let test_component = std::fs::read(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../..")
+                .join("target/test-components/test-filter.component.wasm"),
+        )
+        .expect("test-filter.component.wasm; run just build-filters");
+        registry.import("test-filter", &test_component).unwrap();
+        let snapshot = registry.snapshot();
+
+        let first_cancellation = CancellationToken::new();
+        let mut first = snapshot
+            .clone()
+            .start_streaming_session_with_deadline(
+                session(),
+                first_cancellation.clone(),
+                Instant::now() + Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+        let running = tokio::spawn(async move { first.process(Record::new("loop", "")).await });
+        tokio::time::sleep(Duration::from_millis(25)).await;
+
+        let queued_cancellation = CancellationToken::new();
+        let error = snapshot
+            .clone()
+            .start_streaming_session_with_deadline(
+                session(),
+                queued_cancellation,
+                Instant::now() + Duration::from_millis(25),
+            )
+            .await
+            .err()
+            .expect("queued startup must time out");
+        assert_eq!(error.code(), codes::WASM_DEADLINE);
+        assert_eq!(registry.executor.admission().used(), 64 * 1024 * 1024);
+
+        first_cancellation.cancel();
+        let first_error = running
+            .await
+            .unwrap()
+            .expect_err("running guest must be cancelled");
+        assert_eq!(first_error.code(), codes::WASM_CANCELLED);
+        assert_eq!(registry.executor.admission().used(), 0);
+
+        let third = snapshot
+            .start_streaming_session_with_deadline(
+                session(),
+                CancellationToken::new(),
+                Instant::now() + Duration::from_secs(1),
+            )
+            .await
+            .expect("executor worker remains available");
+        third.cancel_and_wait().await.unwrap();
+        assert_eq!(registry.executor.admission().used(), 0);
+    }
+
+    #[tokio::test]
+    async fn constrained_finish_cap_rejects_large_guest_output() {
+        let registry = PluginRegistry::new();
+        let test_component = std::fs::read(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../..")
+                .join("target/test-components/test-filter.component.wasm"),
+        )
+        .expect("test-filter.component.wasm; run just build-filters");
+        registry.import("test-filter", &test_component).unwrap();
+        let snapshot = registry
+            .snapshot()
+            .constrained(PipelineLimits {
+                max_intermediate_record_bytes: 64 * 1024,
+                max_plugin_finish_bytes: 64 * 1024,
+                max_input_bytes: 64 * 1024,
+                max_output_bytes: 64 * 1024,
+                max_expansion_factor: 8,
+                max_expansion_slack_bytes: 1024,
+                max_plugins: 1,
+                max_cumulative_fuel: DEFAULT_PIPELINE_FUEL,
+                max_wall_time: Duration::from_secs(1),
+            })
+            .unwrap();
+        let mut configured = session();
+        configured.stable_fields = Some("finish-large".to_string());
+        let pipeline = snapshot
+            .start_streaming_session(configured, CancellationToken::new())
+            .await
+            .unwrap();
+        assert_eq!(
+            pipeline.finish().await.unwrap_err().code(),
+            codes::LIMIT_FINISH_BYTES
+        );
+    }
+
+    #[tokio::test]
+    async fn finish_timeout_before_enqueue_drops_sender_and_joins_worker() {
+        let cancellation = CancellationToken::new();
+        let (sender, mut receiver) = mpsc::channel(1);
+        let (queued_response, _queued_receiver) = oneshot::channel();
+        assert!(
+            sender
+                .try_send(PipelineCommand::Process(
+                    Record::new("queued", ""),
+                    queued_response,
+                ))
+                .is_ok()
+        );
+        let task = tokio::task::spawn_blocking(move || -> Result<(), S4Error> {
+            std::thread::sleep(Duration::from_millis(25));
+            while receiver.blocking_recv().is_some() {}
+            Ok(())
+        });
+        let pipeline = StreamingPipelineSession {
+            sender: Some(sender),
+            cancellation,
+            task: Some(task),
+            watchdog: None,
+            object_deadline: Instant::now() + Duration::from_millis(5),
+        };
+
+        let error = tokio::time::timeout(Duration::from_secs(1), pipeline.finish())
+            .await
+            .expect("finish cleanup must not retain the local sender")
+            .expect_err("full command queue must hit the finish deadline");
+        assert_eq!(error.code(), codes::WASM_DEADLINE);
+    }
+
+    #[tokio::test]
+    async fn idle_deadline_watchdog_releases_worker_and_admission() {
+        let registry = PluginRegistry::with_options(
+            DEFAULT_PIPELINE_FUEL,
+            PipelineLimits::default(),
+            ExecutorConfig {
+                workers: 1,
+                queue_capacity: 1,
+                guest_memory_budget_bytes: 64 * 1024 * 1024,
+            },
+        )
+        .unwrap();
+        registry.import("noop", &component()).unwrap();
+        let pipeline = registry
+            .snapshot()
+            .start_streaming_session_with_deadline(
+                session(),
+                CancellationToken::new(),
+                Instant::now() + Duration::from_millis(250),
+            )
+            .await
+            .unwrap();
+        assert_eq!(registry.executor.admission().used(), 64 * 1024 * 1024);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while registry.executor.admission().used() != 0 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("idle deadline must release the executor reservation");
+        let error = pipeline
+            .cancel_and_wait()
+            .await
+            .expect_err("watchdog expiry must preserve the deadline result");
+        assert_eq!(error.code(), codes::WASM_DEADLINE);
+    }
+
+    #[tokio::test]
+    async fn watchdog_weak_sender_does_not_keep_dropped_session_alive() {
+        let registry = PluginRegistry::with_options(
+            DEFAULT_PIPELINE_FUEL,
+            PipelineLimits::default(),
+            ExecutorConfig {
+                workers: 1,
+                queue_capacity: 1,
+                guest_memory_budget_bytes: 64 * 1024 * 1024,
+            },
+        )
+        .unwrap();
+        registry.import("noop", &component()).unwrap();
+        let pipeline = registry
+            .snapshot()
+            .start_streaming_session_with_deadline(
+                session(),
+                CancellationToken::new(),
+                Instant::now() + Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+        assert_eq!(registry.executor.admission().used(), 64 * 1024 * 1024);
+        drop(pipeline);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while registry.executor.admission().used() != 0 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("dropping the last strong sender must stop the idle worker");
     }
 
     #[test]

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -6,10 +6,10 @@
 //! [`crate::control::NoopControlPlane`]; the private SaaS crate builds it with
 //! its own control-plane implementation.
 
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::path::{Path as FsPath, PathBuf};
-use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime};
 
 use aws_sdk_s3::Client;
 use aws_sdk_s3::config::{Credentials, Region};
@@ -28,12 +28,14 @@ use hmac::{Hmac, Mac};
 use http_body_util::BodyExt;
 use md5::Md5;
 use rand::{RngCore, rngs::OsRng};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tower_http::cors::CorsLayer;
 use tracing::{info, warn};
 use utoipa::{OpenApi, ToSchema};
 use utoipa_swagger_ui::SwaggerUi;
 use uuid::Uuid;
+use zeroize::Zeroizing;
 
 use crate::backend::{BackendResolver, PresignedHttpPolicy, ResolvedBackend, StorageOperation};
 use crate::control::{AuthenticatedRequestContext, ControlPlane, RequestKind, StreamingWriteMode};
@@ -55,7 +57,9 @@ use crate::object::{
     BodyLimits, ChunkedBytesBody, ObjectMetadata, OpenedObject, filter_presigned_response_headers,
     harden_object_response_headers,
 };
-use crate::plugin_registry::{PluginCapabilities, PluginRegistry, StreamingPipelineSession};
+use crate::plugin_registry::{
+    PipelineLimits, PipelineSnapshot, PluginCapabilities, PluginRegistry, StreamingPipelineSession,
+};
 use crate::read_spool::EncryptedReadSpool;
 use crate::s3_error;
 use crate::service_storage::{ServiceStorage, parse_service_backends};
@@ -105,6 +109,8 @@ pub struct AppState {
     pub transformed_read_spool_enabled: bool,
     pub dev_memory_max_object_bytes: usize,
     pub dev_memory_streaming_enabled: bool,
+    demo_pipelines: DemoPipelines,
+    demo_limiter: Arc<DemoLimiter>,
     multipart_staging: Option<Arc<MultipartStaging>>,
     multipart_mode: MultipartMode,
     continuation_token_key: [u8; 32],
@@ -224,6 +230,114 @@ struct MultipartStaging {
 }
 
 const LEGACY_MAX_OBJECT_BYTES: usize = 16 * 1024 * 1024;
+const DEMO_MAX_RECORDS: usize = 10;
+const DEMO_MAX_INPUT_BYTES: usize = 64 * 1024;
+const DEMO_MAX_OUTPUT_BYTES: usize = 64 * 1024;
+const DEMO_MAX_RAW_BODY_BYTES: usize = 512 * 1024;
+const DEMO_MAX_CONCURRENCY: usize = 4;
+const DEMO_MAX_STARTS_PER_MINUTE: usize = 30;
+const DEMO_MAX_CUMULATIVE_FUEL: u64 = 50_000_000;
+const DEMO_MAX_WALL_TIME: Duration = Duration::from_secs(2);
+
+#[derive(Clone)]
+struct DemoPipelines {
+    safe: PipelineSnapshot,
+    join: Option<PipelineSnapshot>,
+}
+
+/// The process's single `AppState` shares this anonymous admission policy across
+/// all router clones and both processing routes. A noisy anonymous client can
+/// exhaust the shared allowance; edge or identity-aware limiting is the
+/// follow-up availability control.
+struct DemoLimiter {
+    concurrency: Arc<tokio::sync::Semaphore>,
+    starts: Mutex<VecDeque<Instant>>,
+    max_starts: usize,
+    window: Duration,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DemoLimitError {
+    Concurrent,
+    Rate,
+}
+
+impl DemoLimiter {
+    fn new() -> Self {
+        Self::with_limits(
+            DEMO_MAX_CONCURRENCY,
+            DEMO_MAX_STARTS_PER_MINUTE,
+            Duration::from_secs(60),
+        )
+    }
+
+    fn with_limits(concurrency: usize, max_starts: usize, window: Duration) -> Self {
+        Self {
+            concurrency: Arc::new(tokio::sync::Semaphore::new(concurrency)),
+            starts: Mutex::new(VecDeque::with_capacity(max_starts)),
+            max_starts,
+            window,
+        }
+    }
+
+    fn try_start(&self) -> Result<tokio::sync::OwnedSemaphorePermit, DemoLimitError> {
+        let permit = self
+            .concurrency
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| DemoLimitError::Concurrent)?;
+        let now = Instant::now();
+        let mut starts = self.starts.lock().unwrap();
+        starts.retain(|started| now.saturating_duration_since(*started) < self.window);
+        if starts.len() >= self.max_starts {
+            return Err(DemoLimitError::Rate);
+        }
+        starts.push_back(now);
+        Ok(permit)
+    }
+}
+
+fn demo_pipeline_limits() -> PipelineLimits {
+    PipelineLimits {
+        max_intermediate_record_bytes: DEMO_MAX_OUTPUT_BYTES,
+        max_plugin_finish_bytes: DEMO_MAX_OUTPUT_BYTES,
+        max_input_bytes: DEMO_MAX_INPUT_BYTES as u64,
+        max_output_bytes: DEMO_MAX_OUTPUT_BYTES as u64,
+        max_expansion_factor: 8,
+        max_expansion_slack_bytes: 1024,
+        max_plugins: 2,
+        max_cumulative_fuel: DEMO_MAX_CUMULATIVE_FUEL,
+        max_wall_time: DEMO_MAX_WALL_TIME,
+    }
+}
+
+fn build_demo_pipelines(
+    pii_component: &[u8],
+    stable_component: Option<&[u8]>,
+    engine_fuel: u64,
+) -> anyhow::Result<DemoPipelines> {
+    let registry = PluginRegistry::with_fuel(engine_fuel);
+    let pii = registry.import("pii-default", pii_component)?;
+    let safe = registry.snapshot().constrained(demo_pipeline_limits())?;
+    let join = stable_component.and_then(|component| {
+        let stable = match registry.import("stable-encrypt", component) {
+            Ok(stable) => stable,
+            Err(error) => {
+                warn!("stable-encrypt unavailable for the stateless demo: {error}");
+                return None;
+            }
+        };
+        registry.reorder(vec![stable.id, pii.id.clone()]);
+        match registry.snapshot().constrained(demo_pipeline_limits()) {
+            Ok(snapshot) => Some(snapshot),
+            Err(error) => {
+                warn!("join demo pipeline constraints are invalid: {error}");
+                None
+            }
+        }
+    });
+    Ok(DemoPipelines { safe, join })
+}
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum StreamingReadMode {
@@ -1571,40 +1685,341 @@ async fn get_me(State(state): State<Arc<AppState>>, headers: HeaderMap) -> impl 
 }
 
 /// Interactive demo: run the WASM PII pipeline over the submitted text and
-/// return the redacted output. Uses the demo-user identity (no storage write);
-/// rate limited in the client (5 trials).
+/// return the redacted output without writing request data to storage.
 #[derive(Deserialize, ToSchema)]
 struct DemoRedactRequest {
     text: String,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum DemoMode {
+    Safe,
+    Join,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DemoProcessRequest {
+    records: Vec<serde_json::Value>,
+    mode: DemoMode,
+}
+
+#[derive(Serialize)]
+struct DemoProcessedRecord {
+    record: usize,
+    body: String,
+}
+
+#[derive(Serialize)]
+struct DemoProcessResponse {
+    mode: DemoMode,
+    records: Vec<DemoProcessedRecord>,
+}
+
+#[derive(Serialize)]
+struct DemoErrorResponse {
+    code: &'static str,
+    message: &'static str,
+}
+
+fn harden_demo_response(mut response: axum::response::Response) -> axum::response::Response {
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        "private, no-store".parse().expect("static cache control"),
+    );
+    response.headers_mut().insert(
+        HeaderName::from_static("x-content-type-options"),
+        "nosniff".parse().expect("static content type option"),
+    );
+    response
+}
+
+async fn harden_legacy_demo_response(
+    response: axum::response::Response,
+) -> axum::response::Response {
+    harden_demo_response(response)
+}
+
+struct BoundedDemoJsonWriter {
+    bytes: Vec<u8>,
+    exceeded: bool,
+}
+
+impl BoundedDemoJsonWriter {
+    fn new() -> Self {
+        Self {
+            bytes: Vec::with_capacity(DEMO_MAX_OUTPUT_BYTES),
+            exceeded: false,
+        }
+    }
+}
+
+impl std::io::Write for BoundedDemoJsonWriter {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        if self.bytes.len().saturating_add(buffer.len()) > DEMO_MAX_OUTPUT_BYTES {
+            self.exceeded = true;
+            return Err(std::io::Error::other("demo JSON response exceeds limit"));
+        }
+        self.bytes.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn bounded_demo_json<T: Serialize>(value: &T) -> axum::response::Response {
+    let mut writer = BoundedDemoJsonWriter::new();
+    match serde_json::to_writer(&mut writer, value) {
+        Ok(()) => {
+            let mut response = axum::response::Response::new(axum::body::Body::from(writer.bytes));
+            response.headers_mut().insert(
+                header::CONTENT_TYPE,
+                "application/json".parse().expect("static content type"),
+            );
+            harden_demo_response(response)
+        }
+        Err(_) if writer.exceeded => demo_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "output_too_large",
+            "Demo output exceeds 64 KiB",
+        ),
+        Err(_) => demo_error(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "pipeline_failed",
+            "Demo processing failed",
+        ),
+    }
+}
+
+fn demo_error(
+    status: StatusCode,
+    code: &'static str,
+    message: &'static str,
+) -> axum::response::Response {
+    harden_demo_response((status, Json(DemoErrorResponse { code, message })).into_response())
+}
+
+fn demo_limit_response(error: DemoLimitError) -> axum::response::Response {
+    match error {
+        DemoLimitError::Concurrent => demo_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            "demo_busy",
+            "Too many demo operations are running",
+        ),
+        DemoLimitError::Rate => demo_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            "rate_limited",
+            "Demo rate limit exceeded",
+        ),
+    }
+}
+
+fn start_demo_operation(
+    state: &AppState,
+) -> Result<tokio::sync::OwnedSemaphorePermit, DemoLimitError> {
+    state.demo_limiter.try_start()
+}
+
+fn pipeline_snapshot(state: &AppState) -> Result<PipelineSnapshot, s4_error::S4Error> {
+    state.gateway.pipeline_snapshot().ok_or_else(|| {
+        s4_error::S4Error::new(
+            s4_error::codes::INTERNAL,
+            "demo pipeline requires a plugin registry",
+        )
+    })
+}
+
+fn demo_pipeline(state: &AppState, mode: DemoMode) -> Option<PipelineSnapshot> {
+    match mode {
+        DemoMode::Safe => Some(state.demo_pipelines.safe.clone()),
+        DemoMode::Join => state.demo_pipelines.join.clone(),
+    }
+}
+
+fn demo_request_stable_key() -> Zeroizing<Vec<u8>> {
+    let mut key = Zeroizing::new(vec![0u8; 64]);
+    OsRng.fill_bytes(key.as_mut_slice());
+    key
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DemoBodyError {
+    Invalid,
+    TooLarge,
+    Deadline,
+}
+
+fn demo_body_error(error: DemoBodyError) -> axum::response::Response {
+    match error {
+        DemoBodyError::Invalid => demo_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "Invalid demo request",
+        ),
+        DemoBodyError::TooLarge => demo_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "input_too_large",
+            "Demo request body is too large",
+        ),
+        DemoBodyError::Deadline => demo_error(
+            StatusCode::REQUEST_TIMEOUT,
+            "demo_timeout",
+            "Demo operation timed out",
+        ),
+    }
+}
+
+async fn decode_demo_json<T: DeserializeOwned>(
+    request: Request,
+    deadline: Instant,
+) -> Result<T, DemoBodyError> {
+    let content_type = request
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .filter(|value| value == "application/json" || value.ends_with("+json"));
+    if content_type.is_none() {
+        return Err(DemoBodyError::Invalid);
+    }
+
+    let mut body = request.into_body();
+    let mut bytes = Vec::new();
+    loop {
+        let frame = tokio::time::timeout_at(tokio::time::Instant::from_std(deadline), body.frame())
+            .await
+            .map_err(|_| DemoBodyError::Deadline)?;
+        let Some(frame) = frame else {
+            break;
+        };
+        let frame = frame.map_err(|_| DemoBodyError::Invalid)?;
+        if let Some(data) = frame.data_ref() {
+            if bytes.len().saturating_add(data.len()) > DEMO_MAX_RAW_BODY_BYTES {
+                return Err(DemoBodyError::TooLarge);
+            }
+            bytes.extend_from_slice(data);
+        }
+    }
+    let decoded = serde_json::from_slice(&bytes).map_err(|_| DemoBodyError::Invalid)?;
+    if Instant::now() >= deadline {
+        return Err(DemoBodyError::Deadline);
+    }
+    Ok(decoded)
+}
+
+fn demo_pipeline_error(error: &s4_error::S4Error) -> axum::response::Response {
+    match error.code() {
+        s4_error::codes::LIMIT_INPUT_BYTES | s4_error::codes::RECORD_TOO_LARGE => demo_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "input_too_large",
+            "Demo input exceeds 64 KiB",
+        ),
+        s4_error::codes::LIMIT_OUTPUT_BYTES
+        | s4_error::codes::LIMIT_EXPANSION
+        | s4_error::codes::LIMIT_INTERMEDIATE_BYTES
+        | s4_error::codes::LIMIT_FINISH_BYTES => demo_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "output_too_large",
+            "Demo output exceeds 64 KiB",
+        ),
+        s4_error::codes::WASM_DEADLINE | s4_error::codes::WASM_CANCELLED => demo_error(
+            StatusCode::REQUEST_TIMEOUT,
+            "demo_timeout",
+            "Demo operation timed out",
+        ),
+        _ => demo_error(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "pipeline_failed",
+            "Demo processing failed",
+        ),
+    }
+}
+
+fn demo_deadline_error() -> s4_error::S4Error {
+    s4_error::S4Error::new(
+        s4_error::codes::WASM_DEADLINE,
+        "demo operation deadline exceeded",
+    )
+}
+
+async fn execute_demo_records(
+    snapshot: PipelineSnapshot,
+    session: s4_wasm_runtime::Session,
+    records: Vec<crate::record::Record>,
+    deadline: Instant,
+) -> Result<(Vec<crate::record::Record>, Vec<crate::record::Record>), s4_error::S4Error> {
+    let cancellation = s4_wasm_runtime::CancellationToken::new();
+    let mut pipeline = snapshot
+        .start_streaming_session_with_deadline(session, cancellation, deadline)
+        .await?;
+    let mut output = Vec::with_capacity(records.len());
+    for record in records {
+        if Instant::now() >= deadline {
+            let _ = pipeline.cancel_and_wait().await;
+            return Err(demo_deadline_error());
+        }
+        match pipeline.process(record).await {
+            Ok(Some(record)) => output.push(record),
+            Ok(None) => {
+                let _ = pipeline.cancel_and_wait().await;
+                return Err(s4_error::S4Error::new(
+                    s4_error::codes::WASM_REJECT,
+                    "demo pipeline dropped a record",
+                ));
+            }
+            Err(error) => {
+                let _ = pipeline.cancel_and_wait().await;
+                return Err(error);
+            }
+        }
+    }
+    let trailing = pipeline.finish().await?;
+    Ok((output, trailing))
+}
+
+fn append_demo_output(
+    output: &mut Vec<u8>,
+    record: crate::record::Record,
+    max_output_bytes: Option<usize>,
+) -> Result<(), s4_error::S4Error> {
+    let added = record.payload.len().saturating_add(record.separator.len());
+    if max_output_bytes.is_some_and(|limit| output.len().saturating_add(added) > limit) {
+        return Err(s4_error::S4Error::new(
+            s4_error::codes::LIMIT_OUTPUT_BYTES,
+            "demo output exceeds limit",
+        ));
+    }
+    output.extend_from_slice(&record.payload);
+    output.extend_from_slice(&record.separator);
+    Ok(())
 }
 
 /// Run a bounded in-memory input through the streaming record decoder and
 /// persistent pipeline session. Kept small on purpose: demo endpoints cap the
 /// input so this never becomes a whole-object buffer.
 async fn run_demo_streaming(
-    state: &AppState,
+    snapshot: PipelineSnapshot,
     input: &[u8],
     format: Format,
     content_type: &str,
-    public_key_pem: Option<&str>,
     stable_key: Option<&[u8]>,
     stable_fields: Option<&str>,
+    max_output_bytes: Option<usize>,
 ) -> Result<(Vec<u8>, usize), s4_error::S4Error> {
     let session = s4_wasm_runtime::Session {
         format: format.as_str().to_string(),
         content_type: content_type.to_string(),
         policy_version: 0,
-        public_key_pem: public_key_pem.map(str::to_string),
+        public_key_pem: None,
         stable_key: stable_key.map(<[u8]>::to_vec),
         stable_fields: stable_fields.map(str::to_string),
     };
     let cancellation = s4_wasm_runtime::CancellationToken::new();
-    let snapshot = state.gateway.pipeline_snapshot().ok_or_else(|| {
-        s4_error::S4Error::new(
-            s4_error::codes::INTERNAL,
-            "demo pipeline requires a plugin registry",
-        )
-    })?;
     let mut pipeline = snapshot
         .start_streaming_session(session, cancellation)
         .await?;
@@ -1617,8 +2032,7 @@ async fn run_demo_streaming(
         while let Some(record) = decoder.next_record()? {
             records += 1;
             if let Some(record) = pipeline.process(record).await? {
-                output.extend_from_slice(&record.payload);
-                output.extend_from_slice(&record.separator);
+                append_demo_output(&mut output, record, max_output_bytes)?;
             }
         }
     }
@@ -1626,51 +2040,224 @@ async fn run_demo_streaming(
     while let Some(record) = decoder.next_record()? {
         records += 1;
         if let Some(record) = pipeline.process(record).await? {
-            output.extend_from_slice(&record.payload);
-            output.extend_from_slice(&record.separator);
+            append_demo_output(&mut output, record, max_output_bytes)?;
         }
     }
     for record in pipeline.finish().await? {
-        output.extend_from_slice(&record.payload);
-        output.extend_from_slice(&record.separator);
+        append_demo_output(&mut output, record, max_output_bytes)?;
     }
     Ok((output, records))
 }
 
 async fn demo_redact(
     State(state): State<Arc<AppState>>,
-    Json(body): Json<DemoRedactRequest>,
-) -> impl IntoResponse {
-    if body.text.len() > 64 * 1024 {
-        return (StatusCode::BAD_REQUEST, "demo input must be <= 64KB").into_response();
+    request: Request,
+) -> axum::response::Response {
+    let _permit = match start_demo_operation(&state) {
+        Ok(permit) => permit,
+        Err(error) => return demo_limit_response(error),
+    };
+    let deadline = Instant::now() + DEMO_MAX_WALL_TIME;
+    let body: DemoRedactRequest = match decode_demo_json(request, deadline).await {
+        Ok(body) => body,
+        Err(error) => return demo_body_error(error),
+    };
+    if body.text.len() > DEMO_MAX_INPUT_BYTES {
+        return demo_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "input_too_large",
+            "Demo input exceeds 64 KiB",
+        );
     }
-    // Run the engine's default pipeline (PII redaction). No public key, no
-    // stable key: this is the pure "detect + redact" path.
-    match run_demo_streaming(
-        &state,
-        body.text.as_bytes(),
-        Format::Text,
-        "text/plain",
-        None,
-        None,
-        None,
+    let limits = crate::record::DecoderLimits::default();
+    let mut decoder = match crate::record::RecordDecoder::new(Format::Text, limits) {
+        Ok(decoder) => decoder,
+        Err(error) => return demo_pipeline_error(&error),
+    };
+    if let Err(error) = decoder.push(body.text.as_bytes()) {
+        return demo_pipeline_error(&error);
+    }
+    let mut records = Vec::new();
+    loop {
+        match decoder.next_record() {
+            Ok(Some(record)) => records.push(record),
+            Ok(None) => break,
+            Err(error) => return demo_pipeline_error(&error),
+        }
+    }
+    if let Err(error) = decoder.finish() {
+        return demo_pipeline_error(&error);
+    }
+    loop {
+        match decoder.next_record() {
+            Ok(Some(record)) => records.push(record),
+            Ok(None) => break,
+            Err(error) => return demo_pipeline_error(&error),
+        }
+    }
+    let records_processed = records.len();
+    let session = s4_wasm_runtime::Session {
+        format: Format::Text.as_str().to_string(),
+        content_type: "text/plain".to_string(),
+        policy_version: 0,
+        public_key_pem: None,
+        stable_key: None,
+        stable_fields: None,
+    };
+    match execute_demo_records(
+        state.demo_pipelines.safe.clone(),
+        session,
+        records,
+        deadline,
     )
     .await
     {
-        Ok((bytes, records_processed)) => Json(serde_json::json!({
-            "redacted": String::from_utf8_lossy(&bytes),
-            "records_processed": records_processed,
-        }))
-        .into_response(),
-        Err(e) => (
-            StatusCode::UNPROCESSABLE_ENTITY,
-            format!("pipeline error: {e}"),
-        )
-            .into_response(),
+        Ok((records, trailing)) => {
+            let mut bytes = Vec::new();
+            for record in records.into_iter().chain(trailing) {
+                if let Err(error) =
+                    append_demo_output(&mut bytes, record, Some(DEMO_MAX_OUTPUT_BYTES))
+                {
+                    return demo_pipeline_error(&error);
+                }
+            }
+            if Instant::now() >= deadline {
+                return demo_pipeline_error(&demo_deadline_error());
+            }
+            bounded_demo_json(&serde_json::json!({
+                "redacted": String::from_utf8_lossy(&bytes),
+                "records_processed": records_processed,
+            }))
+        }
+        Err(error) => demo_pipeline_error(&error),
     }
 }
 
-/// Demo store: persist a batch of demo records (shared join keys allowed) in
+async fn demo_process(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> axum::response::Response {
+    let _permit = match start_demo_operation(&state) {
+        Ok(permit) => permit,
+        Err(error) => return demo_limit_response(error),
+    };
+    let deadline = Instant::now() + DEMO_MAX_WALL_TIME;
+    let DemoProcessRequest { records, mode } = match decode_demo_json(request, deadline).await {
+        Ok(body) => body,
+        Err(error) => return demo_body_error(error),
+    };
+    if records.is_empty() || records.len() > DEMO_MAX_RECORDS {
+        return demo_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_record_count",
+            "Demo requests require 1-10 records",
+        );
+    }
+
+    let mut canonical_records = Vec::with_capacity(records.len());
+    let mut input_bytes = 0usize;
+    for record in &records {
+        if Instant::now() >= deadline {
+            return demo_pipeline_error(&demo_deadline_error());
+        }
+        let canonical = match serde_json::to_vec(record) {
+            Ok(canonical) => canonical,
+            Err(_) => {
+                return demo_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request",
+                    "Invalid demo request",
+                );
+            }
+        };
+        input_bytes = input_bytes.saturating_add(canonical.len());
+        if input_bytes > DEMO_MAX_INPUT_BYTES {
+            return demo_error(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "input_too_large",
+                "Demo input exceeds 64 KiB",
+            );
+        }
+        canonical_records.push(crate::record::Record::new(canonical, bytes::Bytes::new()));
+    }
+
+    let snapshot = match demo_pipeline(&state, mode) {
+        Some(snapshot) => snapshot,
+        None => {
+            return demo_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "join_unavailable",
+                "Join demo mode is unavailable",
+            );
+        }
+    };
+    let stable_key = match mode {
+        DemoMode::Safe => None,
+        DemoMode::Join => Some(demo_request_stable_key()),
+    };
+    let session = s4_wasm_runtime::Session {
+        format: Format::Json.as_str().to_string(),
+        content_type: "application/json".to_string(),
+        policy_version: 0,
+        public_key_pem: None,
+        stable_key: stable_key.as_ref().map(|key| key.as_slice().to_vec()),
+        stable_fields: matches!(mode, DemoMode::Join).then(|| "email".to_string()),
+    };
+    let (output, trailing) =
+        match execute_demo_records(snapshot, session, canonical_records, deadline).await {
+            Ok(output) => output,
+            Err(error) => return demo_pipeline_error(&error),
+        };
+    if !trailing.is_empty() {
+        return demo_error(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "pipeline_failed",
+            "Demo processing failed",
+        );
+    }
+    let mut output_bytes = 0usize;
+    let mut processed = Vec::with_capacity(output.len());
+    for (index, record) in output.into_iter().enumerate() {
+        if !record.separator.is_empty() {
+            return demo_error(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "pipeline_failed",
+                "Demo processing failed",
+            );
+        }
+        output_bytes = output_bytes.saturating_add(record.payload.len());
+        if output_bytes > DEMO_MAX_OUTPUT_BYTES {
+            return demo_error(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "output_too_large",
+                "Demo output exceeds 64 KiB",
+            );
+        }
+        let body = match String::from_utf8(record.payload.to_vec()) {
+            Ok(body) => body,
+            Err(_) => {
+                return demo_error(
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "pipeline_failed",
+                    "Demo processing failed",
+                );
+            }
+        };
+        processed.push(DemoProcessedRecord {
+            record: index + 1,
+            body,
+        });
+    }
+    if Instant::now() >= deadline {
+        return demo_pipeline_error(&demo_deadline_error());
+    }
+    bounded_demo_json(&DemoProcessResponse {
+        mode,
+        records: processed,
+    })
+}
+
+/// Deprecated demo store: persist a batch of demo records (shared join keys allowed) in
 /// the in-memory store under a fixed demo namespace. No auth — this is the
 /// landing-page "store raw data" step. The store is in-memory, so it resets on
 /// gateway restart.
@@ -1679,6 +2266,7 @@ struct DemoStoreRequest {
     records: Vec<serde_json::Value>,
 }
 
+#[deprecated(note = "use the stateless /dashboard/api/demo/process endpoint")]
 async fn demo_store(
     State(state): State<Arc<AppState>>,
     Json(body): Json<DemoStoreRequest>,
@@ -1698,7 +2286,7 @@ async fn demo_store(
     Json(serde_json::json!({ "stored": body.records.len(), "namespace": "__demo" })).into_response()
 }
 
-/// Demo read: fetch a stored demo record and run the requested disclosure mode.
+/// Deprecated demo read: fetch a stored demo record and run the requested disclosure mode.
 /// `mode` is `raw` (bytes at rest), `safe` (PII redacted), or `join` (`email`
 /// stable-encrypted so records stay joinable without exposing plaintext).
 #[derive(Deserialize, ToSchema)]
@@ -1707,6 +2295,7 @@ struct DemoReadQuery {
     mode: Option<String>, // raw | safe | join
 }
 
+#[deprecated(note = "use the stateless /dashboard/api/demo/process endpoint")]
 async fn demo_read(
     State(state): State<Arc<AppState>>,
     Query(q): Query<DemoReadQuery>,
@@ -1725,14 +2314,24 @@ async fn demo_read(
                 None
             };
             let stable_fields: Option<&str> = if mode == "join" { Some("email") } else { None };
+            let snapshot = match pipeline_snapshot(&state) {
+                Ok(snapshot) => snapshot,
+                Err(error) => {
+                    return (
+                        StatusCode::UNPROCESSABLE_ENTITY,
+                        format!("pipeline error: {error}"),
+                    )
+                        .into_response();
+                }
+            };
             match run_demo_streaming(
-                &state,
+                snapshot,
                 &obj.data,
                 Format::Json,
                 "application/json",
-                None,
                 stable_key.as_deref(),
                 stable_fields,
+                None,
             )
             .await
             {
@@ -4433,7 +5032,10 @@ mod tests {
                 s4_wasm_runtime::Session {
                     format: "text".to_string(),
                     content_type: "text/plain".to_string(),
-                    ..Default::default()
+                    policy_version: 0,
+                    public_key_pem: None,
+                    stable_key: None,
+                    stable_fields: None,
                 },
                 s4_wasm_runtime::CancellationToken::new(),
             )
@@ -6083,6 +6685,27 @@ fn component_path() -> PathBuf {
         })
 }
 
+fn bundled_stable_component() -> Option<Vec<u8>> {
+    let directory = match std::env::var("S4_PLUGINS_DIR") {
+        Ok(directory) => PathBuf::from(directory),
+        Err(_) => {
+            warn!("join demo disabled because S4_PLUGINS_DIR is not configured");
+            return None;
+        }
+    };
+    let path = directory.join("stable-encrypt.component.wasm");
+    match std::fs::read(&path) {
+        Ok(component) => Some(component),
+        Err(error) => {
+            warn!(
+                "join demo disabled because {} is unavailable: {error}",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
 /// Build the engine state from environment variables, injecting the given
 /// control plane and key-wrapping backend. This is the shared construction
 /// path for both the OSS self-host binary (`NoopControlPlane` +
@@ -6123,6 +6746,13 @@ pub async fn build_state(
             plugins.load_from_dir_with_capabilities(dir, &prefix_safe_hashes)?;
         }
     }
+
+    let stable_demo_component = bundled_stable_component();
+    let demo_pipelines = build_demo_pipelines(
+        &component_bytes,
+        stable_demo_component.as_deref(),
+        pipeline_fuel,
+    )?;
 
     let gateway = Gateway::with_registry(engine, plugins.clone());
 
@@ -6470,6 +7100,8 @@ pub async fn build_state(
         transformed_read_spool_enabled: transformed_read_spool_enabled(),
         dev_memory_max_object_bytes,
         dev_memory_streaming_enabled,
+        demo_pipelines,
+        demo_limiter: Arc::new(DemoLimiter::new()),
         multipart_staging,
         multipart_mode,
         continuation_token_key,
@@ -6563,6 +7195,7 @@ pub async fn build_state(
 
 /// Build the axum router for the engine. The SaaS crate merges its own
 /// control-plane routes (workspaces, billing, dashboard) onto this.
+#[allow(deprecated)]
 pub fn build_router(state: Arc<AppState>) -> Router {
     let mut router = Router::new()
         .route("/health", get(health))
@@ -6576,8 +7209,15 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/dashboard/api/mcp-tokens", delete(delete_mcp_token))
         .route("/dashboard/api/me", get(get_me))
         .route("/dashboard/api/demo/redact", post(demo_redact))
-        .route("/dashboard/api/demo/store", post(demo_store))
-        .route("/dashboard/api/demo/read", get(demo_read))
+        .route("/dashboard/api/demo/process", post(demo_process))
+        .route(
+            "/dashboard/api/demo/store",
+            post(demo_store).layer(axum::middleware::map_response(harden_legacy_demo_response)),
+        )
+        .route(
+            "/dashboard/api/demo/read",
+            get(demo_read).layer(axum::middleware::map_response(harden_legacy_demo_response)),
+        )
         .route("/dashboard/api/backend", get(get_backend))
         .route("/dashboard/api/backend", put(put_backend))
         .route("/{bucket}", get(s3_list_objects))
@@ -6631,6 +7271,95 @@ mod auth_tests {
                 .expect("valid Supabase token");
 
         assert_eq!(decoded.claims["sub"], "user-123");
+    }
+}
+
+#[cfg(test)]
+mod demo_limiter_tests {
+    use std::path::Path;
+    use std::time::Duration;
+
+    use super::{ApiDoc, DemoLimitError, DemoLimiter, build_demo_pipelines};
+    use utoipa::OpenApi;
+
+    #[test]
+    fn rejects_a_fifth_concurrent_operation_without_counting_it_as_a_start() {
+        let limiter = DemoLimiter::with_limits(4, 5, Duration::from_secs(60));
+        let permits: Vec<_> = (0..4)
+            .map(|_| limiter.try_start().expect("first four operations start"))
+            .collect();
+        assert!(matches!(
+            limiter.try_start(),
+            Err(DemoLimitError::Concurrent)
+        ));
+
+        drop(permits);
+        assert!(limiter.try_start().is_ok());
+    }
+
+    #[test]
+    fn rejects_more_than_thirty_starts_in_the_window() {
+        let limiter = DemoLimiter::with_limits(4, 30, Duration::from_secs(60));
+        for _ in 0..30 {
+            drop(limiter.try_start().expect("operation starts within limit"));
+        }
+        assert!(matches!(limiter.try_start(), Err(DemoLimitError::Rate)));
+    }
+
+    #[test]
+    fn dedicated_demo_snapshots_are_ordered_and_join_fails_closed() {
+        let components = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/components");
+        let pii = std::fs::read(components.join("pii-default.component.wasm"))
+            .expect("pii-default.component.wasm; run just build-filters");
+        let stable = std::fs::read(components.join("stable-encrypt.component.wasm"))
+            .expect("stable-encrypt.component.wasm; run just build-filters");
+
+        let unavailable = build_demo_pipelines(&pii, None, 1_000_000_000).unwrap();
+        assert!(unavailable.join.is_none());
+        assert_eq!(
+            unavailable
+                .safe
+                .plugin_infos()
+                .into_iter()
+                .map(|plugin| plugin.name)
+                .collect::<Vec<_>>(),
+            ["pii-default"]
+        );
+
+        let malformed = build_demo_pipelines(&pii, Some(b"not a component"), 1_000_000_000)
+            .expect("safe demo remains available when stable-encrypt is malformed");
+        assert!(malformed.join.is_none());
+
+        let available = build_demo_pipelines(&pii, Some(&stable), 1_000_000_000).unwrap();
+        assert_eq!(
+            available
+                .join
+                .expect("valid bundled stable component enables join")
+                .plugin_infos()
+                .into_iter()
+                .map(|plugin| plugin.name)
+                .collect::<Vec<_>>(),
+            ["stable-encrypt", "pii-default"]
+        );
+    }
+
+    #[test]
+    fn stateless_demo_process_is_not_published_in_openapi() {
+        let document = serde_json::to_value(ApiDoc::openapi()).unwrap();
+        assert!(
+            document["paths"]
+                .get("/dashboard/api/demo/process")
+                .is_none()
+        );
+        for schema in [
+            "DemoMode",
+            "DemoProcessRequest",
+            "DemoProcessedRecord",
+            "DemoProcessResponse",
+            "DemoErrorResponse",
+        ] {
+            assert!(document["components"]["schemas"].get(schema).is_none());
+        }
     }
 }
 

--- a/crates/gateway/tests/fixtures.rs
+++ b/crates/gateway/tests/fixtures.rs
@@ -39,7 +39,9 @@ fn session(format: &str, content_type: &str) -> s4_wasm_runtime::Session {
         format: format.to_string(),
         content_type: content_type.to_string(),
         policy_version: 1,
-        ..Default::default()
+        public_key_pem: None,
+        stable_key: None,
+        stable_fields: None,
     }
 }
 

--- a/crates/gateway/tests/s3_frontdoor_test.rs
+++ b/crates/gateway/tests/s3_frontdoor_test.rs
@@ -2988,6 +2988,8 @@ async fn demo_redact_runs_pipeline() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.headers()[header::CACHE_CONTROL], "private, no-store");
+    assert_eq!(resp.headers()["x-content-type-options"], "nosniff");
     let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
         .await
         .unwrap();
@@ -3001,6 +3003,250 @@ async fn demo_redact_runs_pipeline() {
         redacted.contains("[REDACTED_CARD]"),
         "card redacted: {redacted}"
     );
+}
+
+async fn post_demo_process(app: &Router, body: serde_json::Value) -> axum::response::Response {
+    post_demo_process_body(app, Body::from(body.to_string())).await
+}
+
+async fn post_demo_process_body(app: &Router, body: Body) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/dashboard/api/demo/process")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(body)
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+fn assert_demo_security_headers(response: &axum::response::Response) {
+    assert_eq!(
+        response.headers()[header::CACHE_CONTROL],
+        "private, no-store"
+    );
+    assert_eq!(response.headers()["x-content-type-options"], "nosniff");
+}
+
+fn assert_demo_response_headers(response: &axum::response::Response) {
+    assert_demo_security_headers(response);
+    assert_eq!(response.headers()[header::CONTENT_TYPE], "application/json");
+}
+
+async fn demo_response_json(response: axum::response::Response) -> serde_json::Value {
+    serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn demo_process_is_stateless_ordered_and_supports_safe_and_join_modes() {
+    let (app, state) = router().await;
+    assert!(state.store.list_keys().is_empty());
+    for plugin in state.plugins.list() {
+        state.plugins.set_enabled(&plugin.id, false);
+    }
+    let records = serde_json::json!([
+        {
+            "email": "alice@example.com",
+            "card": "4111111111111111",
+            "note": "first"
+        },
+        {
+            "email": "alice@example.com",
+            "card": "4111111111111111",
+            "note": "second"
+        },
+        {
+            "email": "bob@example.com",
+            "card": "4111111111111111",
+            "note": "third"
+        }
+    ]);
+
+    let safe = post_demo_process(
+        &app,
+        serde_json::json!({"records": records, "mode": "safe"}),
+    )
+    .await;
+    assert_eq!(safe.status(), StatusCode::OK);
+    assert_demo_response_headers(&safe);
+    let safe = demo_response_json(safe).await;
+    assert_eq!(safe["mode"], "safe");
+    assert_eq!(safe["records"][0]["record"], 1);
+    assert_eq!(safe["records"][1]["record"], 2);
+    assert_eq!(safe["records"][2]["record"], 3);
+    for (index, note) in ["first", "second", "third"].into_iter().enumerate() {
+        let body: serde_json::Value =
+            serde_json::from_str(safe["records"][index]["body"].as_str().unwrap()).unwrap();
+        assert_eq!(body["email"], "[REDACTED_EMAIL]");
+        assert_eq!(body["card"], "[REDACTED_CARD]");
+        assert_eq!(body["note"], note);
+    }
+
+    let join = post_demo_process(
+        &app,
+        serde_json::json!({"records": records, "mode": "join"}),
+    )
+    .await;
+    assert_eq!(join.status(), StatusCode::OK);
+    assert_demo_response_headers(&join);
+    let join = demo_response_json(join).await;
+    assert_eq!(join["mode"], "join");
+    let first: serde_json::Value =
+        serde_json::from_str(join["records"][0]["body"].as_str().unwrap()).unwrap();
+    let second: serde_json::Value =
+        serde_json::from_str(join["records"][1]["body"].as_str().unwrap()).unwrap();
+    let third: serde_json::Value =
+        serde_json::from_str(join["records"][2]["body"].as_str().unwrap()).unwrap();
+    assert_ne!(first["email"], "alice@example.com");
+    assert_eq!(first["email"], second["email"]);
+    assert_ne!(first["email"], third["email"]);
+    assert_eq!(first["note"], "first");
+    assert_eq!(second["note"], "second");
+    assert_eq!(third["note"], "third");
+    assert_eq!(first["card"], "[REDACTED_CARD]");
+
+    let next_request = post_demo_process(
+        &app,
+        serde_json::json!({
+            "records": [{"email": "alice@example.com"}],
+            "mode": "join"
+        }),
+    )
+    .await;
+    assert_eq!(next_request.status(), StatusCode::OK);
+    let next_request = demo_response_json(next_request).await;
+    let next_email: serde_json::Value =
+        serde_json::from_str(next_request["records"][0]["body"].as_str().unwrap()).unwrap();
+    assert_ne!(first["email"], next_email["email"]);
+    assert!(state.store.list_keys().is_empty());
+}
+
+#[tokio::test]
+async fn demo_process_rejects_raw_unknown_and_malformed_modes() {
+    let (app, _state) = router().await;
+    for mode in ["raw", "unknown", "SAFE"] {
+        let response = post_demo_process(
+            &app,
+            serde_json::json!({"records": [{"value": 1}], "mode": mode}),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_demo_response_headers(&response);
+        let body = demo_response_json(response).await;
+        assert_eq!(body["code"], "invalid_request");
+        assert_eq!(body["message"], "Invalid demo request");
+    }
+}
+
+#[tokio::test]
+async fn demo_process_enforces_record_and_canonical_input_limits() {
+    let (app, _state) = router().await;
+    for records in [
+        serde_json::json!([]),
+        serde_json::Value::Array(vec![serde_json::Value::Null; 11]),
+    ] {
+        let response = post_demo_process(
+            &app,
+            serde_json::json!({"records": records, "mode": "safe"}),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_demo_response_headers(&response);
+        assert_eq!(
+            demo_response_json(response).await["code"],
+            "invalid_record_count"
+        );
+    }
+
+    let response = post_demo_process(
+        &app,
+        serde_json::json!({
+            "records": ["x".repeat(64 * 1024)],
+            "mode": "safe"
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_demo_response_headers(&response);
+    assert_eq!(
+        demo_response_json(response).await["code"],
+        "input_too_large"
+    );
+
+    let response = post_demo_process_body(&app, Body::from(vec![b' '; 512 * 1024 + 1])).await;
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_demo_response_headers(&response);
+    assert_eq!(
+        demo_response_json(response).await["code"],
+        "input_too_large"
+    );
+}
+
+#[tokio::test]
+async fn demo_process_enforces_aggregate_output_limit() {
+    let state = test_state().await;
+    for plugin in state.plugins.list() {
+        state.plugins.set_enabled(&plugin.id, false);
+    }
+    let app = build_router(state);
+    let response = post_demo_process(
+        &app,
+        serde_json::json!({
+            "records": ["a@b.co ".repeat(7_000)],
+            "mode": "safe"
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_demo_response_headers(&response);
+    let body = demo_response_json(response).await;
+    assert_eq!(body["code"], "output_too_large");
+    assert_eq!(body["message"], "Demo output exceeds 64 KiB");
+}
+
+#[tokio::test]
+async fn demo_process_enforces_serialized_json_response_limit() {
+    let (app, _state) = router().await;
+    let response = post_demo_process(
+        &app,
+        serde_json::json!({
+            "records": ["\\".repeat(30_000)],
+            "mode": "safe"
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_demo_response_headers(&response);
+    assert_eq!(
+        demo_response_json(response).await["code"],
+        "output_too_large"
+    );
+}
+
+#[tokio::test]
+async fn malformed_demo_bodies_consume_the_global_start_allowance() {
+    let (app, _state) = router().await;
+    for _ in 0..30 {
+        let response = post_demo_process_body(&app, Body::from("{")).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_demo_response_headers(&response);
+    }
+    let response = post_demo_process(
+        &app,
+        serde_json::json!({"records": [{"value": 1}], "mode": "safe"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_demo_response_headers(&response);
+    assert_eq!(demo_response_json(response).await["code"], "rate_limited");
 }
 
 #[tokio::test]
@@ -3521,6 +3767,7 @@ async fn demo_read_safe_and_join_modes() {
         .await
         .unwrap();
     assert_eq!(store.status(), StatusCode::OK);
+    assert_demo_response_headers(&store);
 
     // 2. Raw read keeps PII.
     let raw = app
@@ -3534,6 +3781,7 @@ async fn demo_read_safe_and_join_modes() {
         )
         .await
         .unwrap();
+    assert_demo_response_headers(&raw);
     let raw_body = axum::body::to_bytes(raw.into_body(), usize::MAX)
         .await
         .unwrap();
@@ -3556,6 +3804,7 @@ async fn demo_read_safe_and_join_modes() {
         .await
         .unwrap();
     assert_eq!(safe.status(), StatusCode::OK);
+    assert_demo_response_headers(&safe);
     let safe_bytes = axum::body::to_bytes(safe.into_body(), usize::MAX)
         .await
         .unwrap();
@@ -3581,6 +3830,7 @@ async fn demo_read_safe_and_join_modes() {
                 .await
                 .unwrap();
             assert_eq!(resp.status(), StatusCode::OK);
+            assert_demo_response_headers(&resp);
             let text = String::from_utf8_lossy(
                 &axum::body::to_bytes(resp.into_body(), usize::MAX)
                     .await
@@ -3600,4 +3850,46 @@ async fn demo_read_safe_and_join_modes() {
         email1, email2,
         "join must produce identical ciphertext for the same email"
     );
+
+    let missing = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/dashboard/api/demo/read?id=99&mode=raw")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+    assert_demo_security_headers(&missing);
+
+    let unknown = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/dashboard/api/demo/read?id=1&mode=unknown")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unknown.status(), StatusCode::BAD_REQUEST);
+    assert_demo_security_headers(&unknown);
+
+    let malformed_store = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/dashboard/api/demo/store")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(malformed_store.status(), StatusCode::BAD_REQUEST);
+    assert_demo_security_headers(&malformed_store);
 }

--- a/crates/wasm-runtime/Cargo.toml
+++ b/crates/wasm-runtime/Cargo.toml
@@ -11,6 +11,7 @@ wasmtime-wasi.workspace = true
 wit-bindgen.workspace = true
 anyhow = "1"
 rand.workspace = true
+zeroize.workspace = true
 
 [build-dependencies]
 wit-bindgen.workspace = true

--- a/crates/wasm-runtime/src/executor.rs
+++ b/crates/wasm-runtime/src/executor.rs
@@ -1,9 +1,9 @@
 use std::any::Any;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{Receiver, SyncSender, TrySendError, sync_channel};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, TrySendError, sync_channel};
 use std::sync::{Arc, Condvar, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use s4_error::{S4Error, codes};
 use wasmtime::Engine;
@@ -158,6 +158,33 @@ impl MemoryAdmission {
         })
     }
 
+    pub fn reserve_until(
+        &self,
+        bytes: usize,
+        cancellation: &CancellationToken,
+        deadline: Instant,
+    ) -> Result<MemoryPermit, S4Error> {
+        self.validate_request(bytes)?;
+        let mut state = self.inner.state.lock().unwrap();
+        while state.used.saturating_add(bytes) > self.inner.capacity {
+            if let Some(error) = execution_control_error(cancellation, deadline) {
+                return Err(error);
+            }
+            let wait = deadline
+                .saturating_duration_since(Instant::now())
+                .min(Duration::from_millis(10));
+            state = self.inner.available.wait_timeout(state, wait).unwrap().0;
+        }
+        if let Some(error) = execution_control_error(cancellation, deadline) {
+            return Err(error);
+        }
+        state.used += bytes;
+        Ok(MemoryPermit {
+            admission: self.clone(),
+            bytes,
+        })
+    }
+
     fn validate_request(&self, bytes: usize) -> Result<(), S4Error> {
         if bytes > self.inner.capacity {
             return Err(admission_error(bytes, self.inner.capacity));
@@ -251,6 +278,47 @@ impl WasmExecutor {
         })?;
         receive_result(result_receiver)
     }
+
+    pub fn execute_until<R, F>(
+        &self,
+        guest_memory_bytes: usize,
+        cancellation: &CancellationToken,
+        deadline: Instant,
+        task: F,
+    ) -> Result<R, S4Error>
+    where
+        R: Send + 'static,
+        F: FnOnce() -> R + Send + 'static,
+    {
+        let permit = self
+            .admission
+            .reserve_until(guest_memory_bytes, cancellation, deadline)?;
+        let pending = Arc::new(Mutex::new(Some((task, permit))));
+        let (result_sender, result_receiver) = sync_channel(1);
+        let mut job = make_cancellable_job(Arc::clone(&pending), result_sender);
+        loop {
+            match self.sender.try_send(job) {
+                Ok(()) => break,
+                Err(TrySendError::Full(returned)) => {
+                    job = returned;
+                    if let Some(error) = execution_control_error(cancellation, deadline) {
+                        cancellation.cancel();
+                        pending.lock().unwrap().take();
+                        return Err(error);
+                    }
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                Err(TrySendError::Disconnected(_)) => {
+                    pending.lock().unwrap().take();
+                    return Err(S4Error::new(
+                        codes::WASM_ADMISSION,
+                        "Wasm executor is not available",
+                    ));
+                }
+            }
+        }
+        receive_result_until(result_receiver, pending, cancellation, deadline)
+    }
 }
 
 fn make_job<R, F>(
@@ -272,6 +340,24 @@ where
     })
 }
 
+fn make_cancellable_job<R, F>(
+    pending: Arc<Mutex<Option<(F, MemoryPermit)>>>,
+    result_sender: SyncSender<Result<R, S4Error>>,
+) -> Job
+where
+    R: Send + 'static,
+    F: FnOnce() -> R + Send + 'static,
+{
+    Box::new(move || {
+        let Some((task, permit)) = pending.lock().unwrap().take() else {
+            return;
+        };
+        let result = catch_unwind(AssertUnwindSafe(task)).map_err(panic_error);
+        drop(permit);
+        let _ = result_sender.send(result);
+    })
+}
+
 fn receive_result<R>(receiver: Receiver<Result<R, S4Error>>) -> Result<R, S4Error> {
     receiver.recv().map_err(|_| {
         S4Error::new(
@@ -279,6 +365,58 @@ fn receive_result<R>(receiver: Receiver<Result<R, S4Error>>) -> Result<R, S4Erro
             "Wasm executor worker stopped before returning a result",
         )
     })?
+}
+
+fn receive_result_until<R, F>(
+    receiver: Receiver<Result<R, S4Error>>,
+    pending: Arc<Mutex<Option<(F, MemoryPermit)>>>,
+    cancellation: &CancellationToken,
+    deadline: Instant,
+) -> Result<R, S4Error> {
+    loop {
+        if let Some(error) = execution_control_error(cancellation, deadline) {
+            cancellation.cancel();
+            if pending.lock().unwrap().take().is_none() {
+                let _ = receiver.recv();
+            }
+            return Err(error);
+        }
+        let wait = deadline
+            .saturating_duration_since(Instant::now())
+            .min(Duration::from_millis(10));
+        match receiver.recv_timeout(wait) {
+            Ok(result) => {
+                if let Some(error) = execution_control_error(cancellation, deadline) {
+                    cancellation.cancel();
+                    return Err(error);
+                }
+                return result;
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => {
+                return Err(S4Error::new(
+                    codes::INTERNAL,
+                    "Wasm executor worker stopped before returning a result",
+                ));
+            }
+        }
+    }
+}
+
+fn execution_control_error(cancellation: &CancellationToken, deadline: Instant) -> Option<S4Error> {
+    if Instant::now() >= deadline {
+        Some(S4Error::new(
+            codes::WASM_DEADLINE,
+            "Wasm execution deadline exceeded",
+        ))
+    } else if cancellation.is_cancelled() {
+        Some(S4Error::new(
+            codes::WASM_CANCELLED,
+            "Wasm execution was cancelled",
+        ))
+    } else {
+        None
+    }
 }
 
 fn panic_error(payload: Box<dyn Any + Send>) -> S4Error {
@@ -311,6 +449,8 @@ fn spawn_worker(index: usize, receiver: Arc<Mutex<Receiver<Job>>>) -> Result<(),
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     use super::*;
 
     #[test]
@@ -360,5 +500,58 @@ mod tests {
             codes::WASM_CANCELLED
         );
         drop(permit);
+    }
+
+    #[test]
+    fn queued_deadline_drops_the_task_and_releases_admission() {
+        let executor = Arc::new(
+            WasmExecutor::new(ExecutorConfig {
+                workers: 1,
+                queue_capacity: 1,
+                guest_memory_budget_bytes: 2,
+            })
+            .unwrap(),
+        );
+        let release = Arc::new(AtomicBool::new(false));
+        let started = Arc::new(AtomicBool::new(false));
+        let blocker_executor = Arc::clone(&executor);
+        let blocker_release = Arc::clone(&release);
+        let blocker_started = Arc::clone(&started);
+        let blocker = std::thread::spawn(move || {
+            blocker_executor
+                .execute(1, &CancellationToken::new(), move || {
+                    blocker_started.store(true, Ordering::Release);
+                    while !blocker_release.load(Ordering::Acquire) {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                })
+                .unwrap();
+        });
+        while !started.load(Ordering::Acquire) {
+            std::thread::yield_now();
+        }
+
+        let ran = Arc::new(AtomicBool::new(false));
+        let queued_ran = Arc::clone(&ran);
+        let cancellation = CancellationToken::new();
+        let error = executor
+            .execute_until(
+                1,
+                &cancellation,
+                Instant::now() + Duration::from_millis(25),
+                move || queued_ran.store(true, Ordering::Release),
+            )
+            .unwrap_err();
+        assert_eq!(error.code(), codes::WASM_DEADLINE);
+        assert!(!ran.load(Ordering::Acquire));
+        assert_eq!(executor.admission().used(), 1);
+
+        release.store(true, Ordering::Release);
+        blocker.join().unwrap();
+        executor
+            .execute(1, &CancellationToken::new(), || ())
+            .unwrap();
+        assert!(!ran.load(Ordering::Acquire));
+        assert_eq!(executor.admission().used(), 0);
     }
 }

--- a/crates/wasm-runtime/src/lib.rs
+++ b/crates/wasm-runtime/src/lib.rs
@@ -17,6 +17,7 @@ use wasmtime::component::{Component, Linker, ResourceTable};
 use wasmtime::{Engine, ResourceLimiter, Store, Trap, UpdateDeadline};
 use wasmtime_wasi::p2::add_to_linker_sync as add_wasi_to_linker;
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiView};
+use zeroize::Zeroize;
 
 const DEFAULT_GUEST_MEMORY_BYTES: usize = 64 * 1024 * 1024;
 const DEFAULT_MAX_MEMORIES: usize = 4;
@@ -93,6 +94,18 @@ pub struct Session {
     pub public_key_pem: Option<String>,
     pub stable_key: Option<Vec<u8>>,
     pub stable_fields: Option<String>,
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        zeroize_stable_key(&mut self.stable_key);
+    }
+}
+
+fn zeroize_stable_key(stable_key: &mut Option<Vec<u8>>) {
+    if let Some(mut key) = stable_key.take() {
+        key.zeroize();
+    }
 }
 
 pub struct FilterEngine {
@@ -325,6 +338,7 @@ impl FilterEngine {
         &self,
         cancellation: &CancellationToken,
         object_deadline: Instant,
+        initial_fuel: u64,
     ) -> Result<(Store<S4HostState>, Arc<CallControl>), S4Error> {
         let wasi = WasiCtxBuilder::new()
             .inherit_stdout()
@@ -342,7 +356,7 @@ impl FilterEngine {
         };
         let mut store = Store::new(&self.epoch_engine.engine, state);
         store
-            .set_fuel(self.limits.cumulative_fuel)
+            .set_fuel(initial_fuel)
             .map_err(|e| S4Error::new(codes::WASM_INIT, e.to_string()))?;
         store.limiter(|s| &mut s.resource_limiter);
         let control = Arc::new(CallControl {
@@ -419,22 +433,39 @@ impl FilterEngine {
         object_deadline: Instant,
     ) -> Result<FilterSession, S4Error> {
         let object_deadline = object_deadline.min(Instant::now() + self.limits.object_timeout);
+        check_start_control(&cancellation, object_deadline)?;
+        let initial_fuel = self.limits.cumulative_fuel.min(begin_fuel_limit);
+        if initial_fuel == 0 {
+            return Err(S4Error::new(
+                codes::WASM_FUEL,
+                "Wasm startup fuel budget exhausted",
+            ));
+        }
         let (mut store, control) = self
-            .create_store(&cancellation, object_deadline)
+            .create_store(&cancellation, object_deadline, initial_fuel)
             .map_err(|e| S4Error::new(codes::WASM_INIT, e.to_string()))?;
         let mut linker = Linker::new(&self.epoch_engine.engine);
         add_wasi_to_linker(&mut linker)
             .map_err(|e| S4Error::new(codes::WASM_INIT, e.to_string()))?;
+        check_start_control(&cancellation, object_deadline)?;
         let instance = linker
             .instantiate(&mut store, &self.component)
-            .map_err(|e| S4Error::new(codes::WASM_INIT, e.to_string()))?;
+            .map_err(|error| startup_error("instantiate", error, &cancellation, object_deadline))?;
 
-        let funcs = Filter::new(&mut store, &instance)
-            .map_err(|e| S4Error::new(codes::WASM_INIT, e.to_string()))?;
+        let remaining_after_start = store
+            .get_fuel()
+            .map_err(|error| S4Error::new(codes::WASM_FUEL, error.to_string()))?;
+        let startup_fuel = initial_fuel.saturating_sub(remaining_after_start);
+        check_start_control(&cancellation, object_deadline)?;
+
+        let funcs = Filter::new(&mut store, &instance).map_err(|error| {
+            startup_error("bind exports", error, &cancellation, object_deadline)
+        })?;
+        check_start_control(&cancellation, object_deadline)?;
 
         let entropy_seed: Vec<u8> = (0..32).map(|_| rand::random::<u8>()).collect();
 
-        let ctx = Context {
+        let mut ctx = Context {
             format: session.format.clone(),
             content_type: session.content_type.clone(),
             policy_version: session.policy_version,
@@ -451,9 +482,14 @@ impl FilterEngine {
             control,
             limits: self.limits.clone(),
             object_deadline,
-            fuel_consumed: 0,
+            fuel_consumed: startup_fuel,
         };
-        filter_session.call_begin(&ctx, begin_fuel_limit)?;
+        let begin = filter_session.call_begin(&ctx, begin_fuel_limit);
+        zeroize_stable_key(&mut ctx.stable_key);
+        // The trusted guest receives its own linear-memory copy. That memory is
+        // destroyed with this per-request store, but Wasmtime does not
+        // synchronously scrub every guest byte before releasing the pages.
+        begin?;
         Ok(filter_session)
     }
 
@@ -465,6 +501,43 @@ impl FilterEngine {
         }
         Ok(out)
     }
+}
+
+fn check_start_control(
+    cancellation: &CancellationToken,
+    object_deadline: Instant,
+) -> Result<(), S4Error> {
+    if cancellation.is_cancelled() {
+        return Err(S4Error::new(
+            codes::WASM_CANCELLED,
+            "Wasm startup was cancelled",
+        ));
+    }
+    if Instant::now() >= object_deadline {
+        return Err(S4Error::new(
+            codes::WASM_DEADLINE,
+            "Wasm startup deadline exceeded",
+        ));
+    }
+    Ok(())
+}
+
+fn startup_error(
+    stage: &str,
+    error: wasmtime::Error,
+    cancellation: &CancellationToken,
+    object_deadline: Instant,
+) -> S4Error {
+    let code = if cancellation.is_cancelled() {
+        codes::WASM_CANCELLED
+    } else if Instant::now() >= object_deadline {
+        codes::WASM_DEADLINE
+    } else if error.downcast_ref::<Trap>() == Some(&Trap::OutOfFuel) {
+        codes::WASM_FUEL
+    } else {
+        codes::WASM_INIT
+    };
+    S4Error::new(code, format!("{stage}: {error}"))
 }
 
 fn register_epoch_engine(engine: &Arc<EpochEngine>) {
@@ -527,8 +600,31 @@ mod tests {
             format: "text".to_string(),
             content_type: "text/plain".to_string(),
             policy_version: 1,
-            ..Session::default()
+            public_key_pem: None,
+            stable_key: None,
+            stable_fields: None,
         }
+    }
+
+    fn hostile_start_component() -> &'static [u8] {
+        br#"(component
+            (core module $hostile
+                (func $start
+                    (loop $forever
+                        br $forever
+                    )
+                )
+                (start $start)
+            )
+            (core instance $instance (instantiate $hostile))
+        )"#
+    }
+
+    #[test]
+    fn stable_key_zeroization_hook_removes_host_copy() {
+        let mut stable_key = Some(vec![0x5a; 64]);
+        zeroize_stable_key(&mut stable_key);
+        assert!(stable_key.is_none());
     }
 
     #[test]
@@ -697,6 +793,54 @@ mod tests {
             filter.transform(b"loop").unwrap_err().code(),
             codes::WASM_DEADLINE
         );
+    }
+
+    #[test]
+    fn constrained_fuel_interrupts_a_hostile_core_start_function() {
+        let engine = FilterEngine::with_limits(
+            hostile_start_component(),
+            RuntimeLimits {
+                cumulative_fuel: u64::MAX,
+                per_call_fuel: u64::MAX,
+                ..RuntimeLimits::default()
+            },
+        )
+        .unwrap();
+        let error = engine
+            .start_session_with_control(
+                &session(),
+                CancellationToken::new(),
+                1_000,
+                Instant::now() + Duration::from_secs(1),
+            )
+            .err()
+            .expect("hostile start must exhaust constrained fuel");
+        assert_eq!(error.code(), codes::WASM_FUEL);
+    }
+
+    #[test]
+    fn object_deadline_interrupts_a_hostile_core_start_function() {
+        let engine = FilterEngine::with_limits(
+            hostile_start_component(),
+            RuntimeLimits {
+                cumulative_fuel: u64::MAX,
+                per_call_fuel: u64::MAX,
+                per_call_timeout: Duration::from_secs(1),
+                object_timeout: Duration::from_secs(1),
+                ..RuntimeLimits::default()
+            },
+        )
+        .unwrap();
+        let error = engine
+            .start_session_with_control(
+                &session(),
+                CancellationToken::new(),
+                u64::MAX,
+                Instant::now() + Duration::from_millis(25),
+            )
+            .err()
+            .expect("hostile start must hit the object deadline");
+        assert_eq!(error.code(), codes::WASM_DEADLINE);
     }
 
     #[test]

--- a/filters/test-filter/src/lib.rs
+++ b/filters/test-filter/src/lib.rs
@@ -26,6 +26,9 @@ mod guest {
             if context.stable_fields.as_deref() == Some("finish-trap") {
                 finish.extend_from_slice(b"trap");
             }
+            if context.stable_fields.as_deref() == Some("finish-large") {
+                finish.resize(64 * 1024 + 1, b'x');
+            }
             if context.content_type == "test/begin-reject" {
                 return Err("begin rejected".to_string());
             }


### PR DESCRIPTION
## Rollout step 1 of 3
Adds a stateless website demo endpoint while retaining legacy store/read routes temporarily for compatibility. No website behavior changes in this PR.

## Security
- dedicated immutable demo pipelines: safe = PII only; join = stable encryption before PII
- random 64-byte key per request; equality exists only inside one submitted batch
- no request records or keys stored server-side
- bounds concurrency, anonymous starts, raw body, records, pipeline input/intermediate/finish/output, serialized HTTP output, Wasm fuel, and end-to-end wall time
- cancellation wakes idle workers and releases aggregate memory admission
- host stable-key copies zeroize after startup/drop
- endpoint excluded from generated SDK/OpenAPI surface

## Local validation
- source-only rustfmt passed
- independent static review approved with no blockers
- no local compilation was run to preserve disk; GitHub CI is the compilation/runtime gate

## Next steps after deployment
1. switch website demo to client-held records and this endpoint
2. remove legacy `/demo/store` and `/demo/read` routes in a follow-up security PR