### PR TITLE
fix(security): validate credential mutation inputs

### DIFF
--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -30,6 +30,8 @@ md-5.workspace = true
 aes-gcm.workspace = true
 rand.workspace = true
 zeroize.workspace = true
+rsa = { version = "0.9", default-features = false, features = ["pem", "sha2"] }
+x509-parser = "0.16"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tracing.workspace = true
@@ -59,14 +61,12 @@ libc = "0.2"
 proptest.workspace = true
 pollster = "0.4"
 tower = "0.5"
-rsa = { version = "0.9", default-features = false, features = ["pem", "sha2"] }
 sha2 = "0.10"
 sha1 = "0.10"
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }
 base64 = "0.22"
 rand_core = { version = "0.6", default-features = false }
 rand_chacha = { version = "0.3", default-features = false }
-x509-parser = "0.16"
 aes-siv = { version = "0.7", default-features = false, features = ["alloc"] }
 hmac = "0.12"
 wasmtime = "47"

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -17,7 +17,7 @@ use aws_sdk_s3::types::ChecksumMode;
 use aws_smithy_types::date_time::Format as DateTimeFormat;
 use axum::{
     Json, Router,
-    extract::{Path, Query, Request, State},
+    extract::{DefaultBodyLimit, Path, Query, Request, State},
     http::{HeaderMap, HeaderName, Method, StatusCode, Uri, header},
     response::{Html, IntoResponse},
     routing::{any, delete, get, head, post, put},
@@ -69,7 +69,9 @@ use crate::s3_safety::{S3Failure, record_s3_failure, s3_retry_config, s3_timeout
 use crate::service_storage::{ServiceStorage, parse_service_backends};
 use crate::sigv4::{RequestAuthorization, SigV4Error, SigV4Policy, SigningKeyCache};
 use crate::store::{
-    FileKeyStore, KeyRepository, KeyStore, MemoryStore, PostgresKeyStore, sha256_hash,
+    FileKeyStore, KeyRepository, KeyStore, MAX_PUBLIC_KEY_PEM_BYTES, MemoryStore, PostgresKeyStore,
+    canonicalize_credential_label, canonicalize_public_key_pem, sha256_hash,
+    validate_credential_ttl,
 };
 use crate::transaction::{
     AbortSignal, AwsS3TransactionBackend, BackendCapabilities, CompatibilitySpoolConfig,
@@ -245,6 +247,9 @@ const DEMO_MAX_CONCURRENCY: usize = 4;
 const DEMO_MAX_STARTS_PER_MINUTE: usize = 30;
 const DEMO_MAX_CUMULATIVE_FUEL: u64 = 50_000_000;
 const DEMO_MAX_WALL_TIME: Duration = Duration::from_secs(2);
+const SIMPLE_CREDENTIAL_MUTATION_BODY_BYTES: usize = 1024;
+const CREATE_KEY_BODY_BYTES: usize = MAX_PUBLIC_KEY_PEM_BYTES + 1024;
+const SET_PUBLIC_KEY_BODY_BYTES: usize = MAX_PUBLIC_KEY_PEM_BYTES + 512;
 
 #[derive(Clone)]
 struct DemoPipelines {
@@ -6149,6 +6154,10 @@ async fn health() -> impl IntoResponse {
     "ok"
 }
 
+fn invalid_credential_mutation_response() -> axum::response::Response {
+    (StatusCode::BAD_REQUEST, "invalid credential mutation").into_response()
+}
+
 /// List API keys for the authenticated user
 #[utoipa::path(
     get,
@@ -6193,9 +6202,25 @@ async fn create_key(
     let Some(uid) = require_user_id(&headers, &state).await else {
         return StatusCode::UNAUTHORIZED.into_response();
     };
+    let label = match canonicalize_credential_label(&body.label) {
+        Ok(label) => label,
+        Err(_) => return invalid_credential_mutation_response(),
+    };
+    if validate_credential_ttl(body.expires_in).is_err() {
+        return invalid_credential_mutation_response();
+    }
+    let public_key_pem = match body
+        .public_key_pem
+        .as_deref()
+        .map(canonicalize_public_key_pem)
+        .transpose()
+    {
+        Ok(public_key_pem) => public_key_pem,
+        Err(_) => return invalid_credential_mutation_response(),
+    };
     let result = state
         .keys
-        .create_key(&uid, &body.label, body.expires_in, body.public_key_pem)
+        .create_key(&uid, &label, body.expires_in, public_key_pem)
         .await;
     let (key_id, secret) = match result {
         Ok(created) => created,
@@ -6223,7 +6248,7 @@ async fn create_key(
     Json(ApiKeyResponse {
         key_id,
         secret,
-        label: body.label,
+        label,
         created_at,
         expires_at,
         public_key_pem,
@@ -6298,24 +6323,29 @@ async fn create_mcp_token(
     let Some(uid) = require_user_id(&headers, &state).await else {
         return StatusCode::UNAUTHORIZED.into_response();
     };
-    let token = state
+    let label = match canonicalize_credential_label(&body.label) {
+        Ok(label) => label,
+        Err(_) => return invalid_credential_mutation_response(),
+    };
+    if validate_credential_ttl(body.expires_in).is_err() {
+        return invalid_credential_mutation_response();
+    }
+    let (token, created) = match state
         .keys
-        .create_mcp_token(&uid, &body.label, body.expires_in)
-        .await;
-    let hash = sha256_hash(&token);
-    let created_at = state
-        .keys
-        .list_mcp_tokens(&uid)
+        .create_mcp_token(&uid, &label, body.expires_in)
         .await
-        .into_iter()
-        .find(|t| t.token_hash == hash)
-        .map(|t| t.created_at)
-        .unwrap_or_default();
+    {
+        Ok(created) => created,
+        Err(_) => {
+            tracing::error!(user_id = uid, "MCP token creation persistence failed");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
     Json(McpTokenCreatedResponse {
         token,
-        label: body.label,
-        created_at,
-        expires_at: None,
+        label,
+        created_at: created.created_at,
+        expires_at: created.expires_at,
     })
     .into_response()
 }
@@ -6557,9 +6587,13 @@ async fn set_public_key(
         }
         PublicKeyMutationActor::DashboardUser(user_id) => user_id,
     };
+    let public_key_pem = match canonicalize_public_key_pem(&body.public_key_pem) {
+        Ok(public_key_pem) => public_key_pem,
+        Err(_) => return invalid_credential_mutation_response(),
+    };
     match state
         .keys
-        .set_public_key(&body.key_id, &uid, &body.public_key_pem)
+        .set_public_key(&body.key_id, &uid, &public_key_pem)
         .await
     {
         Ok(true) => StatusCode::OK.into_response(),
@@ -7232,12 +7266,29 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/health", get(health))
         .route("/", get(root))
         .route("/dashboard/api/keys", get(get_keys))
-        .route("/dashboard/api/keys", post(create_key))
-        .route("/dashboard/api/keys", delete(delete_key))
-        .route("/dashboard/api/keys/public-key", put(set_public_key))
+        .route(
+            "/dashboard/api/keys",
+            post(create_key).layer(DefaultBodyLimit::max(CREATE_KEY_BODY_BYTES)),
+        )
+        .route(
+            "/dashboard/api/keys",
+            delete(delete_key).layer(DefaultBodyLimit::max(SIMPLE_CREDENTIAL_MUTATION_BODY_BYTES)),
+        )
+        .route(
+            "/dashboard/api/keys/public-key",
+            put(set_public_key).layer(DefaultBodyLimit::max(SET_PUBLIC_KEY_BODY_BYTES)),
+        )
         .route("/dashboard/api/mcp-tokens", get(get_mcp_tokens))
-        .route("/dashboard/api/mcp-tokens", post(create_mcp_token))
-        .route("/dashboard/api/mcp-tokens", delete(delete_mcp_token))
+        .route(
+            "/dashboard/api/mcp-tokens",
+            post(create_mcp_token)
+                .layer(DefaultBodyLimit::max(SIMPLE_CREDENTIAL_MUTATION_BODY_BYTES)),
+        )
+        .route(
+            "/dashboard/api/mcp-tokens",
+            delete(delete_mcp_token)
+                .layer(DefaultBodyLimit::max(SIMPLE_CREDENTIAL_MUTATION_BODY_BYTES)),
+        )
         .route("/dashboard/api/me", get(get_me))
         .route("/dashboard/api/demo/redact", post(demo_redact))
         .route("/dashboard/api/demo/process", post(demo_process))

--- a/crates/gateway/src/store.rs
+++ b/crates/gateway/src/store.rs
@@ -1,6 +1,9 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use bytes::Bytes;
+use rsa::RsaPublicKey;
+use rsa::pkcs8::DecodePublicKey;
+use rsa::traits::PublicKeyParts;
 use sea_orm::sea_query::Expr;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, Set,
@@ -15,6 +18,12 @@ use uuid::Uuid;
 use crate::entity::api_key;
 use crate::entity::mcp_token;
 use crate::key_cipher::SecretCipher;
+
+pub const MAX_CREDENTIAL_LABEL_BYTES: usize = 128;
+pub const MAX_CREDENTIAL_TTL_SECONDS: u64 = 365 * 24 * 60 * 60;
+pub const MAX_PUBLIC_KEY_PEM_BYTES: usize = 16 * 1024;
+const MIN_RSA_PUBLIC_KEY_BITS: usize = 2048;
+const MAX_RSA_PUBLIC_KEY_BITS: usize = 4096;
 
 #[derive(Debug, Clone)]
 pub struct StoredObject {
@@ -226,7 +235,12 @@ pub trait KeyRepository: Send + Sync {
 
     /// Create an MCP bearer token (`s4m_...`) and return the plaintext token
     /// (shown once). Only its SHA-256 hash is stored.
-    async fn create_mcp_token(&self, user_id: &str, label: &str, expires_in: u64) -> String;
+    async fn create_mcp_token(
+        &self,
+        user_id: &str,
+        label: &str,
+        expires_in: u64,
+    ) -> anyhow::Result<(String, McpToken)>;
 
     /// Validate an MCP bearer token and return the owning user id.
     async fn resolve_mcp_token(&self, token: &str) -> Option<String>;
@@ -235,6 +249,63 @@ pub trait KeyRepository: Send + Sync {
     async fn list_mcp_tokens(&self, user_id: &str) -> Vec<McpToken>;
 
     async fn delete_mcp_token(&self, token_hash: &str, user_id: &str) -> bool;
+}
+
+pub fn canonicalize_credential_label(label: &str) -> anyhow::Result<String> {
+    if label.chars().any(char::is_control) {
+        anyhow::bail!("credential label must not contain control characters");
+    }
+    let label = label.trim();
+    if label.is_empty() {
+        anyhow::bail!("credential label must not be empty");
+    }
+    if label.len() > MAX_CREDENTIAL_LABEL_BYTES {
+        anyhow::bail!("credential label must not exceed {MAX_CREDENTIAL_LABEL_BYTES} UTF-8 bytes");
+    }
+    Ok(label.to_string())
+}
+
+pub fn validate_credential_ttl(expires_in: u64) -> anyhow::Result<()> {
+    if expires_in > MAX_CREDENTIAL_TTL_SECONDS {
+        anyhow::bail!(
+            "credential expiry must be 0 or at most {MAX_CREDENTIAL_TTL_SECONDS} seconds"
+        );
+    }
+    Ok(())
+}
+
+pub fn canonicalize_public_key_pem(public_key_pem: &str) -> anyhow::Result<String> {
+    if public_key_pem.len() > MAX_PUBLIC_KEY_PEM_BYTES {
+        anyhow::bail!("public key PEM must not exceed {MAX_PUBLIC_KEY_PEM_BYTES} bytes");
+    }
+    let public_key_pem = public_key_pem.trim();
+    if public_key_pem.is_empty() {
+        anyhow::bail!("public key PEM must not be empty");
+    }
+
+    let key = match RsaPublicKey::from_public_key_pem(public_key_pem) {
+        Ok(key) => key,
+        Err(_) => {
+            let (_, pem) =
+                x509_parser::pem::parse_x509_pem(public_key_pem.as_bytes()).map_err(|_| {
+                    anyhow::anyhow!(
+                        "public key PEM must contain an RSA public key or X.509 certificate"
+                    )
+                })?;
+            let certificate = pem.parse_x509().map_err(|_| {
+                anyhow::anyhow!("public key PEM must contain a valid X.509 certificate")
+            })?;
+            RsaPublicKey::from_public_key_der(certificate.public_key().raw)
+                .map_err(|_| anyhow::anyhow!("X.509 certificate must contain an RSA public key"))?
+        }
+    };
+    let bits = key.n().bits();
+    if !(MIN_RSA_PUBLIC_KEY_BITS..=MAX_RSA_PUBLIC_KEY_BITS).contains(&bits) {
+        anyhow::bail!(
+            "RSA public key must be between {MIN_RSA_PUBLIC_KEY_BITS} and {MAX_RSA_PUBLIC_KEY_BITS} bits"
+        );
+    }
+    Ok(public_key_pem.to_string())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -267,6 +338,12 @@ fn generate_api_key(
     public_key_pem: Option<String>,
     cipher: Option<&SecretCipher>,
 ) -> anyhow::Result<(ApiKey, String)> {
+    let label = canonicalize_credential_label(label)?;
+    validate_credential_ttl(expires_in)?;
+    let public_key_pem = public_key_pem
+        .as_deref()
+        .map(canonicalize_public_key_pem)
+        .transpose()?;
     let key_id = format!("s4_{}", Uuid::new_v4().to_string().replace('-', ""));
     let secret = format!("s4s_{}", Uuid::new_v4().to_string().replace('-', ""));
     let secret_hash = sha256_hash(&secret);
@@ -285,14 +362,18 @@ fn generate_api_key(
     };
     let now = chrono_now().parse::<u64>().unwrap_or(0);
     let expires_at = if expires_in > 0 {
-        Some(format!("{}", now + expires_in))
+        Some(
+            now.checked_add(expires_in)
+                .context("API key expiry overflow")?
+                .to_string(),
+        )
     } else {
         None
     };
     let api_key = build_api_key(
         &key_id,
         user_id,
-        label,
+        &label,
         secret_hash,
         secret_encrypted,
         chrono_now(),
@@ -300,6 +381,36 @@ fn generate_api_key(
         public_key_pem,
     );
     Ok((api_key, secret))
+}
+
+fn generate_mcp_token(
+    user_id: &str,
+    label: &str,
+    expires_in: u64,
+) -> anyhow::Result<(McpToken, String)> {
+    let label = canonicalize_credential_label(label)?;
+    validate_credential_ttl(expires_in)?;
+    let token = format!("s4m_{}", Uuid::new_v4().to_string().replace('-', ""));
+    let now = chrono_now().parse::<u64>().unwrap_or(0);
+    let expires_at = if expires_in > 0 {
+        Some(
+            now.checked_add(expires_in)
+                .context("MCP token expiry overflow")?
+                .to_string(),
+        )
+    } else {
+        None
+    };
+    Ok((
+        McpToken {
+            token_hash: sha256_hash(&token),
+            user_id: user_id.to_string(),
+            label,
+            created_at: chrono_now(),
+            expires_at,
+        },
+        token,
+    ))
 }
 
 fn decrypt_verified_secret(
@@ -481,11 +592,12 @@ impl KeyRepository for KeyStore {
         user_id: &str,
         public_key_pem: &str,
     ) -> anyhow::Result<bool> {
+        let public_key_pem = canonicalize_public_key_pem(public_key_pem)?;
         Ok(set_public_key_in(
             &self.keys,
             key_id,
             user_id,
-            public_key_pem,
+            &public_key_pem,
         ))
     }
 
@@ -531,23 +643,18 @@ impl KeyRepository for KeyStore {
         delete_key_in(&self.keys, key_id, user_id)
     }
 
-    async fn create_mcp_token(&self, user_id: &str, label: &str, expires_in: u64) -> String {
-        let token = format!("s4m_{}", Uuid::new_v4().to_string().replace('-', ""));
-        let now = chrono_now().parse::<u64>().unwrap_or(0);
-        let token_hash = sha256_hash(&token);
-        let mcp = McpToken {
-            token_hash: token_hash.clone(),
-            user_id: user_id.to_string(),
-            label: label.to_string(),
-            created_at: chrono_now(),
-            expires_at: if expires_in > 0 {
-                Some(format!("{}", now + expires_in))
-            } else {
-                None
-            },
-        };
-        self.mcp_tokens.write().unwrap().insert(token_hash, mcp);
-        token
+    async fn create_mcp_token(
+        &self,
+        user_id: &str,
+        label: &str,
+        expires_in: u64,
+    ) -> anyhow::Result<(String, McpToken)> {
+        let (mcp, token) = generate_mcp_token(user_id, label, expires_in)?;
+        self.mcp_tokens
+            .write()
+            .map_err(|_| anyhow::anyhow!("KeyStore MCP token lock poisoned"))?
+            .insert(mcp.token_hash.clone(), mcp.clone());
+        Ok((token, mcp))
     }
 
     async fn resolve_mcp_token(&self, token: &str) -> Option<String> {
@@ -735,6 +842,7 @@ impl KeyRepository for FileKeyStore {
         user_id: &str,
         public_key_pem: &str,
     ) -> anyhow::Result<bool> {
+        let public_key_pem = canonicalize_public_key_pem(public_key_pem)?;
         let _mutation_guard = self
             .mutation_lock
             .lock()
@@ -750,7 +858,7 @@ impl KeyRepository for FileKeyStore {
             if key.user_id != user_id {
                 return Ok(false);
             }
-            key.public_key_pem.replace(public_key_pem.to_string())
+            key.public_key_pem.replace(public_key_pem.clone())
         };
         if let Err(error) = self.persist() {
             let mut keys = self.keys.write().map_err(|_| {
@@ -760,7 +868,7 @@ impl KeyRepository for FileKeyStore {
             })?;
             if let Some(key) = keys.get_mut(key_id)
                 && key.user_id == user_id
-                && key.public_key_pem.as_deref() == Some(public_key_pem)
+                && key.public_key_pem.as_deref() == Some(public_key_pem.as_str())
             {
                 key.public_key_pem = previous;
             }
@@ -844,33 +952,30 @@ impl KeyRepository for FileKeyStore {
         true
     }
 
-    async fn create_mcp_token(&self, user_id: &str, label: &str, expires_in: u64) -> String {
-        let token = format!("s4m_{}", Uuid::new_v4().to_string().replace('-', ""));
-        let now = chrono_now().parse::<u64>().unwrap_or(0);
-        let token_hash = sha256_hash(&token);
-        let mcp = McpToken {
-            token_hash: token_hash.clone(),
-            user_id: user_id.to_string(),
-            label: label.to_string(),
-            created_at: chrono_now(),
-            expires_at: if expires_in > 0 {
-                Some(format!("{}", now + expires_in))
-            } else {
-                None
-            },
-        };
-        let Ok(_mutation_guard) = self.mutation_lock.lock() else {
-            tracing::warn!("FileKeyStore mutation lock poisoned");
-            return token;
-        };
+    async fn create_mcp_token(
+        &self,
+        user_id: &str,
+        label: &str,
+        expires_in: u64,
+    ) -> anyhow::Result<(String, McpToken)> {
+        let (mcp, token) = generate_mcp_token(user_id, label, expires_in)?;
+        let token_hash = mcp.token_hash.clone();
+        let _mutation_guard = self
+            .mutation_lock
+            .lock()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore mutation lock poisoned"))?;
         let inserted = mcp.clone();
         let previous = self
             .mcp_tokens
             .write()
-            .unwrap()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore MCP token lock poisoned"))?
             .insert(token_hash.clone(), mcp);
-        if self.persist().is_err() {
-            let mut tokens = self.mcp_tokens.write().unwrap();
+        if let Err(error) = self.persist() {
+            let mut tokens = self.mcp_tokens.write().map_err(|_| {
+                anyhow::anyhow!(
+                    "FileKeyStore MCP token persist failed and rollback lock was poisoned: {error}"
+                )
+            })?;
             if tokens.get(&token_hash) == Some(&inserted) {
                 if let Some(previous) = previous {
                     tokens.insert(token_hash, previous);
@@ -878,9 +983,9 @@ impl KeyRepository for FileKeyStore {
                     tokens.remove(&token_hash);
                 }
             }
-            tracing::warn!("FileKeyStore MCP token creation persist failed");
+            return Err(error.context("FileKeyStore MCP token creation persist failed"));
         }
-        token
+        Ok((token, inserted))
     }
 
     async fn resolve_mcp_token(&self, token: &str) -> Option<String> {
@@ -972,13 +1077,19 @@ impl KeyRepository for PostgresKeyStore {
             public_key_pem,
             self.cipher.as_deref(),
         )?;
+        let expires_at = api_key
+            .expires_at
+            .as_deref()
+            .map(str::parse::<i64>)
+            .transpose()
+            .context("API key expiry is outside the Postgres timestamp range")?;
         let model = api_key::ActiveModel {
             user_id: Set(api_key.user_id.clone()),
             key_id: Set(api_key.key_id.clone()),
             secret_hash: Set(api_key.secret_hash.clone()),
             secret_encrypted: Set(api_key.secret_encrypted.clone()),
             label: Set(api_key.label.clone()),
-            expires_at: Set(api_key.expires_at.as_ref().and_then(|e| e.parse().ok())),
+            expires_at: Set(expires_at),
             public_key_pem: Set(api_key.public_key_pem.clone()),
             ..Default::default()
         };
@@ -995,10 +1106,11 @@ impl KeyRepository for PostgresKeyStore {
         user_id: &str,
         public_key_pem: &str,
     ) -> anyhow::Result<bool> {
+        let public_key_pem = canonicalize_public_key_pem(public_key_pem)?;
         let result = api_key::Entity::update_many()
             .col_expr(
                 api_key::Column::PublicKeyPem,
-                Expr::value(Some(public_key_pem.to_string())),
+                Expr::value(Some(public_key_pem)),
             )
             .filter(api_key::Column::KeyId.eq(key_id.to_string()))
             .filter(api_key::Column::UserId.eq(user_id.to_string()))
@@ -1104,23 +1216,40 @@ impl KeyRepository for PostgresKeyStore {
         matches!(result, Ok(r) if r.rows_affected == 1)
     }
 
-    async fn create_mcp_token(&self, user_id: &str, label: &str, expires_in: u64) -> String {
-        let token = format!("s4m_{}", Uuid::new_v4().to_string().replace('-', ""));
-        let now = chrono_now().parse::<u64>().unwrap_or(0);
-        let token_hash = sha256_hash(&token);
+    async fn create_mcp_token(
+        &self,
+        user_id: &str,
+        label: &str,
+        expires_in: u64,
+    ) -> anyhow::Result<(String, McpToken)> {
+        let (mcp, token) = generate_mcp_token(user_id, label, expires_in)?;
+        let expires_at = mcp
+            .expires_at
+            .as_deref()
+            .map(str::parse::<i64>)
+            .transpose()
+            .context("MCP token expiry is outside the Postgres timestamp range")?;
         let model = mcp_token::ActiveModel {
-            user_id: Set(user_id.to_string()),
-            token_hash: Set(token_hash),
-            label: Set(label.to_string()),
-            expires_at: Set(if expires_in > 0 {
-                Some((now + expires_in) as i64)
-            } else {
-                None
-            }),
+            user_id: Set(mcp.user_id.clone()),
+            token_hash: Set(mcp.token_hash.clone()),
+            label: Set(mcp.label.clone()),
+            expires_at: Set(expires_at),
             ..Default::default()
         };
-        let _ = model.insert(&self.db).await;
-        token
+        let inserted = model
+            .insert(&self.db)
+            .await
+            .context("Postgres MCP token insert failed")?;
+        Ok((
+            token,
+            McpToken {
+                token_hash: inserted.token_hash,
+                user_id: inserted.user_id,
+                label: inserted.label,
+                created_at: inserted.created_at.to_string(),
+                expires_at: inserted.expires_at.map(|value| value.to_string()),
+            },
+        ))
     }
 
     async fn resolve_mcp_token(&self, token: &str) -> Option<String> {
@@ -1196,9 +1325,7 @@ fn load_file_store(path: &PathBuf) -> (HashMap<String, ApiKey>, HashMap<String, 
 fn is_expired(expires_at: Option<&str>) -> bool {
     if let Some(exp) = expires_at {
         let now = chrono_now().parse::<u64>().unwrap_or(0);
-        if exp.parse::<u64>().is_ok_and(|ts| now >= ts) {
-            return true;
-        }
+        return exp.parse::<u64>().map_or(true, |ts| now >= ts);
     }
     false
 }
@@ -1229,6 +1356,11 @@ fn chrono_now() -> String {
 mod tests {
     use super::*;
     use crate::key_cipher::{KeyWrapping, LocalKeyWrapping};
+    use rand::rngs::OsRng;
+    use rsa::pkcs8::{EncodePublicKey, LineEnding};
+
+    const TEST_PUBLIC_KEY_PEM: &str = include_str!("../../../tests/fixtures/pii/crypto/pub.pem");
+    const TEST_CERTIFICATE_PEM: &str = include_str!("../../../tests/fixtures/pii/crypto/cert.pem");
 
     #[derive(Debug)]
     struct FailingKeyWrapping;
@@ -1251,6 +1383,101 @@ mod tests {
 
     fn failing_cipher() -> Arc<SecretCipher> {
         Arc::new(SecretCipher::new(Arc::new(FailingKeyWrapping)))
+    }
+
+    fn generated_public_key_pem(bits: usize) -> String {
+        rsa::RsaPrivateKey::new(&mut OsRng, bits)
+            .unwrap()
+            .to_public_key()
+            .to_public_key_pem(LineEnding::LF)
+            .unwrap()
+    }
+
+    #[test]
+    fn credential_labels_and_ttls_are_canonical_and_bounded() {
+        assert_eq!(
+            canonicalize_credential_label("  production key  ").unwrap(),
+            "production key"
+        );
+        assert_eq!(
+            canonicalize_credential_label(&"a".repeat(MAX_CREDENTIAL_LABEL_BYTES)).unwrap(),
+            "a".repeat(MAX_CREDENTIAL_LABEL_BYTES)
+        );
+        for invalid in [
+            " ".to_string(),
+            "control\nlabel".to_string(),
+            "a".repeat(MAX_CREDENTIAL_LABEL_BYTES + 1),
+            "é".repeat((MAX_CREDENTIAL_LABEL_BYTES / 2) + 1),
+        ] {
+            assert!(canonicalize_credential_label(&invalid).is_err());
+        }
+        assert!(validate_credential_ttl(0).is_ok());
+        assert!(validate_credential_ttl(MAX_CREDENTIAL_TTL_SECONDS).is_ok());
+        assert!(validate_credential_ttl(MAX_CREDENTIAL_TTL_SECONDS + 1).is_err());
+    }
+
+    #[test]
+    fn public_key_validation_matches_filter_formats_and_bounds() {
+        assert_eq!(
+            canonicalize_public_key_pem(TEST_PUBLIC_KEY_PEM).unwrap(),
+            TEST_PUBLIC_KEY_PEM.trim()
+        );
+        assert_eq!(
+            canonicalize_public_key_pem(TEST_CERTIFICATE_PEM).unwrap(),
+            TEST_CERTIFICATE_PEM.trim()
+        );
+        assert!(canonicalize_public_key_pem("not a PEM").is_err());
+        assert!(canonicalize_public_key_pem(&generated_public_key_pem(1024)).is_err());
+        assert!(canonicalize_public_key_pem(&generated_public_key_pem(4096)).is_ok());
+        assert!(canonicalize_public_key_pem(&"x".repeat(MAX_PUBLIC_KEY_PEM_BYTES + 1)).is_err());
+    }
+
+    #[test]
+    fn malformed_expiry_fails_closed() {
+        assert!(is_expired(Some("-1")));
+        assert!(is_expired(Some("not-a-timestamp")));
+    }
+
+    #[tokio::test]
+    async fn api_key_creation_enforces_input_boundaries() {
+        let store = KeyStore::new();
+        assert!(
+            store
+                .create_key(
+                    "u1",
+                    "  bounded  ",
+                    MAX_CREDENTIAL_TTL_SECONDS,
+                    Some(TEST_CERTIFICATE_PEM.to_string()),
+                )
+                .await
+                .is_ok()
+        );
+        let stored = store.list_for_user("u1").await;
+        assert_eq!(stored[0].label, "bounded");
+        assert_eq!(
+            stored[0].public_key_pem.as_deref(),
+            Some(TEST_CERTIFICATE_PEM.trim())
+        );
+        assert!(
+            store
+                .create_key("u1", "too long", MAX_CREDENTIAL_TTL_SECONDS + 1, None)
+                .await
+                .is_err()
+        );
+
+        let (token, mcp) = store
+            .create_mcp_token("u1", "  agent  ", MAX_CREDENTIAL_TTL_SECONDS)
+            .await
+            .unwrap();
+        assert!(token.starts_with("s4m_"));
+        assert_eq!(mcp.label, "agent");
+        assert!(mcp.expires_at.is_some());
+        assert!(
+            store
+                .create_mcp_token("u1", "agent", MAX_CREDENTIAL_TTL_SECONDS + 1)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -1491,10 +1718,23 @@ mod tests {
     async fn in_memory_public_key_and_delete() {
         let store = KeyStore::new();
         let (key_id, _secret) = store.create_key("u1", "enc", 0, None).await.unwrap();
-        assert!(store.set_public_key(&key_id, "u1", "pem").await.unwrap());
-        assert!(!store.set_public_key(&key_id, "u2", "pem").await.unwrap());
+        assert!(
+            store
+                .set_public_key(&key_id, "u1", TEST_PUBLIC_KEY_PEM)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !store
+                .set_public_key(&key_id, "u2", TEST_CERTIFICATE_PEM)
+                .await
+                .unwrap()
+        );
         let key = store.get_key(&key_id).await.expect("key exists");
-        assert_eq!(key.public_key_pem.as_deref(), Some("pem"));
+        assert_eq!(
+            key.public_key_pem.as_deref(),
+            Some(TEST_PUBLIC_KEY_PEM.trim())
+        );
         let keys = store.list_for_user("u1").await;
         assert_eq!(keys.len(), 1);
         assert!(keys[0].secret_hash.is_empty());
@@ -1554,14 +1794,19 @@ mod tests {
         let path = parent.join("keys.json");
         let store = FileKeyStore::new(path.clone());
         let (key_id, _) = store
-            .create_key("u1", "persisted-public-key", 0, Some("old-pem".to_string()))
+            .create_key(
+                "u1",
+                "persisted-public-key",
+                0,
+                Some(TEST_PUBLIC_KEY_PEM.to_string()),
+            )
             .await
             .unwrap();
         std::fs::rename(&parent, &durable_parent).unwrap();
         std::fs::write(&parent, "not a directory").unwrap();
 
         let error = store
-            .set_public_key(&key_id, "u1", "new-pem")
+            .set_public_key(&key_id, "u1", TEST_CERTIFICATE_PEM)
             .await
             .unwrap_err();
 
@@ -1573,7 +1818,7 @@ mod tests {
                 .unwrap()
                 .public_key_pem
                 .as_deref(),
-            Some("old-pem")
+            Some(TEST_PUBLIC_KEY_PEM.trim())
         );
         std::fs::remove_file(&parent).unwrap();
         std::fs::rename(&durable_parent, &parent).unwrap();
@@ -1587,7 +1832,7 @@ mod tests {
                 .unwrap()
                 .public_key_pem
                 .as_deref(),
-            Some("old-pem")
+            Some(TEST_PUBLIC_KEY_PEM.trim())
         );
         std::fs::remove_dir_all(parent).unwrap();
     }
@@ -1627,13 +1872,16 @@ mod tests {
         std::fs::create_dir_all(&parent).unwrap();
         let path = parent.join("keys.json");
         let store = FileKeyStore::new(path.clone());
-        let persisted_token = store.create_mcp_token("u1", "persisted", 0).await;
+        let persisted_token = store
+            .create_mcp_token("u1", "persisted", 0)
+            .await
+            .unwrap()
+            .0;
         let persisted_hash = sha256_hash(&persisted_token);
         std::fs::rename(&parent, &durable_parent).unwrap();
         std::fs::write(&parent, "not a directory").unwrap();
 
-        let rejected_token = store.create_mcp_token("u1", "rejected", 0).await;
-        assert!(store.resolve_mcp_token(&rejected_token).await.is_none());
+        assert!(store.create_mcp_token("u1", "rejected", 0).await.is_err());
         assert!(!store.delete_mcp_token(&persisted_hash, "u1").await);
         assert_eq!(
             store.resolve_mcp_token(&persisted_token).await.as_deref(),
@@ -1651,7 +1899,7 @@ mod tests {
                 .as_deref(),
             Some("u1")
         );
-        assert!(restarted.resolve_mcp_token(&rejected_token).await.is_none());
+        assert_eq!(restarted.list_mcp_tokens("u1").await.len(), 1);
         std::fs::remove_dir_all(parent).unwrap();
     }
 
@@ -1671,7 +1919,7 @@ mod tests {
         let set_key = key_id.clone();
         let set_task = tokio::spawn(async move {
             set_store
-                .set_public_key(&set_key, "u1", "concurrent-pem")
+                .set_public_key(&set_key, "u1", TEST_PUBLIC_KEY_PEM)
                 .await
         });
         entered_rx
@@ -1735,7 +1983,7 @@ mod tests {
 
         resume_tx.send(()).unwrap();
         let (key_id, secret) = key_task.await.unwrap().unwrap();
-        let token = mcp_task.await.unwrap();
+        let token = mcp_task.await.unwrap().unwrap().0;
         drop(store);
 
         let restarted = FileKeyStore::new(path.clone());
@@ -1792,7 +2040,7 @@ mod tests {
 
         resume_tx.send(()).unwrap();
         assert_eq!(rewrap_task.await.unwrap().as_deref(), Some(secret.as_str()));
-        let token = mcp_task.await.unwrap();
+        let token = mcp_task.await.unwrap().unwrap().0;
         drop(store);
 
         let restarted = FileKeyStore::with_cipher(path.clone(), cipher);
@@ -1811,7 +2059,7 @@ mod tests {
     async fn file_key_store_mcp_delete_does_not_self_deadlock_and_persists() {
         let path = temp_keys_file();
         let store = FileKeyStore::new(path.clone());
-        let token = store.create_mcp_token("u1", "delete", 0).await;
+        let token = store.create_mcp_token("u1", "delete", 0).await.unwrap().0;
         let token_hash = sha256_hash(&token);
 
         assert!(
@@ -1858,6 +2106,16 @@ mod tests {
             .unwrap_err();
 
         assert!(error.to_string().contains("Postgres API key insert failed"));
+
+        let error = store
+            .create_mcp_token("u1", "database-error", 0)
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Postgres MCP token insert failed")
+        );
     }
 
     #[tokio::test]
@@ -1869,7 +2127,7 @@ mod tests {
         let store = PostgresKeyStore::new(pool);
 
         let error = store
-            .set_public_key("missing-key", "u1", "pem")
+            .set_public_key("missing-key", "u1", TEST_PUBLIC_KEY_PEM)
             .await
             .unwrap_err();
 
@@ -1901,13 +2159,26 @@ mod tests {
         let path = temp_keys_file();
         let store = FileKeyStore::new(path.clone());
         let (key_id, _secret) = store.create_key("u1", "enc", 3600, None).await.unwrap();
-        assert!(store.set_public_key(&key_id, "u1", "pem").await.unwrap());
-        assert!(!store.set_public_key(&key_id, "u2", "pem").await.unwrap());
+        assert!(
+            store
+                .set_public_key(&key_id, "u1", TEST_PUBLIC_KEY_PEM)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !store
+                .set_public_key(&key_id, "u2", TEST_CERTIFICATE_PEM)
+                .await
+                .unwrap()
+        );
         drop(store);
 
         let reloaded = FileKeyStore::new(path);
         let key = reloaded.get_key(&key_id).await.expect("key exists");
-        assert_eq!(key.public_key_pem.as_deref(), Some("pem"));
+        assert_eq!(
+            key.public_key_pem.as_deref(),
+            Some(TEST_PUBLIC_KEY_PEM.trim())
+        );
         assert!(key.expires_at.is_some());
     }
 

--- a/crates/gateway/tests/db_keys_test.rs
+++ b/crates/gateway/tests/db_keys_test.rs
@@ -48,6 +48,8 @@ use s4_gateway::server::{build_router, build_state};
 use tower::ServiceExt;
 
 const TEST_KEK: [u8; 32] = [7; 32];
+const TEST_PUBLIC_KEY_PEM: &str = include_str!("../../../tests/fixtures/pii/crypto/pub.pem");
+const TEST_CERTIFICATE_PEM: &str = include_str!("../../../tests/fixtures/pii/crypto/cert.pem");
 static DB_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 fn unix_time_ms() -> i64 {
@@ -1087,13 +1089,13 @@ fn postgres_public_key_binding() {
             .expect("create Postgres API key");
         assert!(
             store
-                .set_public_key(&key_id, &user, "-----BEGIN PUBLIC KEY-----\npem")
+                .set_public_key(&key_id, &user, TEST_PUBLIC_KEY_PEM)
                 .await
                 .unwrap()
         );
         assert!(
             !store
-                .set_public_key(&key_id, "someone-else", "pem2")
+                .set_public_key(&key_id, "someone-else", TEST_CERTIFICATE_PEM)
                 .await
                 .unwrap()
         );
@@ -1103,7 +1105,7 @@ fn postgres_public_key_binding() {
             .await
             .expect("resolve after binding");
         assert_eq!(uid, user);
-        assert_eq!(pk.as_deref(), Some("-----BEGIN PUBLIC KEY-----\npem"));
+        assert_eq!(pk.as_deref(), Some(TEST_PUBLIC_KEY_PEM.trim()));
         delete_api_key(&db, &key_id).await;
     });
 }
@@ -1124,6 +1126,30 @@ fn postgres_expired_key_rejected() {
             "expired key must be rejected"
         );
         delete_api_key(&db, &key_id).await;
+    });
+}
+
+#[test]
+fn postgres_mcp_creation_returns_persisted_metadata() {
+    with_pool(|pool| async move {
+        let store = PostgresKeyStore::new(pool);
+        let user = format!("unit-{}", uuid::Uuid::new_v4());
+        let (token, created) = store
+            .create_mcp_token(&user, "  agent  ", 3600)
+            .await
+            .expect("create Postgres MCP token");
+        let listed = store
+            .list_mcp_tokens(&user)
+            .await
+            .into_iter()
+            .find(|candidate| candidate.token_hash == created.token_hash)
+            .expect("persisted MCP token is listed");
+
+        assert!(token.starts_with("s4m_"));
+        assert_eq!(created, listed);
+        assert_eq!(created.label, "agent");
+        assert!(created.expires_at.is_some());
+        assert!(store.delete_mcp_token(&created.token_hash, &user).await);
     });
 }
 

--- a/crates/gateway/tests/s3_frontdoor_test.rs
+++ b/crates/gateway/tests/s3_frontdoor_test.rs
@@ -18,7 +18,10 @@ use s4_gateway::key_cipher::default_wrapping;
 use s4_gateway::object::BodyLimits;
 use s4_gateway::server::{AppState, StreamingReadMode, build_router, build_state};
 use s4_gateway::sigv4::SigV4Policy;
-use s4_gateway::store::{FileKeyStore, KeyRepository};
+use s4_gateway::store::{
+    FileKeyStore, KeyRepository, MAX_CREDENTIAL_LABEL_BYTES, MAX_CREDENTIAL_TTL_SECONDS,
+    MAX_PUBLIC_KEY_PEM_BYTES,
+};
 use s4_gateway::transaction::SpoolQuota;
 use s4_gateway::workspace_storage::InMemoryWorkspaceStorageRepository;
 use std::collections::VecDeque;
@@ -32,6 +35,9 @@ use std::time::Duration;
 use tokio::io::AsyncWriteExt as _;
 use tokio::process::Command;
 use tower::ServiceExt;
+
+const TEST_PUBLIC_KEY_PEM: &str = include_str!("../../../tests/fixtures/pii/crypto/pub.pem");
+const TEST_CERTIFICATE_PEM: &str = include_str!("../../../tests/fixtures/pii/crypto/cert.pem");
 
 struct PollTrackingBody {
     polls: Arc<AtomicUsize>,
@@ -329,7 +335,7 @@ async fn public_key_persistence_failure_returns_generic_500_and_rolls_back() {
     std::fs::write(&parent, "not a directory").unwrap();
 
     let request = add_headers(
-        public_key_request(&key_id, "must-not-persist"),
+        public_key_request(&key_id, TEST_PUBLIC_KEY_PEM),
         &auth_headers(&key_id, &secret_key),
     );
     let response = app.oneshot(request).await.unwrap();
@@ -339,7 +345,7 @@ async fn public_key_persistence_failure_returns_generic_500_and_rolls_back() {
         .await
         .unwrap();
     assert!(body.is_empty(), "persistence failure body must be generic");
-    assert!(!String::from_utf8_lossy(&body).contains("must-not-persist"));
+    assert!(!String::from_utf8_lossy(&body).contains("BEGIN PUBLIC KEY"));
     assert!(!String::from_utf8_lossy(&body).contains(&secret_key));
     assert!(
         file_store
@@ -590,7 +596,9 @@ async fn public_key_mutation_rejects_duplicate_security_headers_without_mutation
     let mcp_token = state
         .keys
         .create_mcp_token("test-user", "duplicate-test", 0)
-        .await;
+        .await
+        .unwrap()
+        .0;
     let app = build_router(state.clone());
     let bearer = format!("Bearer {key_id}:{secret_key}");
     let requests = [
@@ -651,7 +659,9 @@ async fn public_key_mutation_rejects_mixed_credential_classes_without_mutation()
     let mcp_token = state
         .keys
         .create_mcp_token("test-user", "mixed-test", 0)
-        .await;
+        .await
+        .unwrap()
+        .0;
     let jwt = configure_dashboard_jwt(&mut state, "test-user");
     let app = build_router(state.clone());
     let api_bearer = format!("Bearer {key_id}:{secret_key}");
@@ -719,7 +729,7 @@ async fn public_key_mutation_accepts_own_key_via_headers_and_bearer() {
     let app = build_router(state.clone());
 
     let header_request = add_headers(
-        public_key_request(&header_key, "header-pem"),
+        public_key_request(&header_key, TEST_PUBLIC_KEY_PEM),
         &auth_headers(&header_key, &header_secret),
     );
     assert_eq!(
@@ -728,7 +738,7 @@ async fn public_key_mutation_accepts_own_key_via_headers_and_bearer() {
     );
 
     let bearer_request = add_headers(
-        public_key_request(&bearer_key, "bearer-pem"),
+        public_key_request(&bearer_key, TEST_CERTIFICATE_PEM),
         &[(
             "authorization",
             format!("Bearer {bearer_key}:{bearer_secret}"),
@@ -747,7 +757,7 @@ async fn public_key_mutation_accepts_own_key_via_headers_and_bearer() {
             .unwrap()
             .public_key_pem
             .as_deref(),
-        Some("header-pem")
+        Some(TEST_PUBLIC_KEY_PEM.trim())
     );
     assert_eq!(
         state
@@ -757,7 +767,7 @@ async fn public_key_mutation_accepts_own_key_via_headers_and_bearer() {
             .unwrap()
             .public_key_pem
             .as_deref(),
-        Some("bearer-pem")
+        Some(TEST_CERTIFICATE_PEM.trim())
     );
 }
 
@@ -770,7 +780,7 @@ async fn local_public_key_mutation_accepts_real_target_credentials() {
         .auth_disabled = true;
     let app = build_router(state.clone());
     let request = add_headers(
-        public_key_request(&key_id, "local-authenticated-pem"),
+        public_key_request(&key_id, TEST_PUBLIC_KEY_PEM),
         &auth_headers(&key_id, &secret_key),
     );
 
@@ -783,7 +793,37 @@ async fn local_public_key_mutation_accepts_real_target_credentials() {
             .unwrap()
             .public_key_pem
             .as_deref(),
-        Some("local-authenticated-pem")
+        Some(TEST_PUBLIC_KEY_PEM.trim())
+    );
+}
+
+#[tokio::test]
+async fn public_key_mutation_rejects_invalid_pem_before_persistence() {
+    let state = test_state().await;
+    let (key_id, secret_key) = make_key(&state).await;
+    let app = build_router(state.clone());
+
+    for public_key_pem in [
+        "not an RSA public key".to_string(),
+        "x".repeat(MAX_PUBLIC_KEY_PEM_BYTES + 1),
+    ] {
+        let request = add_headers(
+            public_key_request(&key_id, &public_key_pem),
+            &auth_headers(&key_id, &secret_key),
+        );
+        assert_eq!(
+            app.clone().oneshot(request).await.unwrap().status(),
+            StatusCode::BAD_REQUEST
+        );
+    }
+    assert!(
+        state
+            .keys
+            .get_key(&key_id)
+            .await
+            .unwrap()
+            .public_key_pem
+            .is_none()
     );
 }
 
@@ -834,7 +874,10 @@ async fn jwt_public_key_mutation_is_scoped_to_dashboard_user_ownership() {
     let token = configure_dashboard_jwt(&mut state, "dashboard-user");
     let app = build_router(state.clone());
 
-    for (key_id, pem) in [(&owned_key, "first-pem"), (&second_owned_key, "second-pem")] {
+    for (key_id, pem) in [
+        (&owned_key, TEST_PUBLIC_KEY_PEM),
+        (&second_owned_key, TEST_CERTIFICATE_PEM),
+    ] {
         let request = add_headers(
             public_key_request(key_id, pem),
             &[("authorization", format!("Bearer {token}"))],
@@ -846,7 +889,7 @@ async fn jwt_public_key_mutation_is_scoped_to_dashboard_user_ownership() {
     }
 
     let foreign_request = add_headers(
-        public_key_request(&foreign_key, "rejected-pem"),
+        public_key_request(&foreign_key, TEST_PUBLIC_KEY_PEM),
         &[("authorization", format!("Bearer {token}"))],
     );
     assert_eq!(
@@ -862,7 +905,7 @@ async fn jwt_public_key_mutation_is_scoped_to_dashboard_user_ownership() {
             .unwrap()
             .public_key_pem
             .as_deref(),
-        Some("first-pem")
+        Some(TEST_PUBLIC_KEY_PEM.trim())
     );
     assert_eq!(
         state
@@ -872,7 +915,7 @@ async fn jwt_public_key_mutation_is_scoped_to_dashboard_user_ownership() {
             .unwrap()
             .public_key_pem
             .as_deref(),
-        Some("second-pem")
+        Some(TEST_CERTIFICATE_PEM.trim())
     );
     assert!(
         state
@@ -893,7 +936,9 @@ async fn mcp_tokens_cannot_mutate_public_keys() {
     let token = state
         .keys
         .create_mcp_token("mcp-user", "mutation-test", 0)
-        .await;
+        .await
+        .unwrap()
+        .0;
     let app = build_router(state.clone());
     let requests = [
         add_headers(
@@ -938,7 +983,7 @@ async fn create_key_still_accepts_an_initial_public_key() {
         .body(Body::from(
             serde_json::json!({
                 "label": "created-with-public-key",
-                "public_key_pem": "creation-pem",
+                "public_key_pem": TEST_CERTIFICATE_PEM,
             })
             .to_string(),
         ))
@@ -953,7 +998,7 @@ async fn create_key_still_accepts_an_initial_public_key() {
     )
     .unwrap();
     let key_id = body["key_id"].as_str().unwrap();
-    assert_eq!(body["public_key_pem"], "creation-pem");
+    assert_eq!(body["public_key_pem"], TEST_CERTIFICATE_PEM.trim());
     assert_eq!(
         state
             .keys
@@ -962,8 +1007,135 @@ async fn create_key_still_accepts_an_initial_public_key() {
             .unwrap()
             .public_key_pem
             .as_deref(),
-        Some("creation-pem")
+        Some(TEST_CERTIFICATE_PEM.trim())
     );
+}
+
+#[tokio::test]
+async fn credential_mutation_endpoints_enforce_input_and_body_boundaries() {
+    let mut state = test_state().await;
+    Arc::get_mut(&mut state)
+        .expect("test state is uniquely owned")
+        .auth_disabled = true;
+    let app = build_router(state);
+
+    for (label, expected) in [
+        ("a".repeat(MAX_CREDENTIAL_LABEL_BYTES), StatusCode::OK),
+        (
+            "a".repeat(MAX_CREDENTIAL_LABEL_BYTES + 1),
+            StatusCode::BAD_REQUEST,
+        ),
+        ("control\nlabel".to_string(), StatusCode::BAD_REQUEST),
+        ("   ".to_string(), StatusCode::BAD_REQUEST),
+    ] {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/dashboard/api/keys")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                serde_json::json!({ "label": label }).to_string(),
+            ))
+            .unwrap();
+        assert_eq!(
+            app.clone().oneshot(request).await.unwrap().status(),
+            expected
+        );
+    }
+
+    for (expires_in, expected) in [
+        (MAX_CREDENTIAL_TTL_SECONDS, StatusCode::OK),
+        (MAX_CREDENTIAL_TTL_SECONDS + 1, StatusCode::BAD_REQUEST),
+    ] {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/dashboard/api/keys")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                serde_json::json!({ "label": "ttl", "expires_in": expires_in }).to_string(),
+            ))
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), expected);
+        if expected == StatusCode::OK {
+            let body: serde_json::Value = serde_json::from_slice(
+                &axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap(),
+            )
+            .unwrap();
+            assert!(body["expires_at"].as_str().is_some());
+        }
+    }
+
+    for public_key_pem in [
+        "not a PEM".to_string(),
+        "x".repeat(MAX_PUBLIC_KEY_PEM_BYTES + 1),
+    ] {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/dashboard/api/keys")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                serde_json::json!({
+                    "label": "invalid pem",
+                    "public_key_pem": public_key_pem,
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        assert_eq!(
+            app.clone().oneshot(request).await.unwrap().status(),
+            StatusCode::BAD_REQUEST
+        );
+    }
+
+    for (expires_in, expected) in [
+        (MAX_CREDENTIAL_TTL_SECONDS, StatusCode::OK),
+        (MAX_CREDENTIAL_TTL_SECONDS + 1, StatusCode::BAD_REQUEST),
+    ] {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/dashboard/api/mcp-tokens")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                serde_json::json!({ "label": "agent", "expires_in": expires_in }).to_string(),
+            ))
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), expected);
+        if expected == StatusCode::OK {
+            let body: serde_json::Value = serde_json::from_slice(
+                &axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap(),
+            )
+            .unwrap();
+            assert!(body["expires_at"].as_str().is_some());
+        }
+    }
+
+    for (method, uri, body) in [
+        ("POST", "/dashboard/api/keys", "x".repeat(20 * 1024)),
+        (
+            "PUT",
+            "/dashboard/api/keys/public-key",
+            "x".repeat(20 * 1024),
+        ),
+        ("DELETE", "/dashboard/api/keys", "x".repeat(2048)),
+        ("POST", "/dashboard/api/mcp-tokens", "x".repeat(2048)),
+        ("DELETE", "/dashboard/api/mcp-tokens", "x".repeat(2048)),
+    ] {
+        let request = Request::builder()
+            .method(method)
+            .uri(uri)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        assert_eq!(
+            app.clone().oneshot(request).await.unwrap().status(),
+            StatusCode::PAYLOAD_TOO_LARGE
+        );
+    }
 }
 
 #[tokio::test]
@@ -3340,7 +3512,12 @@ async fn mcp_token_roundtrip_and_auth() {
     let (app, state) = router().await;
 
     // Create an MCP token.
-    let token = state.keys.create_mcp_token("mcp-user", "agent", 0).await;
+    let token = state
+        .keys
+        .create_mcp_token("mcp-user", "agent", 0)
+        .await
+        .unwrap()
+        .0;
     assert!(token.starts_with("s4m_"), "token prefix: {token}");
 
     // Use it as a Bearer token to write.
@@ -3395,8 +3572,18 @@ async fn mcp_token_roundtrip_and_auth() {
 #[tokio::test]
 async fn mcp_token_identity_is_per_user() {
     let (app, state) = router().await;
-    let t1 = state.keys.create_mcp_token("user-a", "agent", 0).await;
-    let t2 = state.keys.create_mcp_token("user-b", "agent", 0).await;
+    let t1 = state
+        .keys
+        .create_mcp_token("user-a", "agent", 0)
+        .await
+        .unwrap()
+        .0;
+    let t2 = state
+        .keys
+        .create_mcp_token("user-b", "agent", 0)
+        .await
+        .unwrap()
+        .0;
 
     // user-a can write; user-b's token cannot read user-a's in-memory object
     // under a different identity via the dashboard key list (identity binding).

--- a/docs/security.md
+++ b/docs/security.md
@@ -131,6 +131,14 @@ The plaintext secret exists only in the create-key HTTP response and,
 transiently, in memory during SigV4 verification. It is never logged or
 persisted.
 
+Credential mutations are bounded before persistence. API-key and MCP labels are
+trimmed, non-empty, free of control characters, and at most 128 UTF-8 bytes.
+Non-zero API-key and MCP lifetimes are at most one year (`0` means no expiry).
+Encryption public keys are at most 16 KiB and must be an SPKI public-key PEM or
+X.509 certificate carrying an RSA key between 2048 and 4096 bits, matching the
+formats consumed by the envelope-encryption filter. Credential JSON endpoints
+also have route-specific body limits; oversized requests receive `413`.
+
 ### Key-wrapping providers
 
 | Provider | Durability | When to use |


### PR DESCRIPTION
## Security impact
Credential mutations are now bounded before persistence:
- labels are trimmed, non-empty, control-free, and limited to 128 UTF-8 bytes
- API-key and MCP TTLs are limited to one year or non-expiring zero
- encryption keys are limited to 16 KiB and must be 2048-4096-bit RSA SPKI PEM or X.509 certificates, matching the filter runtime
- invalid expiry state fails closed
- credential JSON routes have method-specific body limits

MCP creation is now fallible at the repository boundary. File/Postgres persistence failures do not return a bearer token, and Postgres returns the exact inserted metadata. This changes the public Rust `KeyRepository::create_mcp_token` return type to `anyhow::Result<(String, McpToken)>`. HTTP response shapes are unchanged.

## Validation
- rustfmt passed
- locked Cargo metadata passed
- independent source review approved
- no local compilation; GitHub CI is the runtime gate