### PR TITLE
fix(security): bind semantic headers into SigV4

### DIFF
--- a/crates/gateway/src/sigv4.rs
+++ b/crates/gateway/src/sigv4.rs
@@ -21,6 +21,16 @@ use crate::integrity::{BodyVerifier, IntegrityError, StreamingSigning};
 
 const DEFAULT_REGION: &str = "us-east-1";
 const MAX_PRESIGN_EXPIRY: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+const SEMANTIC_HEADERS: &[&str] = &[
+    "x-s4-storage-mode",
+    "x-s4-backend-url",
+    "x-s4-process",
+    "x-s4-stable-fields",
+    "content-type",
+    "content-encoding",
+    "content-md5",
+];
+const X_AMZ_SIGNER_EXCLUSIONS: &[&str] = &["x-amz-user-agent", "x-amz-checksum-mode"];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SigV4Error {
@@ -472,6 +482,7 @@ fn validate_signed_headers(
     {
         return Err(SigV4Error::InvalidSignedHeaders);
     }
+    validate_integrity_header_values(headers)?;
     for name in signed {
         if headers.get(name).is_none() {
             return Err(SigV4Error::MissingHeader("signed header"));
@@ -479,14 +490,46 @@ fn validate_signed_headers(
     }
     for name in headers.keys() {
         let name = name.as_str();
-        if name.starts_with("x-amz-")
-            && name != "x-amz-content-sha256"
-            && !signed.iter().any(|signed| signed == name)
-        {
+        if requires_signed_header_integrity(name) && !signed.iter().any(|signed| signed == name) {
             return Err(SigV4Error::InvalidSignedHeaders);
         }
     }
     Ok(())
+}
+
+fn requires_signed_header_integrity(name: &str) -> bool {
+    SEMANTIC_HEADERS.contains(&name)
+        || (name.starts_with("x-amz-") && !X_AMZ_SIGNER_EXCLUSIONS.contains(&name))
+}
+
+fn validate_integrity_header_values(headers: &HeaderMap) -> Result<(), SigV4Error> {
+    for name in headers.keys() {
+        let name = name.as_str();
+        if !requires_signed_header_integrity(name) {
+            continue;
+        }
+        let mut values = headers.get_all(name).iter();
+        let Some(value) = values.next() else {
+            continue;
+        };
+        if values.next().is_some() {
+            return Err(SigV4Error::InvalidSignedHeaders);
+        }
+        let value =
+            std::str::from_utf8(value.as_bytes()).map_err(|_| SigV4Error::InvalidSignedHeaders)?;
+        if !is_trim_all_canonical(value) {
+            return Err(SigV4Error::InvalidSignedHeaders);
+        }
+    }
+    Ok(())
+}
+
+fn is_trim_all_canonical(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.contains(&b'\t')
+        && !bytes.first().is_some_and(|byte| *byte == b' ')
+        && !bytes.last().is_some_and(|byte| *byte == b' ')
+        && !bytes.windows(2).any(|pair| pair == b"  ")
 }
 
 fn collect_signed_header_values(
@@ -765,7 +808,11 @@ mod tests {
     const SECRET: &str = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
     const DATE: &str = "20260819T120000Z";
 
-    fn signed_request(uri: &str, region: &str) -> (Uri, HeaderMap, SystemTime) {
+    fn signed_request(
+        uri: &str,
+        region: &str,
+        extra_headers: &[(&'static str, &str)],
+    ) -> (Uri, HeaderMap, SystemTime) {
         let time = parse_timestamp(DATE).unwrap();
         let mut settings = SigningSettings::default();
         settings.percent_encoding_mode = PercentEncodingMode::Single;
@@ -785,7 +832,7 @@ mod tests {
         let request = SignableRequest::new(
             Method::PUT.as_str(),
             uri,
-            std::iter::empty(),
+            extra_headers.iter().copied(),
             SignableBody::Bytes(b"payload"),
         )
         .unwrap();
@@ -796,6 +843,11 @@ mod tests {
             .uri(uri.clone())
             .body(())
             .unwrap();
+        for &(name, value) in extra_headers {
+            request
+                .headers_mut()
+                .append(name, HeaderValue::from_str(value).unwrap());
+        }
         instructions.apply_to_request_http1x(&mut request);
         request.headers_mut().insert(
             "host",
@@ -804,7 +856,10 @@ mod tests {
         (uri, request.into_parts().0.headers, time)
     }
 
-    fn presigned_request(uri: &str) -> (Uri, HeaderMap, SystemTime) {
+    fn presigned_request(
+        uri: &str,
+        extra_headers: &[(&'static str, &str)],
+    ) -> (Uri, HeaderMap, SystemTime) {
         let time = parse_timestamp(DATE).unwrap();
         let mut settings = SigningSettings::default();
         settings.percent_encoding_mode = PercentEncodingMode::Single;
@@ -825,7 +880,7 @@ mod tests {
         let request = SignableRequest::new(
             Method::GET.as_str(),
             uri,
-            std::iter::empty(),
+            extra_headers.iter().copied(),
             SignableBody::UnsignedPayload,
         )
         .unwrap();
@@ -835,6 +890,11 @@ mod tests {
             .uri(uri)
             .body(())
             .unwrap();
+        for &(name, value) in extra_headers {
+            request
+                .headers_mut()
+                .append(name, HeaderValue::from_str(value).unwrap());
+        }
         instructions.apply_to_request_http1x(&mut request);
         let authority = request.uri().authority().unwrap().as_str().to_string();
         request
@@ -864,7 +924,7 @@ mod tests {
             "http://s4.local/bucket/a%20b//c?z=last&a=first",
             "http://s4.local/bucket/%E2%98%83?empty=&repeat=b&repeat=a",
         ] {
-            let (uri, headers, time) = signed_request(uri, "us-east-1");
+            let (uri, headers, time) = signed_request(uri, "us-east-1", &[]);
             let auth = RequestAuthorization::parse(&uri, &headers)
                 .unwrap()
                 .unwrap();
@@ -883,7 +943,7 @@ mod tests {
 
     #[test]
     fn rejects_wrong_scope_skew_and_duplicate_or_unsorted_headers() {
-        let (uri, headers, time) = signed_request("http://s4.local/bucket/key", "eu-west-1");
+        let (uri, headers, time) = signed_request("http://s4.local/bucket/key", "eu-west-1", &[]);
         let auth = RequestAuthorization::parse(&uri, &headers)
             .unwrap()
             .unwrap();
@@ -902,7 +962,7 @@ mod tests {
             SigV4Error::InvalidScope
         );
 
-        let (uri, headers, time) = signed_request("http://s4.local/bucket/key", "us-east-1");
+        let (uri, headers, time) = signed_request("http://s4.local/bucket/key", "us-east-1", &[]);
         let auth = RequestAuthorization::parse(&uri, &headers)
             .unwrap()
             .unwrap();
@@ -928,6 +988,383 @@ mod tests {
             parse_signed_headers("x-amz-date;host"),
             Err(SigV4Error::InvalidSignedHeaders)
         );
+    }
+
+    #[test]
+    fn requires_every_present_semantic_and_amz_header_to_be_signed() {
+        let protected_headers = [
+            ("x-s4-storage-mode", "managed"),
+            ("x-s4-backend-url", "https://storage.example/object"),
+            ("x-s4-process", "read"),
+            ("x-s4-stable-fields", "email"),
+            ("content-type", "text/plain"),
+            ("content-encoding", "identity"),
+            ("content-md5", "CY9rzUYh03PK3k6DJie09g=="),
+            ("x-amz-meta-dynamic-name", "metadata"),
+        ];
+
+        for location in [
+            Location::Header,
+            Location::Query {
+                expires: Duration::ZERO,
+            },
+        ] {
+            let mut baseline_headers = HeaderMap::new();
+            baseline_headers.insert("host", HeaderValue::from_static("s4.local"));
+            let mut baseline_signed = vec!["host".to_string()];
+            if location == Location::Header {
+                baseline_headers.insert("x-amz-date", HeaderValue::from_static(DATE));
+                baseline_headers.insert(
+                    "x-amz-content-sha256",
+                    HeaderValue::from_static(
+                        "239f59ed55e737c77147cf55ad0c1b030b6d7ee748a7426952f9b852d5a935e5",
+                    ),
+                );
+                baseline_signed
+                    .extend(["x-amz-content-sha256".to_string(), "x-amz-date".to_string()]);
+            }
+            assert_eq!(
+                validate_signed_headers(&baseline_signed, location, &baseline_headers),
+                Ok(()),
+                "absent optional headers remain valid for {location:?}"
+            );
+
+            for (name, value) in protected_headers {
+                let mut headers = baseline_headers.clone();
+                headers.insert(name, HeaderValue::from_static(value));
+                assert_eq!(
+                    validate_signed_headers(&baseline_signed, location, &headers),
+                    Err(SigV4Error::InvalidSignedHeaders),
+                    "unsigned {name} must be rejected for {location:?}"
+                );
+
+                let mut signed = baseline_signed.clone();
+                signed.push(name.to_string());
+                signed.sort_unstable();
+                assert_eq!(
+                    validate_signed_headers(&signed, location, &headers),
+                    Ok(()),
+                    "signed {name} must be accepted for {location:?}"
+                );
+            }
+        }
+
+        let mut query_headers = HeaderMap::new();
+        query_headers.insert("host", HeaderValue::from_static("s4.local"));
+        query_headers.insert(
+            "x-amz-content-sha256",
+            HeaderValue::from_static("UNSIGNED-PAYLOAD"),
+        );
+        assert_eq!(
+            validate_signed_headers(
+                &["host".to_string()],
+                Location::Query {
+                    expires: Duration::ZERO,
+                },
+                &query_headers,
+            ),
+            Err(SigV4Error::InvalidSignedHeaders)
+        );
+    }
+
+    #[test]
+    fn integrity_header_values_must_be_unique_utf8_and_trim_all_canonical() {
+        let canonical_values = [
+            ("x-s4-storage-mode", "managed"),
+            ("x-s4-backend-url", "https://storage.example/object"),
+            ("x-s4-process", "read"),
+            ("x-s4-stable-fields", "email, account_id"),
+            ("content-type", "text/plain; charset=utf-8"),
+            ("content-encoding", "aws-chunked"),
+            ("content-md5", "CY9rzUYh03PK3k6DJie09g=="),
+            ("x-amz-meta-project", "project one"),
+            ("x-amz-tagging", "project=one&owner=two"),
+            ("x-amz-checksum-sha256", "checksum"),
+            ("x-amz-trailer", "x-amz-checksum-sha256"),
+            ("x-amz-decoded-content-length", "123"),
+            ("x-amz-security-token", "token"),
+            (
+                "x-amz-content-sha256",
+                "239f59ed55e737c77147cf55ad0c1b030b6d7ee748a7426952f9b852d5a935e5",
+            ),
+            ("x-amz-date", DATE),
+            ("x-amz-future-semantics", "future value"),
+        ];
+        for (name, value) in canonical_values {
+            let mut headers = HeaderMap::new();
+            headers.insert("host", HeaderValue::from_static("s4.local"));
+            headers.insert("x-amz-date", HeaderValue::from_static(DATE));
+            headers.insert(
+                "x-amz-content-sha256",
+                HeaderValue::from_static(
+                    "239f59ed55e737c77147cf55ad0c1b030b6d7ee748a7426952f9b852d5a935e5",
+                ),
+            );
+            headers.insert(name, HeaderValue::from_static(value));
+            let mut signed = vec![
+                "host".to_string(),
+                "x-amz-content-sha256".to_string(),
+                "x-amz-date".to_string(),
+            ];
+            if !signed.iter().any(|signed| signed == name) {
+                signed.push(name.to_string());
+            }
+            signed.sort_unstable();
+            assert_eq!(
+                validate_signed_headers(&signed, Location::Header, &headers),
+                Ok(()),
+                "canonical {name} must remain accepted"
+            );
+
+            headers.append(name, HeaderValue::from_static(value));
+            assert_eq!(
+                validate_signed_headers(&signed, Location::Header, &headers),
+                Err(SigV4Error::InvalidSignedHeaders),
+                "duplicate {name} must be rejected"
+            );
+        }
+
+        let mut invalid_utf8 = HeaderMap::new();
+        invalid_utf8.insert("host", HeaderValue::from_static("s4.local"));
+        invalid_utf8.insert(
+            "x-amz-meta-project",
+            HeaderValue::from_bytes(&[0xff]).unwrap(),
+        );
+        assert_eq!(
+            validate_signed_headers(
+                &["host".to_string(), "x-amz-meta-project".to_string()],
+                Location::Query {
+                    expires: Duration::ZERO,
+                },
+                &invalid_utf8,
+            ),
+            Err(SigV4Error::InvalidSignedHeaders)
+        );
+
+        let mut excluded_amz = HeaderMap::new();
+        excluded_amz.insert("host", HeaderValue::from_static("s4.local"));
+        excluded_amz.append("x-amz-user-agent", HeaderValue::from_static(" agent "));
+        excluded_amz.append("x-amz-user-agent", HeaderValue::from_static("second"));
+        excluded_amz.append("x-amz-checksum-mode", HeaderValue::from_static(" ENABLED "));
+        excluded_amz.append("x-amz-checksum-mode", HeaderValue::from_static("second"));
+        assert_eq!(
+            validate_signed_headers(
+                &["host".to_string()],
+                Location::Query {
+                    expires: Duration::ZERO,
+                },
+                &excluded_amz,
+            ),
+            Ok(()),
+            "the pinned signer exclusions remain unsigned and value-unconstrained"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_integrity_headers_even_when_joined_value_matches_the_signature() {
+        for (name, combined, first, second) in [
+            (
+                "x-s4-stable-fields",
+                "email,account_id",
+                "email",
+                "account_id",
+            ),
+            (
+                "x-s4-backend-url",
+                "https://storage.example/one,https://storage.example/two",
+                "https://storage.example/one",
+                "https://storage.example/two",
+            ),
+            (
+                "content-type",
+                "text/plain;charset=utf-8",
+                "text/plain",
+                "charset=utf-8",
+            ),
+            ("x-amz-meta-project", "one,two", "one", "two"),
+        ] {
+            let (uri, headers, time) = signed_request(
+                "http://s4.local/bucket/duplicate",
+                "us-east-1",
+                &[(name, combined)],
+            );
+            let authorization = RequestAuthorization::parse(&uri, &headers)
+                .unwrap()
+                .unwrap();
+            authorization
+                .authorize(
+                    "PUT",
+                    &uri,
+                    &headers,
+                    SECRET,
+                    &SigningKeyCache::standard(),
+                    &SigV4Policy::new("us-east-1", false),
+                    time,
+                )
+                .unwrap();
+
+            let mut duplicated = headers.clone();
+            duplicated.remove(name);
+            duplicated.append(name, HeaderValue::from_static(first));
+            duplicated.append(name, HeaderValue::from_static(second));
+            assert_eq!(
+                authorization
+                    .authorize(
+                        "PUT",
+                        &uri,
+                        &duplicated,
+                        SECRET,
+                        &SigningKeyCache::standard(),
+                        &SigV4Policy::new("us-east-1", false),
+                        time,
+                    )
+                    .err()
+                    .unwrap(),
+                SigV4Error::InvalidSignedHeaders,
+                "comma-equivalent duplicate {name} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_signed_trim_all_variants_and_accepts_canonical_single_spaces() {
+        for (name, raw) in [
+            ("x-s4-stable-fields", " email"),
+            ("x-s4-stable-fields", "email "),
+            ("x-s4-backend-url", "\thttps://storage.example/object"),
+            ("content-type", "text/plain;  charset=utf-8"),
+            ("content-md5", "CY9rzUYh03PK3k6DJie09g==\t"),
+            ("x-amz-tagging", " project=one&owner=two"),
+        ] {
+            let (uri, headers, time) = signed_request(
+                "http://s4.local/bucket/noncanonical",
+                "us-east-1",
+                &[(name, raw)],
+            );
+            let authorization = RequestAuthorization::parse(&uri, &headers)
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                authorization
+                    .authorize(
+                        "PUT",
+                        &uri,
+                        &headers,
+                        SECRET,
+                        &SigningKeyCache::standard(),
+                        &SigV4Policy::new("us-east-1", false),
+                        time,
+                    )
+                    .err()
+                    .unwrap(),
+                SigV4Error::InvalidSignedHeaders,
+                "noncanonical {name} value {raw:?} must be rejected"
+            );
+        }
+
+        for (name, canonical) in [
+            ("x-s4-stable-fields", "email, account_id"),
+            ("x-s4-backend-url", "https://storage.example/object"),
+            ("content-type", "text/plain; charset=utf-8"),
+            ("content-md5", "CY9rzUYh03PK3k6DJie09g=="),
+            ("x-amz-meta-project", "project one"),
+        ] {
+            let (uri, headers, time) = signed_request(
+                "http://s4.local/bucket/canonical",
+                "us-east-1",
+                &[(name, canonical)],
+            );
+            RequestAuthorization::parse(&uri, &headers)
+                .unwrap()
+                .unwrap()
+                .authorize(
+                    "PUT",
+                    &uri,
+                    &headers,
+                    SECRET,
+                    &SigningKeyCache::standard(),
+                    &SigV4Policy::new("us-east-1", false),
+                    time,
+                )
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn signed_integrity_values_are_cryptographically_bound_and_required() {
+        for (name, value, mutation) in [
+            (
+                "x-s4-backend-url",
+                "https://one.example/object",
+                "https://two.example/object",
+            ),
+            ("x-s4-stable-fields", "email", "account_id"),
+            ("content-type", "text/plain", "application/json"),
+            (
+                "content-md5",
+                "CY9rzUYh03PK3k6DJie09g==",
+                "AAAAAAAAAAAAAAAAAAAAAA==",
+            ),
+            ("x-amz-meta-dynamic-name", "one", "two"),
+        ] {
+            let (uri, headers, time) = signed_request(
+                "http://s4.local/bucket/semantic",
+                "us-east-1",
+                &[(name, value)],
+            );
+            let authorization = RequestAuthorization::parse(&uri, &headers)
+                .unwrap()
+                .unwrap();
+            authorization
+                .authorize(
+                    "PUT",
+                    &uri,
+                    &headers,
+                    SECRET,
+                    &SigningKeyCache::standard(),
+                    &SigV4Policy::new("us-east-1", false),
+                    time,
+                )
+                .unwrap();
+
+            let mut mutated = headers.clone();
+            mutated.insert(name, HeaderValue::from_static(mutation));
+            assert_eq!(
+                authorization
+                    .authorize(
+                        "PUT",
+                        &uri,
+                        &mutated,
+                        SECRET,
+                        &SigningKeyCache::standard(),
+                        &SigV4Policy::new("us-east-1", false),
+                        time,
+                    )
+                    .err()
+                    .unwrap(),
+                SigV4Error::SignatureMismatch,
+                "mutated {name} must fail signature verification"
+            );
+
+            let mut removed = headers.clone();
+            removed.remove(name);
+            assert_eq!(
+                authorization
+                    .authorize(
+                        "PUT",
+                        &uri,
+                        &removed,
+                        SECRET,
+                        &SigningKeyCache::standard(),
+                        &SigV4Policy::new("us-east-1", false),
+                        time,
+                    )
+                    .err()
+                    .unwrap(),
+                SigV4Error::MissingHeader("signed header"),
+                "removed {name} must be rejected"
+            );
+        }
     }
 
     #[test]
@@ -959,10 +1396,12 @@ mod tests {
 
     #[test]
     fn accepts_sdk_generated_presign_and_rejects_expiry_replay() {
-        let (uri, headers, time) = presigned_request("https://s4.local/bucket/a%20b?versionId=one");
+        let (uri, headers, time) =
+            presigned_request("https://s4.local/bucket/a%20b?versionId=one", &[]);
         let authorization = RequestAuthorization::parse(&uri, &headers)
             .unwrap()
             .unwrap();
+        assert_eq!(authorization.signed_headers, vec!["host".to_string()]);
         authorization
             .authorize(
                 "GET",
@@ -991,6 +1430,38 @@ mod tests {
                 .unwrap(),
             SigV4Error::Expired
         );
+    }
+
+    #[test]
+    fn presign_rejects_headers_appended_after_host_only_signing() {
+        let (uri, headers, time) = presigned_request("https://s4.local/bucket/object", &[]);
+        let authorization = RequestAuthorization::parse(&uri, &headers)
+            .unwrap()
+            .unwrap();
+        for (name, value) in [
+            ("x-s4-process", "read"),
+            ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
+            ("x-amz-meta-dynamic-name", "metadata"),
+        ] {
+            let mut appended = headers.clone();
+            appended.insert(name, HeaderValue::from_static(value));
+            assert_eq!(
+                authorization
+                    .authorize(
+                        "GET",
+                        &uri,
+                        &appended,
+                        SECRET,
+                        &SigningKeyCache::standard(),
+                        &SigV4Policy::new("us-east-1", false),
+                        time,
+                    )
+                    .err()
+                    .unwrap(),
+                SigV4Error::InvalidSignedHeaders,
+                "appended {name} must be rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/gateway/tests/s3_frontdoor_test.rs
+++ b/crates/gateway/tests/s3_frontdoor_test.rs
@@ -2316,6 +2316,7 @@ fn signed_request(
     method: &str,
     uri: &str,
     body: &[u8],
+    headers: &[(&'static str, &str)],
 ) -> Request<Body> {
     use aws_credential_types::Credentials;
     use aws_sigv4::http_request::{
@@ -2342,16 +2343,24 @@ fn signed_request(
         .unwrap()
         .into();
 
-    let signable =
-        SignableRequest::new(method, uri, std::iter::empty(), SignableBody::Bytes(body)).unwrap();
-    let output = sign(signable, &params).unwrap();
-    let instructions = output.into_parts().0;
-
     let mut req = Request::builder()
         .method(method)
         .uri(uri)
         .body(Body::from(body.to_vec()))
         .unwrap();
+    for &(name, value) in headers {
+        req.headers_mut().append(name, value.parse().unwrap());
+    }
+    let signable = SignableRequest::new(
+        method,
+        uri,
+        req.headers()
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.to_str().unwrap())),
+        SignableBody::Bytes(body),
+    )
+    .unwrap();
+    let instructions = sign(signable, &params).unwrap().into_parts().0;
     instructions.apply_to_request_http1x(&mut req);
     // The signer covered `host`; the outgoing request must carry it too.
     let authority = req
@@ -2364,14 +2373,66 @@ fn signed_request(
     req
 }
 
-/// Streaming PUT requires an explicit Content-Type (it is not part of the
-/// SigV4 SignedHeaders, so injecting it after signing is safe).
-fn with_content_type(request: Request<Body>, content_type: &str) -> Request<Body> {
-    let (mut parts, body) = request.into_parts();
-    parts
-        .headers
-        .insert(header::CONTENT_TYPE, content_type.parse().unwrap());
-    Request::from_parts(parts, body)
+fn presigned_request(
+    access_key: &str,
+    secret: &str,
+    method: &str,
+    uri: &str,
+    headers: &[(&'static str, &str)],
+) -> Request<Body> {
+    use aws_credential_types::Credentials;
+    use aws_sigv4::http_request::{
+        PercentEncodingMode, SignableBody, SignableRequest, SignatureLocation, SigningParams,
+        SigningSettings, UriPathNormalizationMode, sign,
+    };
+    use aws_sigv4::sign::v4;
+    use std::time::SystemTime;
+
+    let mut settings = SigningSettings::default();
+    settings.percent_encoding_mode = PercentEncodingMode::Single;
+    settings.uri_path_normalization_mode = UriPathNormalizationMode::Disabled;
+    settings.signature_location = SignatureLocation::QueryParams;
+    settings.expires_in = Some(Duration::from_secs(300));
+
+    let identity: aws_smithy_runtime_api::client::identity::Identity =
+        Credentials::new(access_key, secret, None, None, "test").into();
+    let params: SigningParams = v4::SigningParams::builder()
+        .identity(&identity)
+        .region("us-east-1")
+        .name("s3")
+        .time(SystemTime::now())
+        .settings(settings)
+        .build()
+        .unwrap()
+        .into();
+
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    for &(name, value) in headers {
+        req.headers_mut().append(name, value.parse().unwrap());
+    }
+    let signable = SignableRequest::new(
+        method,
+        uri,
+        req.headers()
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.to_str().unwrap())),
+        SignableBody::UnsignedPayload,
+    )
+    .unwrap();
+    let instructions = sign(signable, &params).unwrap().into_parts().0;
+    instructions.apply_to_request_http1x(&mut req);
+    let authority = req
+        .uri()
+        .authority()
+        .expect("absolute uri")
+        .as_str()
+        .to_string();
+    req.headers_mut().insert("host", authority.parse().unwrap());
+    req
 }
 
 #[tokio::test]
@@ -2381,9 +2442,13 @@ async fn sigv4_signed_request_accepted_and_rejected() {
     let uri = "http://s4.local/demo/signed.txt";
 
     // Correct signature → 200.
-    let req = with_content_type(
-        signed_request(&ak, &sk, "PUT", uri, b"hello world"),
-        "text/plain",
+    let req = signed_request(
+        &ak,
+        &sk,
+        "PUT",
+        uri,
+        b"hello world",
+        &[("content-type", "text/plain")],
     );
     let resp = app.clone().oneshot(req).await.unwrap();
     let status = resp.status();
@@ -2396,7 +2461,7 @@ async fn sigv4_signed_request_accepted_and_rejected() {
     assert_eq!(status, StatusCode::OK, "valid SigV4 should pass");
 
     // Wrong secret → 403.
-    let req = signed_request(&ak, "not-the-secret", "PUT", uri, b"hello world");
+    let req = signed_request(&ak, "not-the-secret", "PUT", uri, b"hello world", &[]);
     let resp = app.clone().oneshot(req).await.unwrap();
     assert_eq!(
         resp.status(),
@@ -2405,13 +2470,372 @@ async fn sigv4_signed_request_accepted_and_rejected() {
     );
 
     // Unknown access key → 403.
-    let req = signed_request("s4_unknown", &sk, "PUT", uri, b"hello world");
+    let req = signed_request("s4_unknown", &sk, "PUT", uri, b"hello world", &[]);
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(
         resp.status(),
         StatusCode::FORBIDDEN,
         "unknown key must fail"
     );
+}
+
+#[tokio::test]
+async fn sigv4_signed_semantic_headers_accept_and_detect_mutation_or_removal() {
+    enum HeaderChange {
+        None,
+        Replace(&'static str, &'static str),
+        Remove(&'static str),
+    }
+
+    let (app, state) = router().await;
+    let (access_key, secret_key) = make_key(&state).await;
+    for (index, (name, change, expected)) in [
+        ("unchanged", HeaderChange::None, StatusCode::OK),
+        (
+            "mutated content type",
+            HeaderChange::Replace("content-type", "application/json"),
+            StatusCode::FORBIDDEN,
+        ),
+        (
+            "removed content type",
+            HeaderChange::Remove("content-type"),
+            StatusCode::FORBIDDEN,
+        ),
+        (
+            "mutated dynamic metadata",
+            HeaderChange::Replace("x-amz-meta-dynamic-name", "two"),
+            StatusCode::FORBIDDEN,
+        ),
+        (
+            "removed S4 semantic header",
+            HeaderChange::Remove("x-s4-process"),
+            StatusCode::FORBIDDEN,
+        ),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let uri = format!("http://s4.local/semantic/signed-{index}.txt");
+        let request = signed_request(
+            &access_key,
+            &secret_key,
+            "PUT",
+            &uri,
+            b"semantic body",
+            &[
+                ("content-type", "text/plain"),
+                ("x-s4-process", "write"),
+                ("x-amz-meta-dynamic-name", "one"),
+            ],
+        );
+        let (mut parts, body) = request.into_parts();
+        match change {
+            HeaderChange::None => {}
+            HeaderChange::Replace(header, value) => {
+                parts.headers.insert(header, value.parse().unwrap());
+            }
+            HeaderChange::Remove(header) => {
+                parts.headers.remove(header);
+            }
+        }
+        let response = app
+            .clone()
+            .oneshot(Request::from_parts(parts, body))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), expected, "{name}");
+        if expected == StatusCode::FORBIDDEN {
+            let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            assert!(
+                String::from_utf8_lossy(&body).contains("<Code>SignatureDoesNotMatch</Code>"),
+                "{name}: {}",
+                String::from_utf8_lossy(&body)
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn sigv4_rejects_ambiguous_or_noncanonical_integrity_headers_before_body_polling() {
+    enum HeaderShape {
+        Raw(&'static str),
+        Duplicate {
+            signed: &'static str,
+            first: &'static str,
+            second: &'static str,
+        },
+    }
+
+    let (app, state) = router().await;
+    let (access_key, secret_key) = make_key(&state).await;
+    for (index, (name, shape)) in [
+        (
+            "x-s4-stable-fields",
+            HeaderShape::Duplicate {
+                signed: "email,account_id",
+                first: "email",
+                second: "account_id",
+            },
+        ),
+        (
+            "x-s4-backend-url",
+            HeaderShape::Duplicate {
+                signed: "https://storage.example/one,https://storage.example/two",
+                first: "https://storage.example/one",
+                second: "https://storage.example/two",
+            },
+        ),
+        (
+            "content-type",
+            HeaderShape::Duplicate {
+                signed: "text/plain;charset=utf-8",
+                first: "text/plain",
+                second: "charset=utf-8",
+            },
+        ),
+        (
+            "x-amz-meta-project",
+            HeaderShape::Duplicate {
+                signed: "one,two",
+                first: "one",
+                second: "two",
+            },
+        ),
+        ("x-s4-stable-fields", HeaderShape::Raw(" email, account_id")),
+        ("x-s4-stable-fields", HeaderShape::Raw("email, account_id ")),
+        (
+            "x-s4-backend-url",
+            HeaderShape::Raw("\thttps://storage.example/object"),
+        ),
+        (
+            "content-type",
+            HeaderShape::Raw("text/plain;  charset=utf-8"),
+        ),
+        (
+            "content-md5",
+            HeaderShape::Raw("CY9rzUYh03PK3k6DJie09g==\t"),
+        ),
+        ("x-amz-tagging", HeaderShape::Raw(" project=one&owner=two")),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let signed_value = match &shape {
+            HeaderShape::Raw(value) => *value,
+            HeaderShape::Duplicate { signed, .. } => *signed,
+        };
+        let mut signed_headers = Vec::with_capacity(2);
+        if name != "content-type" {
+            signed_headers.push(("content-type", "text/plain"));
+        }
+        signed_headers.push((name, signed_value));
+        let uri = format!("http://s4.local/semantic/shape-{index}.txt");
+        let request = signed_request(
+            &access_key,
+            &secret_key,
+            "PUT",
+            &uri,
+            b"must not be polled",
+            &signed_headers,
+        );
+        let (mut parts, _) = request.into_parts();
+        if let HeaderShape::Duplicate { first, second, .. } = shape {
+            parts.headers.remove(name);
+            parts.headers.append(name, first.parse().unwrap());
+            parts.headers.append(name, second.parse().unwrap());
+        }
+        let polls = Arc::new(AtomicUsize::new(0));
+        let request = Request::from_parts(
+            parts,
+            Body::new(PollTrackingBody {
+                polls: polls.clone(),
+                data: Some(Bytes::from_static(b"must not be polled")),
+            }),
+        );
+
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN, "{name}");
+        assert_eq!(polls.load(Ordering::SeqCst), 0, "{name}");
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&body).contains("<Code>SignatureDoesNotMatch</Code>"),
+            "{name}: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+}
+
+#[tokio::test]
+async fn sigv4_rejects_unsigned_integrity_header_injection_before_polling_the_body() {
+    let (app, state) = router().await;
+    let (access_key, secret_key) = make_key(&state).await;
+    for (index, (name, value)) in [
+        ("x-s4-storage-mode", "managed"),
+        ("x-s4-backend-url", "https://storage.example/object"),
+        ("x-s4-process", "read"),
+        ("x-s4-stable-fields", "email"),
+        ("content-type", "text/plain"),
+        ("content-encoding", "gzip"),
+        ("content-md5", "CY9rzUYh03PK3k6DJie09g=="),
+        ("x-amz-meta-dynamic-name", "metadata"),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let uri = format!("http://s4.local/semantic/unsigned-{index}.txt");
+        let request = signed_request(
+            &access_key,
+            &secret_key,
+            "PUT",
+            &uri,
+            b"must not be polled",
+            &[],
+        );
+        let (mut parts, _) = request.into_parts();
+        parts.headers.insert(name, value.parse().unwrap());
+        let polls = Arc::new(AtomicUsize::new(0));
+        let request = Request::from_parts(
+            parts,
+            Body::new(PollTrackingBody {
+                polls: polls.clone(),
+                data: Some(Bytes::from_static(b"must not be polled")),
+            }),
+        );
+
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN, "{name}");
+        assert_eq!(polls.load(Ordering::SeqCst), 0, "{name}");
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&body).contains("<Code>SignatureDoesNotMatch</Code>"),
+            "{name}: {}",
+            String::from_utf8_lossy(&body)
+        );
+        assert!(
+            String::from_utf8_lossy(&body).contains(
+                "The request signature we calculated does not match the signature you provided."
+            ),
+            "{name} must use the generic 403 message"
+        );
+        assert!(
+            !String::from_utf8_lossy(&body).contains(name),
+            "{name} must not be disclosed by the generic rejection"
+        );
+    }
+}
+
+#[tokio::test]
+async fn presigned_host_only_get_accepts_but_appended_protected_headers_are_rejected() {
+    let (app, state) = router().await;
+    let (access_key, secret_key) = make_key(&state).await;
+    state.store.put(
+        "presigned",
+        "object.txt",
+        Bytes::from_static(b"presigned body"),
+        "text/plain",
+    );
+    let uri = "https://s4.local/presigned/object.txt";
+
+    let response = app
+        .clone()
+        .oneshot(presigned_request(&access_key, &secret_key, "GET", uri, &[]))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+        "presigned body"
+    );
+
+    for (name, value) in [
+        ("x-amz-user-agent", "unsigned-agent"),
+        ("x-amz-checksum-mode", "ENABLED"),
+    ] {
+        let request = presigned_request(&access_key, &secret_key, "GET", uri, &[]);
+        let (mut parts, body) = request.into_parts();
+        parts.headers.insert(name, value.parse().unwrap());
+        let response = app
+            .clone()
+            .oneshot(Request::from_parts(parts, body))
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "unsigned signer exclusion {name}"
+        );
+    }
+
+    let response = app
+        .clone()
+        .oneshot(presigned_request(
+            &access_key,
+            &secret_key,
+            "GET",
+            uri,
+            &[("x-amz-meta-dynamic-name", "signed")],
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    for (name, value) in [
+        ("x-s4-process", "read"),
+        ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
+        ("x-amz-meta-dynamic-name", "appended"),
+        ("x-amz-tagging", "project=appended"),
+    ] {
+        let request = presigned_request(&access_key, &secret_key, "GET", uri, &[]);
+        let (mut parts, body) = request.into_parts();
+        parts.headers.insert(name, value.parse().unwrap());
+        let response = app
+            .clone()
+            .oneshot(Request::from_parts(parts, body))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN, "{name}");
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&body).contains("<Code>SignatureDoesNotMatch</Code>"),
+            "{name}: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+}
+
+#[tokio::test]
+async fn non_sigv4_api_key_auth_keeps_raw_semantic_header_behavior() {
+    let (app, state) = router().await;
+    let (access_key, secret_key) = make_key(&state).await;
+    let request = append_headers(
+        add_headers(
+            Request::builder()
+                .method("PUT")
+                .uri("/semantic/api-key.txt")
+                .header(header::CONTENT_TYPE, "text/plain")
+                .header("x-amz-meta-dynamic-name", "metadata")
+                .body(Body::from("API key body"))
+                .unwrap(),
+            &auth_headers(&access_key, &secret_key),
+        ),
+        &[
+            ("x-s4-process", " write ".to_string()),
+            ("x-s4-process", "read".to_string()),
+        ],
+    );
+
+    assert_eq!(app.oneshot(request).await.unwrap().status(), StatusCode::OK);
+    assert!(state.store.get("semantic", "api-key.txt").is_some());
 }
 
 #[tokio::test]
@@ -2425,11 +2849,15 @@ async fn streaming_sigv4_hash_is_checked_before_atomic_commit() {
     let uri = "http://s4.local/stream/signed-stream.txt";
     let input = b"contact a@b.com now\n";
 
-    let request = signed_request(&access_key, &secret_key, "PUT", uri, input);
-    let (mut parts, _) = request.into_parts();
-    parts
-        .headers
-        .insert(header::CONTENT_TYPE, "text/plain".parse().unwrap());
+    let request = signed_request(
+        &access_key,
+        &secret_key,
+        "PUT",
+        uri,
+        input,
+        &[("content-type", "text/plain")],
+    );
+    let (parts, _) = request.into_parts();
     let request = Request::from_parts(
         parts,
         Body::new(FrameSequenceBody::data([
@@ -2451,11 +2879,15 @@ async fn streaming_sigv4_hash_is_checked_before_atomic_commit() {
     );
 
     let bad_uri = "http://s4.local/stream/tampered-stream.txt";
-    let request = signed_request(&access_key, &secret_key, "PUT", bad_uri, input);
-    let (mut parts, _) = request.into_parts();
-    parts
-        .headers
-        .insert(header::CONTENT_TYPE, "text/plain".parse().unwrap());
+    let request = signed_request(
+        &access_key,
+        &secret_key,
+        "PUT",
+        bad_uri,
+        input,
+        &[("content-type", "text/plain")],
+    );
+    let (parts, _) = request.into_parts();
     let request = Request::from_parts(parts, Body::from("tampered body\n"));
     let response = app.oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
@@ -2469,15 +2901,19 @@ async fn sigv4_get_object_roundtrip() {
 
     // PUT via SigV4.
     let uri = "http://s4.local/bkt/signed.txt";
-    let req = with_content_type(
-        signed_request(&ak, &sk, "PUT", uri, b"content a@b.com"),
-        "text/plain",
+    let req = signed_request(
+        &ak,
+        &sk,
+        "PUT",
+        uri,
+        b"content a@b.com",
+        &[("content-type", "text/plain")],
     );
     let resp = app.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 
     // GET via SigV4 returns the filtered object.
-    let req = signed_request(&ak, &sk, "GET", uri, b"");
+    let req = signed_request(&ak, &sk, "GET", uri, b"", &[]);
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
@@ -2638,11 +3074,15 @@ async fn sigv4_tampered_body_rejected() {
     let uri = "http://s4.local/bkt/tamper.txt";
 
     // Sign body A, then send body B with the A-signature -> 403.
-    let req = with_content_type(signed_request(&ak, &sk, "PUT", uri, b"AAAA"), "text/plain");
-    let (mut parts, _old_body) = req.into_parts();
-    parts
-        .headers
-        .insert(header::CONTENT_TYPE, "text/plain".parse().unwrap());
+    let req = signed_request(
+        &ak,
+        &sk,
+        "PUT",
+        uri,
+        b"AAAA",
+        &[("content-type", "text/plain")],
+    );
+    let (parts, _old_body) = req.into_parts();
     let req = Request::from_parts(parts, Body::from("BBBB"));
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(
@@ -2657,7 +3097,7 @@ async fn invalid_sigv4_headers_are_rejected_without_polling_put_body() {
     let (app, state) = router().await;
     let (ak, _sk) = make_key(&state).await;
     let uri = "http://s4.local/bkt/unpolled.txt";
-    let signed = signed_request(&ak, "wrong-secret", "PUT", uri, b"sensitive body");
+    let signed = signed_request(&ak, "wrong-secret", "PUT", uri, b"sensitive body", &[]);
     let (parts, _) = signed.into_parts();
     let polls = Arc::new(AtomicUsize::new(0));
     let request = Request::from_parts(
@@ -2678,9 +3118,13 @@ async fn valid_sigv4_seed_polls_then_rejects_payload_hash_mismatch() {
     let (app, state) = router().await;
     let (ak, sk) = make_key(&state).await;
     let uri = "http://s4.local/bkt/hash-mismatch.txt";
-    let signed = with_content_type(
-        signed_request(&ak, &sk, "PUT", uri, b"claimed body"),
-        "text/plain",
+    let signed = signed_request(
+        &ak,
+        &sk,
+        "PUT",
+        uri,
+        b"claimed body",
+        &[("content-type", "text/plain")],
     );
     let (parts, _) = signed.into_parts();
     let polls = Arc::new(AtomicUsize::new(0));

--- a/docs/security.md
+++ b/docs/security.md
@@ -76,6 +76,23 @@ signature verification all complete before a request body is polled.
 - **Query auth (presigned)** — `X-Amz-*` query parameters; presigned requests
   without an explicit `x-amz-content-sha256` header default to
   `UNSIGNED-PAYLOAD`, which is only accepted over trusted TLS.
+- **Signed-header integrity** — `host` is always signed, and header auth also
+  requires signed `x-amz-date` and `x-amz-content-sha256`. In every SigV4 mode,
+  every present `x-amz-*` header except `x-amz-user-agent` and
+  `x-amz-checksum-mode`, plus each present request-semantic header
+  (`x-s4-storage-mode`, `x-s4-backend-url`, `x-s4-process`,
+  `x-s4-stable-fields`, `content-type`, `content-encoding`, and `content-md5`),
+  must appear in `SignedHeaders`, occur exactly once, contain valid UTF-8, and
+  already equal AWS SigV4 TrimAll form: no leading or trailing SP/HTAB and every
+  internal SP/HTAB run collapsed to one ASCII space. The gateway rejects rather
+  than rewrites noncanonical values, including comma-equivalent duplicates, so
+  metadata and tagging consumers observe the same sole canonical value that was
+  signed. The two exact exceptions are also exempt from duplicate and canonical
+  value enforcement because the pinned `aws-sigv4` presigner excludes them.
+  `x-amz-checksum-mode` is read-only response-integrity negotiation, not a
+  storage-selection or processing semantic. Optional headers may be absent, so
+  a normal host-only presigned GET remains valid; violations receive the generic
+  signature-mismatch response before the request body is read.
 - **Scope validation** — region (`S4_SIGV4_REGION`, default `us-east-1`),
   service (`s3`), and terminator (`aws4_request`) are enforced; the request
   timestamp must fall within the clock-skew window (15 minutes) and presigned


### PR DESCRIPTION
## Security impact
Every present behavior-changing S4 header and protected x-amz header must now be included in SigV4 SignedHeaders, appear exactly once, and already use canonical whitespace. This prevents intermediaries from changing storage, backend, processing, format, encryption-field, metadata, tagging, checksum, or payload semantics without invalidating the signature.

Absent optional headers remain valid. API-key, MCP, JWT, and local-auth paths are unchanged. Exact AWS signer exclusions remain for x-amz-user-agent and read-only x-amz-checksum-mode.

## Validation
- source rustfmt and locked metadata passed
- independent review approved after duplicate/whitespace/x-amz canonical-equivalence fixes
- no local compilation; GitHub CI is the runtime gate