### PR TITLE
fix(security): propagate credential repository failures

### DIFF
--- a/crates/gateway/src/key_cipher.rs
+++ b/crates/gateway/src/key_cipher.rs
@@ -182,21 +182,41 @@ impl SecretCipher {
         ))
     }
 
-    /// Decrypt a v1 or v2 envelope. v2 must match `key_id`'s AAD binding.
+    /// Decrypt a v1 or v2 envelope, preserving the original compatibility
+    /// behavior that collapses invalid data and wrapping-provider errors.
     pub fn decrypt(&self, key_id: &str, blob: &str) -> Option<String> {
+        self.decrypt_result(key_id, blob).ok().flatten()
+    }
+
+    /// Decrypt while distinguishing wrapping-provider failures from invalid
+    /// envelope data. Credential repositories use this method so operational
+    /// KMS/Vault outages can propagate instead of becoming authentication
+    /// denials.
+    pub fn decrypt_result(&self, key_id: &str, blob: &str) -> Result<Option<String>> {
         let parts: Vec<&str> = blob.splitn(4, ':').collect();
         if parts.len() != 4 || (parts[0] != ENVELOPE_VERSION && parts[0] != LEGACY_ENVELOPE_VERSION)
         {
-            return None;
+            return Ok(None);
         }
-        let wrapped = B64.decode(parts[1]).ok()?;
-        let nonce = B64.decode(parts[2]).ok()?;
+        let Ok(wrapped) = B64.decode(parts[1]) else {
+            return Ok(None);
+        };
+        let Ok(nonce) = B64.decode(parts[2]) else {
+            return Ok(None);
+        };
         if nonce.len() != NONCE_LEN {
-            return None;
+            return Ok(None);
         }
-        let ct = B64.decode(parts[3]).ok()?;
-        let dek = self.wrapping.unwrap(&wrapped).ok()?;
-        let cipher = Aes256Gcm::new_from_slice(&dek).ok()?;
+        let Ok(ct) = B64.decode(parts[3]) else {
+            return Ok(None);
+        };
+        let dek = self
+            .wrapping
+            .unwrap(&wrapped)
+            .context("key wrapping provider failed to unwrap API key DEK")?;
+        let Ok(cipher) = Aes256Gcm::new_from_slice(&dek) else {
+            return Ok(None);
+        };
         let plaintext = if parts[0] == ENVELOPE_VERSION {
             let aad = envelope_aad(key_id);
             cipher.decrypt(
@@ -209,7 +229,10 @@ impl SecretCipher {
         } else {
             cipher.decrypt(Nonce::from_slice(&nonce), ct.as_ref())
         };
-        plaintext.ok().and_then(|p| String::from_utf8(p).ok())
+        let Ok(plaintext) = plaintext else {
+            return Ok(None);
+        };
+        Ok(String::from_utf8(plaintext).ok())
     }
 
     pub fn is_legacy_envelope(blob: &str) -> bool {
@@ -239,6 +262,19 @@ mod tests {
 
     fn cipher_with_kek(kek: u8) -> SecretCipher {
         SecretCipher::new(Arc::new(LocalKeyWrapping::with_kek([kek; KEY_LEN])))
+    }
+
+    #[derive(Debug)]
+    struct FailingUnwrapper;
+
+    impl KeyWrapping for FailingUnwrapper {
+        fn wrap(&self, _dek: &[u8]) -> Result<Vec<u8>> {
+            Err(anyhow!("unexpected wrap"))
+        }
+
+        fn unwrap(&self, _wrapped: &[u8]) -> Result<Vec<u8>> {
+            Err(anyhow!("wrapping provider unavailable"))
+        }
     }
 
     #[test]
@@ -298,10 +334,20 @@ mod tests {
     }
 
     #[test]
-    fn wrong_kek_fails() {
+    fn wrong_kek_preserves_compatibility_and_is_a_fallible_unwrap_error() {
         let blob = cipher_with_kek(7).encrypt("key-a", "secret").unwrap();
         let other = cipher_with_kek(9);
         assert_eq!(other.decrypt("key-a", &blob), None);
+        assert!(other.decrypt_result("key-a", &blob).is_err());
+    }
+
+    #[test]
+    fn wrapping_provider_failure_is_an_operational_error() {
+        let blob = cipher_with_kek(7).encrypt("key-a", "secret").unwrap();
+        let cipher = SecretCipher::new(Arc::new(FailingUnwrapper));
+
+        assert_eq!(cipher.decrypt("key-a", &blob), None);
+        assert!(cipher.decrypt_result("key-a", &blob).is_err());
     }
 
     #[test]
@@ -320,6 +366,34 @@ mod tests {
         parts[2] = B64.encode([0u8; NONCE_LEN - 1]);
 
         assert_eq!(cipher.decrypt("key-a", &parts.join(":")), None);
+    }
+
+    #[test]
+    fn invalid_utf8_plaintext_returns_none() {
+        let wrapping = Arc::new(LocalKeyWrapping::with_kek([7; KEY_LEN]));
+        let dek = [5u8; KEY_LEN];
+        let wrapped = wrapping.wrap(&dek).unwrap();
+        let nonce = [3u8; NONCE_LEN];
+        let cipher = Aes256Gcm::new_from_slice(&dek).unwrap();
+        let aad = envelope_aad("key-a");
+        let ciphertext = cipher
+            .encrypt(
+                Nonce::from_slice(&nonce),
+                Payload {
+                    msg: &[0xff],
+                    aad: &aad,
+                },
+            )
+            .unwrap();
+        let blob = format!(
+            "v2:{}:{}:{}",
+            B64.encode(wrapped),
+            B64.encode(nonce),
+            B64.encode(ciphertext)
+        );
+        let secret_cipher = SecretCipher::new(wrapping);
+
+        assert_eq!(secret_cipher.decrypt("key-a", &blob), None);
     }
 
     #[test]

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -1268,6 +1268,7 @@ impl HeaderAuthentication {
 enum HeaderAuthError {
     Denied,
     InvalidPayload(IntegrityError),
+    CredentialStoreUnavailable(String),
     Unavailable(String),
 }
 
@@ -1309,6 +1310,10 @@ fn authentication_error_response(key: &str, error: HeaderAuthError) -> axum::res
         HeaderAuthError::InvalidPayload(error) => {
             s3_error::invalid_request(key, &error.to_string())
         }
+        HeaderAuthError::CredentialStoreUnavailable(error) => {
+            warn!("credential storage unavailable during authentication: {error}");
+            s3_error::service_unavailable(key, "credential storage is temporarily unavailable")
+        }
         HeaderAuthError::Unavailable(error) => {
             warn!("workspace resolution failed: {error}");
             s3_error::service_unavailable(key, "workspace storage is temporarily unavailable")
@@ -1342,6 +1347,7 @@ async fn authenticate_headers(
         let key = keys
             .get_key(sigv4.access_key())
             .await
+            .map_err(|error| HeaderAuthError::CredentialStoreUnavailable(error.to_string()))?
             .ok_or(HeaderAuthError::Denied)?;
         if key_expired(key.expires_at.as_deref()) {
             return Err(HeaderAuthError::Denied);
@@ -1349,6 +1355,7 @@ async fn authenticate_headers(
         let secret = keys
             .decrypt_secret(sigv4.access_key())
             .await
+            .map_err(|error| HeaderAuthError::CredentialStoreUnavailable(error.to_string()))?
             .ok_or(HeaderAuthError::Denied)?;
         let body_verifier = sigv4
             .authorize(
@@ -1380,7 +1387,10 @@ async fn authenticate_headers(
             let token = &a[7..];
             // MCP bearer token (s4m_...): a self-contained credential.
             if token.starts_with("s4m_") {
-                if let Some(user_id) = keys.resolve_mcp_token(token).await {
+                let user_id = keys.resolve_mcp_token(token).await.map_err(|error| {
+                    HeaderAuthError::CredentialStoreUnavailable(error.to_string())
+                })?;
+                if let Some(user_id) = user_id {
                     return Ok(HeaderAuthentication::without_body(
                         authenticated_request(
                             state,
@@ -1399,6 +1409,9 @@ async fn authenticate_headers(
                 let (user_id, public_key_pem) = keys
                     .resolve_credentials(ak, sk)
                     .await
+                    .map_err(|error| {
+                        HeaderAuthError::CredentialStoreUnavailable(error.to_string())
+                    })?
                     .ok_or(HeaderAuthError::Denied)?;
                 return Ok(HeaderAuthentication::without_body(
                     authenticated_request(
@@ -1426,9 +1439,14 @@ async fn authenticate_headers(
     };
     // x-s4-mcp-token header: MCP bearer token.
     if let Some(tok) = headers.get("x-s4-mcp-token").and_then(|v| v.to_str().ok()) {
-        if tok.starts_with("s4m_")
-            && let Some(user_id) = keys.resolve_mcp_token(tok).await
-        {
+        let user_id = if tok.starts_with("s4m_") {
+            keys.resolve_mcp_token(tok)
+                .await
+                .map_err(|error| HeaderAuthError::CredentialStoreUnavailable(error.to_string()))?
+        } else {
+            None
+        };
+        if let Some(user_id) = user_id {
             return Ok(HeaderAuthentication::without_body(
                 authenticated_request(
                     state,
@@ -1450,7 +1468,11 @@ async fn authenticate_headers(
         .get("x-s4-secret-key")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
-    if let Some((user_id, public_key_pem)) = keys.resolve_credentials(ak, sk).await {
+    let resolved = keys
+        .resolve_credentials(ak, sk)
+        .await
+        .map_err(|error| HeaderAuthError::CredentialStoreUnavailable(error.to_string()))?;
+    if let Some((user_id, public_key_pem)) = resolved {
         return Ok(HeaderAuthentication::without_body(
             authenticated_request(
                 state,
@@ -1704,7 +1726,13 @@ async fn get_me(State(state): State<Arc<AppState>>, headers: HeaderMap) -> impl 
         .and_then(|v| v.as_str())
         .unwrap_or("email")
         .to_string();
-    let keys = state.keys.list_for_user(user_id).await;
+    let keys = match state.keys.list_for_user(user_id).await {
+        Ok(keys) => keys,
+        Err(error) => {
+            tracing::error!(user_id, error = %error, "credential storage unavailable");
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+    };
     Json(serde_json::json!({
         "user_id": user_id,
         "email": email,
@@ -6172,7 +6200,13 @@ async fn get_keys(
     let Some(uid) = require_user_id(&headers, &state).await else {
         return StatusCode::UNAUTHORIZED.into_response();
     };
-    let keys = state.keys.list_for_user(&uid).await;
+    let keys = match state.keys.list_for_user(&uid).await {
+        Ok(keys) => keys,
+        Err(error) => {
+            tracing::error!(user_id = uid, error = %error, "API key listing failed");
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+    };
     let resp: Vec<ListKeyResponse> = keys
         .into_iter()
         .map(|k| ListKeyResponse {
@@ -6222,7 +6256,7 @@ async fn create_key(
         .keys
         .create_key(&uid, &label, body.expires_in, public_key_pem)
         .await;
-    let (key_id, secret) = match result {
+    let (secret, created) = match result {
         Ok(created) => created,
         Err(error) => {
             tracing::error!(
@@ -6231,7 +6265,7 @@ async fn create_key(
                 "API key creation persistence failed"
             );
             return (
-                StatusCode::INTERNAL_SERVER_ERROR,
+                StatusCode::SERVICE_UNAVAILABLE,
                 Json(InternalErrorResponse {
                     error: "internal_error".to_string(),
                 }),
@@ -6239,19 +6273,13 @@ async fn create_key(
                 .into_response();
         }
     };
-    let key = state.keys.get_key(&key_id).await;
-    let created_at = key
-        .as_ref()
-        .map_or_else(|| "0".to_string(), |k| k.created_at.clone());
-    let expires_at = key.as_ref().and_then(|k| k.expires_at.clone());
-    let public_key_pem = key.as_ref().and_then(|k| k.public_key_pem.clone());
     Json(ApiKeyResponse {
-        key_id,
+        key_id: created.key_id,
         secret,
-        label,
-        created_at,
-        expires_at,
-        public_key_pem,
+        label: created.label,
+        created_at: created.created_at,
+        expires_at: created.expires_at,
+        public_key_pem: created.public_key_pem,
     })
     .into_response()
 }
@@ -6272,10 +6300,13 @@ async fn delete_key(
     let Some(uid) = require_user_id(&headers, &state).await else {
         return StatusCode::UNAUTHORIZED.into_response();
     };
-    if state.keys.delete_key(&body.key_id, &uid).await {
-        StatusCode::NO_CONTENT.into_response()
-    } else {
-        (StatusCode::NOT_FOUND, "key not found").into_response()
+    match state.keys.delete_key(&body.key_id, &uid).await {
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => (StatusCode::NOT_FOUND, "key not found").into_response(),
+        Err(error) => {
+            tracing::error!(user_id = uid, error = %error, "API key deletion failed");
+            StatusCode::SERVICE_UNAVAILABLE.into_response()
+        }
     }
 }
 
@@ -6293,7 +6324,13 @@ async fn get_mcp_tokens(
     let Some(uid) = require_user_id(&headers, &state).await else {
         return StatusCode::UNAUTHORIZED.into_response();
     };
-    let tokens = state.keys.list_mcp_tokens(&uid).await;
+    let tokens = match state.keys.list_mcp_tokens(&uid).await {
+        Ok(tokens) => tokens,
+        Err(error) => {
+            tracing::error!(user_id = uid, error = %error, "MCP token listing failed");
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+    };
     let resp: Vec<McpTokenResponse> = tokens
         .into_iter()
         .map(|t| McpTokenResponse {
@@ -6336,9 +6373,9 @@ async fn create_mcp_token(
         .await
     {
         Ok(created) => created,
-        Err(_) => {
-            tracing::error!(user_id = uid, "MCP token creation persistence failed");
-            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        Err(error) => {
+            tracing::error!(user_id = uid, error = %error, "MCP token creation persistence failed");
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
         }
     };
     Json(McpTokenCreatedResponse {
@@ -6366,10 +6403,13 @@ async fn delete_mcp_token(
     let Some(uid) = require_user_id(&headers, &state).await else {
         return StatusCode::UNAUTHORIZED.into_response();
     };
-    if state.keys.delete_mcp_token(&body.token_hash, &uid).await {
-        StatusCode::NO_CONTENT.into_response()
-    } else {
-        (StatusCode::NOT_FOUND, "token not found").into_response()
+    match state.keys.delete_mcp_token(&body.token_hash, &uid).await {
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => (StatusCode::NOT_FOUND, "token not found").into_response(),
+        Err(error) => {
+            tracing::error!(user_id = uid, error = %error, "MCP token deletion failed");
+            StatusCode::SERVICE_UNAVAILABLE.into_response()
+        }
     }
 }
 
@@ -6527,11 +6567,15 @@ async fn authenticate_public_key_mutation(
         let secret_key = secret_key
             .filter(|value| !value.is_empty())
             .ok_or(StatusCode::UNAUTHORIZED)?;
-        let (user_id, _) = state
+        let resolved = state
             .keys
             .resolve_credentials(access_key, secret_key)
             .await
-            .ok_or(StatusCode::UNAUTHORIZED)?;
+            .map_err(|error| {
+                tracing::error!(error = %error, "credential storage unavailable");
+                StatusCode::SERVICE_UNAVAILABLE
+            })?;
+        let (user_id, _) = resolved.ok_or(StatusCode::UNAUTHORIZED)?;
         return Ok(PublicKeyMutationActor::ApiKey {
             access_key: access_key.to_string(),
             user_id,
@@ -6546,11 +6590,15 @@ async fn authenticate_public_key_mutation(
         if access_key.is_empty() || secret_key.is_empty() {
             return Err(StatusCode::UNAUTHORIZED);
         }
-        let (user_id, _) = state
+        let resolved = state
             .keys
             .resolve_credentials(access_key, secret_key)
             .await
-            .ok_or(StatusCode::UNAUTHORIZED)?;
+            .map_err(|error| {
+                tracing::error!(error = %error, "credential storage unavailable");
+                StatusCode::SERVICE_UNAVAILABLE
+            })?;
+        let (user_id, _) = resolved.ok_or(StatusCode::UNAUTHORIZED)?;
         return Ok(PublicKeyMutationActor::ApiKey {
             access_key: access_key.to_string(),
             user_id,
@@ -6598,9 +6646,9 @@ async fn set_public_key(
     {
         Ok(true) => StatusCode::OK.into_response(),
         Ok(false) => (StatusCode::NOT_FOUND, "key not found").into_response(),
-        Err(_) => {
-            tracing::error!(user_id = uid, "public key persistence failed");
-            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        Err(error) => {
+            tracing::error!(user_id = uid, error = %error, "public key persistence failed");
+            StatusCode::SERVICE_UNAVAILABLE.into_response()
         }
     }
 }
@@ -6984,11 +7032,11 @@ pub async fn build_state(
         Arc::new(FileKeyStore::with_cipher(
             PathBuf::from(keys_file),
             cipher.clone(),
-        ))
+        )?)
     } else if auth_disabled {
         let path = FileKeyStore::default_path();
         info!("Key store: file ({}) (local mode)", path.display());
-        Arc::new(FileKeyStore::with_cipher(path, cipher))
+        Arc::new(FileKeyStore::with_cipher(path, cipher)?)
     } else {
         info!("Key store: in-memory (set DATABASE_URL or S4_KEYS_FILE for persistence)");
         Arc::new(KeyStore::with_cipher(cipher))
@@ -7120,15 +7168,15 @@ pub async fn build_state(
     // Local mode: ensure a demo key exists and print it so SDK demos and
     // `aws s3 --endpoint-url` work out of the box.
     if auth_disabled {
-        let existing = keys.list_for_user("demo-user").await;
+        let existing = keys.list_for_user("demo-user").await?;
         if existing.is_empty() {
-            let (key_id, secret) = keys
+            let (secret, created) = keys
                 .create_key("demo-user", "local-default", 0, None)
                 .await?;
-            println!("S4_ACCESS_KEY={key_id}");
+            println!("S4_ACCESS_KEY={}", created.key_id);
             println!("S4_SECRET_KEY={secret}");
         } else if let Some(k) = existing.into_iter().find(|k| k.label == "local-default")
-            && let Some(secret) = keys.decrypt_secret(&k.key_id).await
+            && let Some(secret) = keys.decrypt_secret(&k.key_id).await?
         {
             println!("S4_ACCESS_KEY={}", k.key_id);
             println!("S4_SECRET_KEY={secret}");

--- a/crates/gateway/src/store.rs
+++ b/crates/gateway/src/store.rs
@@ -11,7 +11,8 @@ use sea_orm::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, RwLock};
 use uuid::Uuid;
 
@@ -196,16 +197,16 @@ impl PostgresKeyStore {
 /// (`PostgresKeyStore`); selected by the presence of `DATABASE_URL`.
 #[async_trait]
 pub trait KeyRepository: Send + Sync {
-    /// Create and persist a key, then return the plaintext `(key_id, secret)`.
-    /// The secret is hashed (SHA-256) before storage and never returned when
-    /// persistence fails.
+    /// Create and persist a key, then return the plaintext secret and committed
+    /// metadata. The secret is hashed (SHA-256) before storage and never
+    /// returned when persistence fails.
     async fn create_key(
         &self,
         user_id: &str,
         label: &str,
         expires_in: u64,
         public_key_pem: Option<String>,
-    ) -> anyhow::Result<(String, String)>;
+    ) -> anyhow::Result<(String, ApiKey)>;
 
     async fn set_public_key(
         &self,
@@ -214,11 +215,11 @@ pub trait KeyRepository: Send + Sync {
         public_key_pem: &str,
     ) -> anyhow::Result<bool>;
 
-    async fn get_key(&self, key_id: &str) -> Option<ApiKey>;
+    async fn get_key(&self, key_id: &str) -> anyhow::Result<Option<ApiKey>>;
 
     /// Decrypt the stored plaintext secret for `key_id` (used to verify SigV4
     /// signatures). Returns `None` for legacy keys that only have a hash.
-    async fn decrypt_secret(&self, key_id: &str) -> Option<String>;
+    async fn decrypt_secret(&self, key_id: &str) -> anyhow::Result<Option<String>>;
 
     /// Validate an access key/secret pair and return the owning user id plus
     /// the API key's public key PEM (used by the encryption pipeline).
@@ -226,12 +227,12 @@ pub trait KeyRepository: Send + Sync {
         &self,
         access_key: &str,
         secret_key: &str,
-    ) -> Option<(String, Option<String>)>;
+    ) -> anyhow::Result<Option<(String, Option<String>)>>;
 
     /// Keys for a user, with the secret hash stripped.
-    async fn list_for_user(&self, user_id: &str) -> Vec<ApiKey>;
+    async fn list_for_user(&self, user_id: &str) -> anyhow::Result<Vec<ApiKey>>;
 
-    async fn delete_key(&self, key_id: &str, user_id: &str) -> bool;
+    async fn delete_key(&self, key_id: &str, user_id: &str) -> anyhow::Result<bool>;
 
     /// Create an MCP bearer token (`s4m_...`) and return the plaintext token
     /// (shown once). Only its SHA-256 hash is stored.
@@ -243,12 +244,12 @@ pub trait KeyRepository: Send + Sync {
     ) -> anyhow::Result<(String, McpToken)>;
 
     /// Validate an MCP bearer token and return the owning user id.
-    async fn resolve_mcp_token(&self, token: &str) -> Option<String>;
+    async fn resolve_mcp_token(&self, token: &str) -> anyhow::Result<Option<String>>;
 
     /// MCP tokens for a user (hashes only).
-    async fn list_mcp_tokens(&self, user_id: &str) -> Vec<McpToken>;
+    async fn list_mcp_tokens(&self, user_id: &str) -> anyhow::Result<Vec<McpToken>>;
 
-    async fn delete_mcp_token(&self, token_hash: &str, user_id: &str) -> bool;
+    async fn delete_mcp_token(&self, token_hash: &str, user_id: &str) -> anyhow::Result<bool>;
 }
 
 pub fn canonicalize_credential_label(label: &str) -> anyhow::Result<String> {
@@ -418,21 +419,27 @@ fn decrypt_verified_secret(
     key_id: &str,
     secret_hash: &str,
     blob: &str,
-) -> Option<(String, Option<String>)> {
-    let secret = cipher.decrypt(key_id, blob)?;
+) -> anyhow::Result<Option<(String, Option<String>)>> {
+    let Some(secret) = cipher.decrypt_result(key_id, blob)? else {
+        return Ok(None);
+    };
     if sha256_hash(&secret) != secret_hash {
         tracing::warn!(
             key_id = key_id,
             "decrypted API key secret failed hash verification"
         );
-        return None;
+        return Ok(None);
     }
     let rewrapped = if SecretCipher::is_legacy_envelope(blob) {
-        Some(cipher.encrypt(key_id, &secret).ok()?)
+        Some(
+            cipher
+                .encrypt(key_id, &secret)
+                .context("legacy API key secret rewrap encryption failed")?,
+        )
     } else {
         None
     };
-    Some((secret, rewrapped))
+    Ok(Some((secret, rewrapped)))
 }
 
 fn compare_and_swap_envelope(
@@ -440,16 +447,18 @@ fn compare_and_swap_envelope(
     key_id: &str,
     expected: &str,
     replacement: String,
-) -> bool {
-    let mut keys = keys.write().unwrap();
+) -> anyhow::Result<bool> {
+    let mut keys = keys
+        .write()
+        .map_err(|_| anyhow::anyhow!("KeyStore API key lock poisoned"))?;
     let Some(key) = keys.get_mut(key_id) else {
-        return false;
+        return Ok(false);
     };
     if key.secret_encrypted.as_deref() != Some(expected) {
-        return false;
+        return Ok(false);
     }
     key.secret_encrypted = Some(replacement);
-    true
+    Ok(true)
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -464,18 +473,18 @@ fn key_has_matching_v2_secret(
     key_id: &str,
     secret_hash: &str,
     secret: &str,
-) -> bool {
+) -> anyhow::Result<bool> {
     if key.key_id != key_id || key.secret_hash != secret_hash {
-        return false;
+        return Ok(false);
     }
     let Some(blob) = key.secret_encrypted.as_deref() else {
-        return false;
+        return Ok(false);
     };
     if !blob.starts_with("v2:") {
-        return false;
+        return Ok(false);
     }
-    decrypt_verified_secret(cipher, key_id, secret_hash, blob)
-        .is_some_and(|(current, rewrapped)| rewrapped.is_none() && current == secret)
+    Ok(decrypt_verified_secret(cipher, key_id, secret_hash, blob)?
+        .is_some_and(|(current, rewrapped)| rewrapped.is_none() && current == secret))
 }
 
 fn replace_or_accept_rewrapped_envelope(
@@ -486,13 +495,20 @@ fn replace_or_accept_rewrapped_envelope(
     secret: &str,
     expected: &str,
     replacement: String,
-) -> Option<EnvelopeUpdate> {
-    if compare_and_swap_envelope(keys, key_id, expected, replacement) {
-        return Some(EnvelopeUpdate::Replaced);
+) -> anyhow::Result<Option<EnvelopeUpdate>> {
+    if compare_and_swap_envelope(keys, key_id, expected, replacement)? {
+        return Ok(Some(EnvelopeUpdate::Replaced));
     }
-    let current = keys.read().ok()?.get(key_id)?.clone();
-    key_has_matching_v2_secret(cipher, &current, key_id, secret_hash, secret)
-        .then_some(EnvelopeUpdate::AlreadyRewrapped)
+    let keys = keys
+        .read()
+        .map_err(|_| anyhow::anyhow!("KeyStore API key lock poisoned"))?;
+    let Some(current) = keys.get(key_id) else {
+        return Ok(None);
+    };
+    Ok(
+        key_has_matching_v2_secret(cipher, current, key_id, secret_hash, secret)?
+            .then_some(EnvelopeUpdate::AlreadyRewrapped),
+    )
 }
 
 fn set_public_key_in(
@@ -500,40 +516,57 @@ fn set_public_key_in(
     key_id: &str,
     user_id: &str,
     public_key_pem: &str,
-) -> bool {
-    let mut keys = keys.write().unwrap();
+) -> anyhow::Result<bool> {
+    let mut keys = keys
+        .write()
+        .map_err(|_| anyhow::anyhow!("KeyStore API key lock poisoned"))?;
     if let Some(k) = keys.get_mut(key_id)
         && k.user_id == user_id
     {
         k.public_key_pem = Some(public_key_pem.to_string());
-        return true;
+        return Ok(true);
     }
-    false
+    Ok(false)
 }
 
-fn get_key_in(keys: &RwLock<HashMap<String, ApiKey>>, key_id: &str) -> Option<ApiKey> {
-    keys.read().unwrap().get(key_id).cloned()
+fn get_key_in(
+    keys: &RwLock<HashMap<String, ApiKey>>,
+    key_id: &str,
+) -> anyhow::Result<Option<ApiKey>> {
+    Ok(keys
+        .read()
+        .map_err(|_| anyhow::anyhow!("KeyStore API key lock poisoned"))?
+        .get(key_id)
+        .cloned())
 }
 
 fn resolve_credentials_in(
     keys: &RwLock<HashMap<String, ApiKey>>,
     access_key: &str,
     secret_key: &str,
-) -> Option<(String, Option<String>)> {
-    let keys = keys.read().unwrap();
-    let key = keys.get(access_key)?;
+) -> anyhow::Result<Option<(String, Option<String>)>> {
+    let keys = keys
+        .read()
+        .map_err(|_| anyhow::anyhow!("KeyStore API key lock poisoned"))?;
+    let Some(key) = keys.get(access_key) else {
+        return Ok(None);
+    };
     if key.secret_hash != sha256_hash(secret_key) {
-        return None;
+        return Ok(None);
     }
     if is_expired(key.expires_at.as_deref()) {
-        return None;
+        return Ok(None);
     }
-    Some((key.user_id.clone(), key.public_key_pem.clone()))
+    Ok(Some((key.user_id.clone(), key.public_key_pem.clone())))
 }
 
-fn list_for_user_in(keys: &RwLock<HashMap<String, ApiKey>>, user_id: &str) -> Vec<ApiKey> {
-    keys.read()
-        .unwrap()
+fn list_for_user_in(
+    keys: &RwLock<HashMap<String, ApiKey>>,
+    user_id: &str,
+) -> anyhow::Result<Vec<ApiKey>> {
+    Ok(keys
+        .read()
+        .map_err(|_| anyhow::anyhow!("KeyStore API key lock poisoned"))?
         .values()
         .filter(|k| k.user_id == user_id)
         .map(|k| {
@@ -548,18 +581,24 @@ fn list_for_user_in(keys: &RwLock<HashMap<String, ApiKey>>, user_id: &str) -> Ve
                 k.public_key_pem.clone(),
             )
         })
-        .collect()
+        .collect())
 }
 
-fn delete_key_in(keys: &RwLock<HashMap<String, ApiKey>>, key_id: &str, user_id: &str) -> bool {
-    let mut keys = keys.write().unwrap();
+fn delete_key_in(
+    keys: &RwLock<HashMap<String, ApiKey>>,
+    key_id: &str,
+    user_id: &str,
+) -> anyhow::Result<bool> {
+    let mut keys = keys
+        .write()
+        .map_err(|_| anyhow::anyhow!("KeyStore API key lock poisoned"))?;
     if let Some(k) = keys.get(key_id)
         && k.user_id == user_id
     {
         keys.remove(key_id);
-        return true;
+        return Ok(true);
     }
-    false
+    Ok(false)
 }
 
 #[async_trait]
@@ -570,7 +609,7 @@ impl KeyRepository for KeyStore {
         label: &str,
         expires_in: u64,
         public_key_pem: Option<String>,
-    ) -> anyhow::Result<(String, String)> {
+    ) -> anyhow::Result<(String, ApiKey)> {
         let (api_key, secret) = generate_api_key(
             user_id,
             label,
@@ -579,11 +618,12 @@ impl KeyRepository for KeyStore {
             self.cipher.as_deref(),
         )?;
         let key_id = api_key.key_id.clone();
+        let committed = api_key.clone();
         self.keys
             .write()
             .map_err(|_| anyhow::anyhow!("KeyStore API key lock poisoned"))?
             .insert(key_id.clone(), api_key);
-        Ok((key_id, secret))
+        Ok((secret, committed))
     }
 
     async fn set_public_key(
@@ -593,28 +633,37 @@ impl KeyRepository for KeyStore {
         public_key_pem: &str,
     ) -> anyhow::Result<bool> {
         let public_key_pem = canonicalize_public_key_pem(public_key_pem)?;
-        Ok(set_public_key_in(
-            &self.keys,
-            key_id,
-            user_id,
-            &public_key_pem,
-        ))
+        set_public_key_in(&self.keys, key_id, user_id, &public_key_pem)
     }
 
-    async fn get_key(&self, key_id: &str) -> Option<ApiKey> {
+    async fn get_key(&self, key_id: &str) -> anyhow::Result<Option<ApiKey>> {
         get_key_in(&self.keys, key_id)
     }
 
-    async fn decrypt_secret(&self, key_id: &str) -> Option<String> {
-        let cipher = self.cipher.as_deref()?;
-        let (secret_hash, blob) = {
-            let keys = self.keys.read().unwrap();
-            let key = keys.get(key_id)?;
-            (key.secret_hash.clone(), key.secret_encrypted.clone()?)
+    async fn decrypt_secret(&self, key_id: &str) -> anyhow::Result<Option<String>> {
+        let Some(cipher) = self.cipher.as_deref() else {
+            return Ok(None);
         };
-        let (secret, rewrapped) = decrypt_verified_secret(cipher, key_id, &secret_hash, &blob)?;
+        let (secret_hash, blob) = {
+            let keys = self
+                .keys
+                .read()
+                .map_err(|_| anyhow::anyhow!("KeyStore API key lock poisoned"))?;
+            let Some(key) = keys.get(key_id) else {
+                return Ok(None);
+            };
+            let Some(blob) = key.secret_encrypted.clone() else {
+                return Ok(None);
+            };
+            (key.secret_hash.clone(), blob)
+        };
+        let Some((secret, rewrapped)) =
+            decrypt_verified_secret(cipher, key_id, &secret_hash, &blob)?
+        else {
+            return Ok(None);
+        };
         if let Some(rewrapped) = rewrapped {
-            replace_or_accept_rewrapped_envelope(
+            let Some(_) = replace_or_accept_rewrapped_envelope(
                 &self.keys,
                 cipher,
                 key_id,
@@ -622,24 +671,27 @@ impl KeyRepository for KeyStore {
                 &secret,
                 &blob,
                 rewrapped,
-            )?;
+            )?
+            else {
+                return Ok(None);
+            };
         }
-        Some(secret)
+        Ok(Some(secret))
     }
 
     async fn resolve_credentials(
         &self,
         access_key: &str,
         secret_key: &str,
-    ) -> Option<(String, Option<String>)> {
+    ) -> anyhow::Result<Option<(String, Option<String>)>> {
         resolve_credentials_in(&self.keys, access_key, secret_key)
     }
 
-    async fn list_for_user(&self, user_id: &str) -> Vec<ApiKey> {
+    async fn list_for_user(&self, user_id: &str) -> anyhow::Result<Vec<ApiKey>> {
         list_for_user_in(&self.keys, user_id)
     }
 
-    async fn delete_key(&self, key_id: &str, user_id: &str) -> bool {
+    async fn delete_key(&self, key_id: &str, user_id: &str) -> anyhow::Result<bool> {
         delete_key_in(&self.keys, key_id, user_id)
     }
 
@@ -657,35 +709,44 @@ impl KeyRepository for KeyStore {
         Ok((token, mcp))
     }
 
-    async fn resolve_mcp_token(&self, token: &str) -> Option<String> {
+    async fn resolve_mcp_token(&self, token: &str) -> anyhow::Result<Option<String>> {
         let hash = sha256_hash(token);
-        let tokens = self.mcp_tokens.read().unwrap();
-        let t = tokens.get(&hash)?;
+        let tokens = self
+            .mcp_tokens
+            .read()
+            .map_err(|_| anyhow::anyhow!("KeyStore MCP token lock poisoned"))?;
+        let Some(t) = tokens.get(&hash) else {
+            return Ok(None);
+        };
         if is_expired(t.expires_at.as_deref()) {
-            return None;
+            return Ok(None);
         }
-        Some(t.user_id.clone())
+        Ok(Some(t.user_id.clone()))
     }
 
-    async fn list_mcp_tokens(&self, user_id: &str) -> Vec<McpToken> {
-        self.mcp_tokens
+    async fn list_mcp_tokens(&self, user_id: &str) -> anyhow::Result<Vec<McpToken>> {
+        Ok(self
+            .mcp_tokens
             .read()
-            .unwrap()
+            .map_err(|_| anyhow::anyhow!("KeyStore MCP token lock poisoned"))?
             .values()
             .filter(|t| t.user_id == user_id)
             .cloned()
-            .collect()
+            .collect())
     }
 
-    async fn delete_mcp_token(&self, token_hash: &str, user_id: &str) -> bool {
-        let mut tokens = self.mcp_tokens.write().unwrap();
+    async fn delete_mcp_token(&self, token_hash: &str, user_id: &str) -> anyhow::Result<bool> {
+        let mut tokens = self
+            .mcp_tokens
+            .write()
+            .map_err(|_| anyhow::anyhow!("KeyStore MCP token lock poisoned"))?;
         if let Some(t) = tokens.get(token_hash)
             && t.user_id == user_id
         {
             tokens.remove(token_hash);
-            return true;
+            return Ok(true);
         }
-        false
+        Ok(false)
     }
 }
 
@@ -699,7 +760,8 @@ impl KeyRepository for KeyStore {
 pub struct FileKeyStore {
     keys: RwLock<HashMap<String, ApiKey>>,
     mcp_tokens: RwLock<HashMap<String, McpToken>>,
-    // Every state mutation shares one snapshot file and must commit in order.
+    // Every mutation shares one snapshot file. Writers take this lock first,
+    // then acquire keys before mcp_tokens whenever both maps are needed.
     mutation_lock: Mutex<()>,
     #[cfg(test)]
     persist_hook: Mutex<Option<PersistTestHook>>,
@@ -715,9 +777,10 @@ struct PersistTestHook {
 }
 
 impl FileKeyStore {
-    pub fn new(path: PathBuf) -> Self {
-        let (keys, mcp_tokens) = load_file_store(&path);
-        Self {
+    pub fn new(path: PathBuf) -> anyhow::Result<Self> {
+        let (keys, mcp_tokens) = load_file_store(&path)?;
+        ensure_file_store_parent(&path)?;
+        Ok(Self {
             keys: RwLock::new(keys),
             mcp_tokens: RwLock::new(mcp_tokens),
             mutation_lock: Mutex::new(()),
@@ -725,12 +788,13 @@ impl FileKeyStore {
             persist_hook: Mutex::new(None),
             path,
             cipher: None,
-        }
+        })
     }
 
-    pub fn with_cipher(path: PathBuf, cipher: Arc<SecretCipher>) -> Self {
-        let (keys, mcp_tokens) = load_file_store(&path);
-        Self {
+    pub fn with_cipher(path: PathBuf, cipher: Arc<SecretCipher>) -> anyhow::Result<Self> {
+        let (keys, mcp_tokens) = load_file_store(&path)?;
+        ensure_file_store_parent(&path)?;
+        Ok(Self {
             keys: RwLock::new(keys),
             mcp_tokens: RwLock::new(mcp_tokens),
             mutation_lock: Mutex::new(()),
@@ -738,7 +802,7 @@ impl FileKeyStore {
             persist_hook: Mutex::new(None),
             path,
             cipher: Some(cipher),
-        }
+        })
     }
 
     /// Default location for the local-mode keys file.
@@ -749,46 +813,91 @@ impl FileKeyStore {
             .join("keys.json")
     }
 
-    /// Atomically write the current key set to disk (0600 on unix).
-    fn persist(&self) -> anyhow::Result<()> {
+    /// Atomically write a caller-locked key snapshot to disk (0600 on unix).
+    fn persist_snapshot(
+        &self,
+        keys: &HashMap<String, ApiKey>,
+        mcp_tokens: &HashMap<String, McpToken>,
+    ) -> anyhow::Result<()> {
         #[cfg(test)]
-        if let Some(hook) = self.persist_hook.lock().unwrap().take() {
+        if let Some(hook) = self
+            .persist_hook
+            .lock()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore persist hook lock poisoned"))?
+            .take()
+        {
             hook.entered.send(()).unwrap();
             hook.resume.recv().unwrap();
         }
         #[derive(serde::Serialize)]
-        struct Persisted {
-            keys: HashMap<String, ApiKey>,
-            mcp_tokens: HashMap<String, McpToken>,
+        struct Persisted<'a> {
+            keys: &'a HashMap<String, ApiKey>,
+            mcp_tokens: &'a HashMap<String, McpToken>,
         }
-        let data = Persisted {
-            keys: self
-                .keys
-                .read()
-                .map_err(|_| anyhow::anyhow!("FileKeyStore API key lock poisoned"))?
-                .clone(),
-            mcp_tokens: self
-                .mcp_tokens
-                .read()
-                .map_err(|_| anyhow::anyhow!("FileKeyStore MCP token lock poisoned"))?
-                .clone(),
-        };
+        let data = Persisted { keys, mcp_tokens };
         let json = serde_json::to_string_pretty(&data)?;
-        if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
+        ensure_file_store_parent(&self.path)?;
         let mut tmp_name = self.path.as_os_str().to_os_string();
         tmp_name.push(".tmp");
         let tmp = PathBuf::from(tmp_name);
-        std::fs::write(&tmp, json)?;
+        let mut options = std::fs::OpenOptions::new();
+        options.create(true).truncate(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&tmp)?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600));
+            file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
         }
+        file.write_all(json.as_bytes())?;
+        file.sync_all()?;
+        drop(file);
         std::fs::rename(&tmp, &self.path)?;
+        // Rename commits the snapshot. No error may escape after this point or
+        // callers would roll back memory while disk contains the new state.
+        #[cfg(unix)]
+        {
+            let parent = self
+                .path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .unwrap_or_else(|| Path::new("."));
+            if std::fs::File::open(parent)
+                .and_then(|directory| directory.sync_all())
+                .is_err()
+            {
+                tracing::warn!("FileKeyStore parent directory sync failed after committed rename");
+            }
+        }
         Ok(())
     }
+
+    #[cfg(test)]
+    fn persist(&self) -> anyhow::Result<()> {
+        let keys = self
+            .keys
+            .read()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore API key lock poisoned"))?;
+        let mcp_tokens = self
+            .mcp_tokens
+            .read()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore MCP token lock poisoned"))?;
+        self.persist_snapshot(&keys, &mcp_tokens)
+    }
+}
+
+fn ensure_file_store_parent(path: &Path) -> anyhow::Result<()> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent).context("FileKeyStore parent directory creation failed")?;
+    }
+    Ok(())
 }
 
 #[async_trait]
@@ -799,7 +908,7 @@ impl KeyRepository for FileKeyStore {
         label: &str,
         expires_in: u64,
         public_key_pem: Option<String>,
-    ) -> anyhow::Result<(String, String)> {
+    ) -> anyhow::Result<(String, ApiKey)> {
         let (api_key, secret) = generate_api_key(
             user_id,
             label,
@@ -813,27 +922,27 @@ impl KeyRepository for FileKeyStore {
             .map_err(|_| anyhow::anyhow!("FileKeyStore mutation lock poisoned"))?;
         let key_id = api_key.key_id.clone();
         let inserted = api_key.clone();
-        let previous = self
+        let mut keys = self
             .keys
             .write()
-            .map_err(|_| anyhow::anyhow!("FileKeyStore API key lock poisoned"))?
-            .insert(key_id.clone(), api_key);
-        if let Err(error) = self.persist() {
-            let mut keys = self.keys.write().map_err(|_| {
-                anyhow::anyhow!(
-                    "FileKeyStore persist failed and API key rollback lock was poisoned: {error}"
-                )
-            })?;
+            .map_err(|_| anyhow::anyhow!("FileKeyStore API key lock poisoned"))?;
+        let mcp_tokens = self
+            .mcp_tokens
+            .read()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore MCP token lock poisoned"))?
+            .clone();
+        let previous = keys.insert(key_id.clone(), api_key);
+        if let Err(error) = self.persist_snapshot(&keys, &mcp_tokens) {
             if keys.get(&key_id) == Some(&inserted) {
                 if let Some(previous) = previous {
-                    keys.insert(key_id, previous);
+                    keys.insert(key_id.clone(), previous);
                 } else {
                     keys.remove(&key_id);
                 }
             }
             return Err(error.context("FileKeyStore persist failed"));
         }
-        Ok((key_id, secret))
+        Ok((secret, inserted))
     }
 
     async fn set_public_key(
@@ -847,25 +956,23 @@ impl KeyRepository for FileKeyStore {
             .mutation_lock
             .lock()
             .map_err(|_| anyhow::anyhow!("FileKeyStore mutation lock poisoned"))?;
-        let previous = {
-            let mut keys = self
-                .keys
-                .write()
-                .map_err(|_| anyhow::anyhow!("FileKeyStore API key lock poisoned"))?;
-            let Some(key) = keys.get_mut(key_id) else {
-                return Ok(false);
-            };
-            if key.user_id != user_id {
-                return Ok(false);
-            }
-            key.public_key_pem.replace(public_key_pem.clone())
+        let mut keys = self
+            .keys
+            .write()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore API key lock poisoned"))?;
+        let mcp_tokens = self
+            .mcp_tokens
+            .read()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore MCP token lock poisoned"))?
+            .clone();
+        let Some(key) = keys.get_mut(key_id) else {
+            return Ok(false);
         };
-        if let Err(error) = self.persist() {
-            let mut keys = self.keys.write().map_err(|_| {
-                anyhow::anyhow!(
-                    "FileKeyStore public key persist failed and rollback lock was poisoned: {error}"
-                )
-            })?;
+        if key.user_id != user_id {
+            return Ok(false);
+        }
+        let previous = key.public_key_pem.replace(public_key_pem.clone());
+        if let Err(error) = self.persist_snapshot(&keys, &mcp_tokens) {
             if let Some(key) = keys.get_mut(key_id)
                 && key.user_id == user_id
                 && key.public_key_pem.as_deref() == Some(public_key_pem.as_str())
@@ -877,79 +984,118 @@ impl KeyRepository for FileKeyStore {
         Ok(true)
     }
 
-    async fn get_key(&self, key_id: &str) -> Option<ApiKey> {
+    async fn get_key(&self, key_id: &str) -> anyhow::Result<Option<ApiKey>> {
         get_key_in(&self.keys, key_id)
     }
 
-    async fn decrypt_secret(&self, key_id: &str) -> Option<String> {
-        let cipher = self.cipher.as_deref()?;
-        let (secret_hash, blob) = {
-            let keys = self.keys.read().unwrap();
-            let key = keys.get(key_id)?;
-            (key.secret_hash.clone(), key.secret_encrypted.clone()?)
+    async fn decrypt_secret(&self, key_id: &str) -> anyhow::Result<Option<String>> {
+        let Some(cipher) = self.cipher.as_deref() else {
+            return Ok(None);
         };
-        let (secret, rewrapped) = decrypt_verified_secret(cipher, key_id, &secret_hash, &blob)?;
+        let (secret_hash, blob) = {
+            let keys = self
+                .keys
+                .read()
+                .map_err(|_| anyhow::anyhow!("FileKeyStore API key lock poisoned"))?;
+            let Some(key) = keys.get(key_id) else {
+                return Ok(None);
+            };
+            let Some(blob) = key.secret_encrypted.clone() else {
+                return Ok(None);
+            };
+            (key.secret_hash.clone(), blob)
+        };
+        let Some((secret, rewrapped)) =
+            decrypt_verified_secret(cipher, key_id, &secret_hash, &blob)?
+        else {
+            return Ok(None);
+        };
         if let Some(rewrapped) = rewrapped {
-            let _mutation_guard = self.mutation_lock.lock().ok()?;
-            match replace_or_accept_rewrapped_envelope(
-                &self.keys,
-                cipher,
-                key_id,
-                &secret_hash,
-                &secret,
-                &blob,
-                rewrapped.clone(),
-            )? {
+            let _mutation_guard = self
+                .mutation_lock
+                .lock()
+                .map_err(|_| anyhow::anyhow!("FileKeyStore mutation lock poisoned"))?;
+            let mut keys = self
+                .keys
+                .write()
+                .map_err(|_| anyhow::anyhow!("FileKeyStore API key lock poisoned"))?;
+            let mcp_tokens = self
+                .mcp_tokens
+                .read()
+                .map_err(|_| anyhow::anyhow!("FileKeyStore MCP token lock poisoned"))?
+                .clone();
+            let update = if let Some(key) = keys.get_mut(key_id) {
+                if key.secret_encrypted.as_deref() == Some(blob.as_str()) {
+                    key.secret_encrypted = Some(rewrapped.clone());
+                    Some(EnvelopeUpdate::Replaced)
+                } else if key_has_matching_v2_secret(cipher, key, key_id, &secret_hash, &secret)? {
+                    Some(EnvelopeUpdate::AlreadyRewrapped)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            let Some(update) = update else {
+                return Ok(None);
+            };
+            match update {
                 EnvelopeUpdate::Replaced => {
-                    if self.persist().is_err() {
-                        let _ = compare_and_swap_envelope(&self.keys, key_id, &rewrapped, blob);
-                        tracing::warn!("FileKeyStore legacy secret rewrap persist failed");
-                        return None;
+                    if let Err(error) = self.persist_snapshot(&keys, &mcp_tokens) {
+                        if let Some(key) = keys.get_mut(key_id)
+                            && key.secret_encrypted.as_deref() == Some(rewrapped.as_str())
+                        {
+                            key.secret_encrypted = Some(blob);
+                        }
+                        return Err(
+                            error.context("FileKeyStore legacy secret rewrap persist failed")
+                        );
                     }
                 }
                 EnvelopeUpdate::AlreadyRewrapped => {}
             }
         }
-        Some(secret)
+        Ok(Some(secret))
     }
 
     async fn resolve_credentials(
         &self,
         access_key: &str,
         secret_key: &str,
-    ) -> Option<(String, Option<String>)> {
+    ) -> anyhow::Result<Option<(String, Option<String>)>> {
         resolve_credentials_in(&self.keys, access_key, secret_key)
     }
 
-    async fn list_for_user(&self, user_id: &str) -> Vec<ApiKey> {
+    async fn list_for_user(&self, user_id: &str) -> anyhow::Result<Vec<ApiKey>> {
         list_for_user_in(&self.keys, user_id)
     }
 
-    async fn delete_key(&self, key_id: &str, user_id: &str) -> bool {
-        let Ok(_mutation_guard) = self.mutation_lock.lock() else {
-            tracing::warn!("FileKeyStore mutation lock poisoned");
-            return false;
+    async fn delete_key(&self, key_id: &str, user_id: &str) -> anyhow::Result<bool> {
+        let _mutation_guard = self
+            .mutation_lock
+            .lock()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore mutation lock poisoned"))?;
+        let mut keys = self
+            .keys
+            .write()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore API key lock poisoned"))?;
+        let mcp_tokens = self
+            .mcp_tokens
+            .read()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore MCP token lock poisoned"))?
+            .clone();
+        let Some(key) = keys.get(key_id) else {
+            return Ok(false);
         };
-        let removed = {
-            let mut keys = self.keys.write().unwrap();
-            let Some(key) = keys.get(key_id) else {
-                return false;
-            };
-            if key.user_id != user_id {
-                return false;
-            }
-            keys.remove(key_id).expect("key existence checked")
-        };
-        if self.persist().is_err() {
-            self.keys
-                .write()
-                .unwrap()
-                .entry(key_id.to_string())
-                .or_insert(removed);
-            tracing::warn!("FileKeyStore key deletion persist failed");
-            return false;
+        if key.user_id != user_id {
+            return Ok(false);
         }
-        true
+        let removed = keys.remove(key_id).expect("key existence checked");
+        if let Err(error) = self.persist_snapshot(&keys, &mcp_tokens) {
+            keys.insert(key_id.to_string(), removed);
+            return Err(error.context("FileKeyStore key deletion persist failed"));
+        }
+        Ok(true)
     }
 
     async fn create_mcp_token(
@@ -964,21 +1110,21 @@ impl KeyRepository for FileKeyStore {
             .mutation_lock
             .lock()
             .map_err(|_| anyhow::anyhow!("FileKeyStore mutation lock poisoned"))?;
+        let keys = self
+            .keys
+            .read()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore API key lock poisoned"))?
+            .clone();
         let inserted = mcp.clone();
-        let previous = self
+        let mut tokens = self
             .mcp_tokens
             .write()
-            .map_err(|_| anyhow::anyhow!("FileKeyStore MCP token lock poisoned"))?
-            .insert(token_hash.clone(), mcp);
-        if let Err(error) = self.persist() {
-            let mut tokens = self.mcp_tokens.write().map_err(|_| {
-                anyhow::anyhow!(
-                    "FileKeyStore MCP token persist failed and rollback lock was poisoned: {error}"
-                )
-            })?;
+            .map_err(|_| anyhow::anyhow!("FileKeyStore MCP token lock poisoned"))?;
+        let previous = tokens.insert(token_hash.clone(), mcp);
+        if let Err(error) = self.persist_snapshot(&keys, &tokens) {
             if tokens.get(&token_hash) == Some(&inserted) {
                 if let Some(previous) = previous {
-                    tokens.insert(token_hash, previous);
+                    tokens.insert(token_hash.clone(), previous);
                 } else {
                     tokens.remove(&token_hash);
                 }
@@ -988,51 +1134,58 @@ impl KeyRepository for FileKeyStore {
         Ok((token, inserted))
     }
 
-    async fn resolve_mcp_token(&self, token: &str) -> Option<String> {
+    async fn resolve_mcp_token(&self, token: &str) -> anyhow::Result<Option<String>> {
         let hash = sha256_hash(token);
-        let tokens = self.mcp_tokens.read().unwrap();
-        let t = tokens.get(&hash)?;
+        let tokens = self
+            .mcp_tokens
+            .read()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore MCP token lock poisoned"))?;
+        let Some(t) = tokens.get(&hash) else {
+            return Ok(None);
+        };
         if is_expired(t.expires_at.as_deref()) {
-            return None;
+            return Ok(None);
         }
-        Some(t.user_id.clone())
+        Ok(Some(t.user_id.clone()))
     }
 
-    async fn list_mcp_tokens(&self, user_id: &str) -> Vec<McpToken> {
-        self.mcp_tokens
+    async fn list_mcp_tokens(&self, user_id: &str) -> anyhow::Result<Vec<McpToken>> {
+        Ok(self
+            .mcp_tokens
             .read()
-            .unwrap()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore MCP token lock poisoned"))?
             .values()
             .filter(|t| t.user_id == user_id)
             .cloned()
-            .collect()
+            .collect())
     }
 
-    async fn delete_mcp_token(&self, token_hash: &str, user_id: &str) -> bool {
-        let Ok(_mutation_guard) = self.mutation_lock.lock() else {
-            tracing::warn!("FileKeyStore mutation lock poisoned");
-            return false;
+    async fn delete_mcp_token(&self, token_hash: &str, user_id: &str) -> anyhow::Result<bool> {
+        let _mutation_guard = self
+            .mutation_lock
+            .lock()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore mutation lock poisoned"))?;
+        let keys = self
+            .keys
+            .read()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore API key lock poisoned"))?
+            .clone();
+        let mut tokens = self
+            .mcp_tokens
+            .write()
+            .map_err(|_| anyhow::anyhow!("FileKeyStore MCP token lock poisoned"))?;
+        let Some(token) = tokens.get(token_hash) else {
+            return Ok(false);
         };
-        let removed = {
-            let mut tokens = self.mcp_tokens.write().unwrap();
-            let Some(token) = tokens.get(token_hash) else {
-                return false;
-            };
-            if token.user_id != user_id {
-                return false;
-            }
-            tokens.remove(token_hash).expect("token existence checked")
-        };
-        if self.persist().is_err() {
-            self.mcp_tokens
-                .write()
-                .unwrap()
-                .entry(token_hash.to_string())
-                .or_insert(removed);
-            tracing::warn!("FileKeyStore MCP token deletion persist failed");
-            return false;
+        if token.user_id != user_id {
+            return Ok(false);
         }
-        true
+        let removed = tokens.remove(token_hash).expect("token existence checked");
+        if let Err(error) = self.persist_snapshot(&keys, &tokens) {
+            tokens.insert(token_hash.to_string(), removed);
+            return Err(error.context("FileKeyStore MCP token deletion persist failed"));
+        }
+        Ok(true)
     }
 }
 
@@ -1051,14 +1204,13 @@ impl From<api_key::Model> for ApiKey {
     }
 }
 
-async fn fetch_key(db: &DatabaseConnection, key_id: &str) -> Option<ApiKey> {
-    api_key::Entity::find()
+async fn fetch_key(db: &DatabaseConnection, key_id: &str) -> anyhow::Result<Option<ApiKey>> {
+    Ok(api_key::Entity::find()
         .filter(api_key::Column::KeyId.eq(key_id.to_string()))
         .one(db)
         .await
-        .ok()
-        .flatten()
-        .map(Into::into)
+        .context("Postgres API key lookup failed")?
+        .map(Into::into))
 }
 
 #[async_trait]
@@ -1069,7 +1221,7 @@ impl KeyRepository for PostgresKeyStore {
         label: &str,
         expires_in: u64,
         public_key_pem: Option<String>,
-    ) -> anyhow::Result<(String, String)> {
+    ) -> anyhow::Result<(String, ApiKey)> {
         let (api_key, secret) = generate_api_key(
             user_id,
             label,
@@ -1093,11 +1245,11 @@ impl KeyRepository for PostgresKeyStore {
             public_key_pem: Set(api_key.public_key_pem.clone()),
             ..Default::default()
         };
-        model
+        let inserted = model
             .insert(&self.db)
             .await
             .context("Postgres API key insert failed")?;
-        Ok((api_key.key_id, secret))
+        Ok((secret, inserted.into()))
     }
 
     async fn set_public_key(
@@ -1117,18 +1269,32 @@ impl KeyRepository for PostgresKeyStore {
             .exec(&self.db)
             .await
             .context("Postgres public key update failed")?;
-        Ok(result.rows_affected == 1)
+        match result.rows_affected {
+            0 => Ok(false),
+            1 => Ok(true),
+            rows => anyhow::bail!("Postgres public key update affected {rows} rows"),
+        }
     }
 
-    async fn get_key(&self, key_id: &str) -> Option<ApiKey> {
+    async fn get_key(&self, key_id: &str) -> anyhow::Result<Option<ApiKey>> {
         fetch_key(&self.db, key_id).await
     }
 
-    async fn decrypt_secret(&self, key_id: &str) -> Option<String> {
-        let cipher = self.cipher.as_deref()?;
-        let key = fetch_key(&self.db, key_id).await?;
-        let blob = key.secret_encrypted?;
-        let (secret, rewrapped) = decrypt_verified_secret(cipher, key_id, &key.secret_hash, &blob)?;
+    async fn decrypt_secret(&self, key_id: &str) -> anyhow::Result<Option<String>> {
+        let Some(cipher) = self.cipher.as_deref() else {
+            return Ok(None);
+        };
+        let Some(key) = fetch_key(&self.db, key_id).await? else {
+            return Ok(None);
+        };
+        let Some(blob) = key.secret_encrypted.clone() else {
+            return Ok(None);
+        };
+        let Some((secret, rewrapped)) =
+            decrypt_verified_secret(cipher, key_id, &key.secret_hash, &blob)?
+        else {
+            return Ok(None);
+        };
         if let Some(rewrapped) = rewrapped {
             let result = api_key::Entity::update_many()
                 .col_expr(
@@ -1142,78 +1308,88 @@ impl KeyRepository for PostgresKeyStore {
             let reread = match result {
                 Ok(update) if update.rows_affected == 1 => false,
                 Ok(update) if update.rows_affected == 0 => true,
-                Ok(update) => {
-                    tracing::warn!(
-                        key_id = key_id,
-                        rows_affected = update.rows_affected,
-                        "Postgres legacy secret rewrap updated multiple rows"
-                    );
-                    return None;
-                }
+                Ok(update) => anyhow::bail!(
+                    "Postgres legacy secret rewrap affected {} rows",
+                    update.rows_affected
+                ),
                 Err(error) => {
-                    tracing::warn!(
-                        key_id = key_id,
-                        "Postgres legacy secret rewrap failed; checking current envelope: {error}"
+                    let current = fetch_key(&self.db, key_id).await?;
+                    if let Some(current) = current.as_ref()
+                        && key_has_matching_v2_secret(
+                            cipher,
+                            current,
+                            key_id,
+                            &key.secret_hash,
+                            &secret,
+                        )?
+                    {
+                        return Ok(Some(secret));
+                    }
+                    return Err(
+                        anyhow::Error::new(error).context("Postgres legacy secret rewrap failed")
                     );
-                    true
                 }
             };
             if reread {
-                let current = fetch_key(&self.db, key_id).await?;
-                if !key_has_matching_v2_secret(cipher, &current, key_id, &key.secret_hash, &secret)
+                let Some(current) = fetch_key(&self.db, key_id).await? else {
+                    return Ok(None);
+                };
+                if !key_has_matching_v2_secret(cipher, &current, key_id, &key.secret_hash, &secret)?
                 {
-                    return None;
+                    return Ok(None);
                 }
             }
         }
-        Some(secret)
+        Ok(Some(secret))
     }
 
     async fn resolve_credentials(
         &self,
         access_key: &str,
         secret_key: &str,
-    ) -> Option<(String, Option<String>)> {
-        let key = fetch_key(&self.db, access_key).await?;
+    ) -> anyhow::Result<Option<(String, Option<String>)>> {
+        let Some(key) = fetch_key(&self.db, access_key).await? else {
+            return Ok(None);
+        };
         if key.secret_hash != sha256_hash(secret_key) {
-            return None;
+            return Ok(None);
         }
         if is_expired(key.expires_at.as_deref()) {
-            return None;
+            return Ok(None);
         }
-        Some((key.user_id, key.public_key_pem))
+        Ok(Some((key.user_id, key.public_key_pem)))
     }
 
-    async fn list_for_user(&self, user_id: &str) -> Vec<ApiKey> {
-        match api_key::Entity::find()
+    async fn list_for_user(&self, user_id: &str) -> anyhow::Result<Vec<ApiKey>> {
+        let rows = api_key::Entity::find()
             .filter(api_key::Column::UserId.eq(user_id.to_string()))
             .order_by_desc(api_key::Column::CreatedAt)
             .all(&self.db)
             .await
-        {
-            Ok(rows) => rows
-                .into_iter()
-                .map(|m| {
-                    let mut k: ApiKey = m.into();
-                    k.secret_hash = String::new();
-                    k.secret_encrypted = None;
-                    k
-                })
-                .collect(),
-            Err(e) => {
-                tracing::warn!("list_for_user failed: {e}");
-                Vec::new()
-            }
-        }
+            .context("Postgres API key list failed")?;
+        Ok(rows
+            .into_iter()
+            .map(|m| {
+                let mut k: ApiKey = m.into();
+                k.secret_hash = String::new();
+                k.secret_encrypted = None;
+                k
+            })
+            .collect())
     }
 
-    async fn delete_key(&self, key_id: &str, user_id: &str) -> bool {
+    async fn delete_key(&self, key_id: &str, user_id: &str) -> anyhow::Result<bool> {
         let result = api_key::Entity::delete_many()
             .filter(api_key::Column::KeyId.eq(key_id.to_string()))
             .filter(api_key::Column::UserId.eq(user_id.to_string()))
             .exec(&self.db)
-            .await;
-        matches!(result, Ok(r) if r.rows_affected == 1)
+            .await
+            .context("Postgres API key delete failed")?;
+        match result.rows_affected {
+            0 => Ok(false),
+            1 => Ok(true),
+            rows => anyhow::bail!("Postgres API key delete affected {rows} rows"),
+        }
     }
 
     async fn create_mcp_token(
@@ -1252,74 +1428,83 @@ impl KeyRepository for PostgresKeyStore {
         ))
     }
 
-    async fn resolve_mcp_token(&self, token: &str) -> Option<String> {
+    async fn resolve_mcp_token(&self, token: &str) -> anyhow::Result<Option<String>> {
         let hash = sha256_hash(token);
         let row = mcp_token::Entity::find()
             .filter(mcp_token::Column::TokenHash.eq(hash))
             .one(&self.db)
             .await
-            .ok()?;
-        let row = row?;
+            .context("Postgres MCP token lookup failed")?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
         if is_expired(row.expires_at.as_ref().map(|e| e.to_string()).as_deref()) {
-            return None;
+            return Ok(None);
         }
-        Some(row.user_id)
+        Ok(Some(row.user_id))
     }
 
-    async fn list_mcp_tokens(&self, user_id: &str) -> Vec<McpToken> {
-        match mcp_token::Entity::find()
+    async fn list_mcp_tokens(&self, user_id: &str) -> anyhow::Result<Vec<McpToken>> {
+        let rows = mcp_token::Entity::find()
             .filter(mcp_token::Column::UserId.eq(user_id.to_string()))
             .order_by_desc(mcp_token::Column::CreatedAt)
             .all(&self.db)
             .await
-        {
-            Ok(rows) => rows
-                .into_iter()
-                .map(|m| McpToken {
-                    token_hash: m.token_hash,
-                    user_id: m.user_id,
-                    label: m.label,
-                    created_at: m.created_at.to_string(),
-                    expires_at: m.expires_at.map(|e| e.to_string()),
-                })
-                .collect(),
-            Err(e) => {
-                tracing::warn!("list_mcp_tokens failed: {e}");
-                Vec::new()
-            }
-        }
+            .context("Postgres MCP token list failed")?;
+        Ok(rows
+            .into_iter()
+            .map(|m| McpToken {
+                token_hash: m.token_hash,
+                user_id: m.user_id,
+                label: m.label,
+                created_at: m.created_at.to_string(),
+                expires_at: m.expires_at.map(|e| e.to_string()),
+            })
+            .collect())
     }
 
-    async fn delete_mcp_token(&self, token_hash: &str, user_id: &str) -> bool {
+    async fn delete_mcp_token(&self, token_hash: &str, user_id: &str) -> anyhow::Result<bool> {
         let result = mcp_token::Entity::delete_many()
             .filter(mcp_token::Column::TokenHash.eq(token_hash.to_string()))
             .filter(mcp_token::Column::UserId.eq(user_id.to_string()))
             .exec(&self.db)
-            .await;
-        matches!(result, Ok(r) if r.rows_affected == 1)
+            .await
+            .context("Postgres MCP token delete failed")?;
+        match result.rows_affected {
+            0 => Ok(false),
+            1 => Ok(true),
+            rows => anyhow::bail!("Postgres MCP token delete affected {rows} rows"),
+        }
     }
 }
 
 /// Load a persisted FileKeyStore payload (keys + mcp_tokens), tolerating the
 /// legacy keys-only JSON shape.
-fn load_file_store(path: &PathBuf) -> (HashMap<String, ApiKey>, HashMap<String, McpToken>) {
+fn load_file_store(
+    path: &Path,
+) -> anyhow::Result<(HashMap<String, ApiKey>, HashMap<String, McpToken>)> {
     #[derive(serde::Deserialize)]
+    #[serde(deny_unknown_fields)]
     struct Persisted {
-        keys: Option<HashMap<String, ApiKey>>,
-        mcp_tokens: Option<HashMap<String, McpToken>>,
+        #[serde(default)]
+        keys: HashMap<String, ApiKey>,
+        #[serde(default)]
+        mcp_tokens: HashMap<String, McpToken>,
     }
-    let Some(s) = std::fs::read_to_string(path).ok() else {
-        return (HashMap::new(), HashMap::new());
+    let payload = match std::fs::read_to_string(path) {
+        Ok(payload) => payload,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok((HashMap::new(), HashMap::new()));
+        }
+        Err(error) => return Err(error).context("FileKeyStore snapshot read failed"),
     };
-    if let Ok(data) = serde_json::from_str::<Persisted>(&s) {
-        return (
-            data.keys.unwrap_or_default(),
-            data.mcp_tokens.unwrap_or_default(),
-        );
+    if let Ok(data) = serde_json::from_str::<Persisted>(&payload) {
+        return Ok((data.keys, data.mcp_tokens));
     }
     // Legacy shape: bare keys map.
-    let keys: HashMap<String, ApiKey> = serde_json::from_str(&s).unwrap_or_default();
-    (keys, HashMap::new())
+    let keys = serde_json::from_str::<HashMap<String, ApiKey>>(&payload)
+        .context("FileKeyStore snapshot is invalid as current and legacy formats")?;
+    Ok((keys, HashMap::new()))
 }
 
 fn is_expired(expires_at: Option<&str>) -> bool {
@@ -1372,6 +1557,32 @@ mod tests {
 
         fn unwrap(&self, _wrapped: &[u8]) -> anyhow::Result<Vec<u8>> {
             Err(anyhow::anyhow!("intentional unwrap failure"))
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingUnwrapKeyWrapping(LocalKeyWrapping);
+
+    impl KeyWrapping for FailingUnwrapKeyWrapping {
+        fn wrap(&self, dek: &[u8]) -> anyhow::Result<Vec<u8>> {
+            self.0.wrap(dek)
+        }
+
+        fn unwrap(&self, _wrapped: &[u8]) -> anyhow::Result<Vec<u8>> {
+            Err(anyhow::anyhow!("intentional unwrap failure"))
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingWrapKeyWrapping(LocalKeyWrapping);
+
+    impl KeyWrapping for FailingWrapKeyWrapping {
+        fn wrap(&self, _dek: &[u8]) -> anyhow::Result<Vec<u8>> {
+            Err(anyhow::anyhow!("intentional wrap failure"))
+        }
+
+        fn unwrap(&self, wrapped: &[u8]) -> anyhow::Result<Vec<u8>> {
+            self.0.unwrap(wrapped)
         }
     }
 
@@ -1452,7 +1663,7 @@ mod tests {
                 .await
                 .is_ok()
         );
-        let stored = store.list_for_user("u1").await;
+        let stored = store.list_for_user("u1").await.unwrap();
         assert_eq!(stored[0].label, "bounded");
         assert_eq!(
             stored[0].public_key_pem.as_deref(),
@@ -1483,10 +1694,12 @@ mod tests {
     #[tokio::test]
     async fn in_memory_key_roundtrip() {
         let store = KeyStore::new();
-        let (key_id, secret) = store.create_key("u1", "test", 0, None).await.unwrap();
+        let (secret, created) = store.create_key("u1", "test", 0, None).await.unwrap();
+        let key_id = created.key_id;
         let (uid, pk) = store
             .resolve_credentials(&key_id, &secret)
             .await
+            .unwrap()
             .expect("valid credentials should resolve");
         assert_eq!(uid, "u1");
         assert!(pk.is_none());
@@ -1495,15 +1708,23 @@ mod tests {
                 .get_key(&key_id)
                 .await
                 .unwrap()
+                .unwrap()
                 .secret_encrypted
                 .is_none(),
             "a store without a cipher may create a hash-only key"
         );
-        assert!(store.resolve_credentials(&key_id, "nope").await.is_none());
+        assert!(
+            store
+                .resolve_credentials(&key_id, "nope")
+                .await
+                .unwrap()
+                .is_none()
+        );
         assert!(
             store
                 .resolve_credentials("missing", &secret)
                 .await
+                .unwrap()
                 .is_none()
         );
     }
@@ -1519,6 +1740,51 @@ mod tests {
 
         assert!(error.to_string().contains("secret encryption failed"));
         assert!(store.keys.read().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn wrapping_provider_unwrap_failure_is_a_repository_error() {
+        let cipher = Arc::new(SecretCipher::new(Arc::new(FailingUnwrapKeyWrapping(
+            LocalKeyWrapping::with_kek([7; 32]),
+        ))));
+        let store = KeyStore::with_cipher(cipher);
+        let (_, created) = store
+            .create_key("u1", "unwrap-failure", 0, None)
+            .await
+            .unwrap();
+
+        let error = store.decrypt_secret(&created.key_id).await.unwrap_err();
+        assert!(error.to_string().contains("wrapping provider failed"));
+    }
+
+    #[tokio::test]
+    async fn legacy_rewrap_encryption_failure_is_a_repository_error() {
+        let key_id = "s4_legacy";
+        let secret = "s4s_legacy";
+        let legacy = test_cipher().encrypt_v1(secret).unwrap();
+        let cipher = Arc::new(SecretCipher::new(Arc::new(FailingWrapKeyWrapping(
+            LocalKeyWrapping::with_kek([7; 32]),
+        ))));
+        let store = KeyStore {
+            keys: RwLock::new(HashMap::from([(
+                key_id.to_string(),
+                build_api_key(
+                    key_id,
+                    "u1",
+                    "legacy",
+                    sha256_hash(secret),
+                    Some(legacy),
+                    chrono_now(),
+                    None,
+                    None,
+                ),
+            )])),
+            mcp_tokens: RwLock::new(HashMap::new()),
+            cipher: Some(cipher),
+        };
+
+        let error = store.decrypt_secret(key_id).await.unwrap_err();
+        assert!(error.to_string().contains("rewrap encryption failed"));
     }
 
     #[test]
@@ -1554,7 +1820,7 @@ mod tests {
             losing_rewrap,
         );
 
-        assert_eq!(result, Some(EnvelopeUpdate::AlreadyRewrapped));
+        assert_eq!(result.unwrap(), Some(EnvelopeUpdate::AlreadyRewrapped));
         assert_eq!(
             keys.read().unwrap()[key_id].secret_encrypted.as_deref(),
             Some(current_v2.as_str())
@@ -1594,7 +1860,7 @@ mod tests {
             losing_rewrap,
         );
 
-        assert_eq!(result, None);
+        assert_eq!(result.unwrap(), None);
         assert_eq!(
             keys.read().unwrap()[key_id].secret_encrypted.as_deref(),
             Some(current_v2.as_str())
@@ -1602,8 +1868,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn in_memory_create_key_returns_lock_error() {
-        let store = Arc::new(KeyStore::new());
+    async fn in_memory_api_key_operations_return_lock_errors() {
+        let store = Arc::new(KeyStore::with_cipher(test_cipher()));
         let poisoner = store.clone();
         let _ = std::thread::spawn(move || {
             let _keys = poisoner.keys.write().unwrap();
@@ -1611,27 +1877,50 @@ mod tests {
         })
         .join();
 
-        let error = store
-            .create_key("u1", "lock-error", 0, None)
-            .await
-            .unwrap_err();
-        assert!(error.to_string().contains("lock poisoned"));
+        assert!(store.get_key("missing").await.is_err());
+        assert!(store.decrypt_secret("missing").await.is_err());
+        assert!(store.list_for_user("u1").await.is_err());
+        assert!(
+            store
+                .resolve_credentials("missing", "secret")
+                .await
+                .is_err()
+        );
+        assert!(store.delete_key("missing", "u1").await.is_err());
+        assert!(store.create_key("u1", "lock-error", 0, None).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn in_memory_mcp_operations_return_lock_errors() {
+        let store = Arc::new(KeyStore::new());
+        let poisoner = store.clone();
+        let _ = std::thread::spawn(move || {
+            let _tokens = poisoner.mcp_tokens.write().unwrap();
+            panic!("poison MCP token lock");
+        })
+        .join();
+
+        assert!(store.resolve_mcp_token("s4m_missing").await.is_err());
+        assert!(store.list_mcp_tokens("u1").await.is_err());
+        assert!(store.create_mcp_token("u1", "lock-error", 0).await.is_err());
+        assert!(store.delete_mcp_token(&"a".repeat(64), "u1").await.is_err());
     }
 
     #[tokio::test]
     async fn newly_generated_encrypted_secret_uses_v2() {
         let cipher = test_cipher();
         let store = KeyStore::with_cipher(cipher);
-        let (key_id, secret) = store.create_key("u1", "v2", 0, None).await.unwrap();
+        let (secret, created) = store.create_key("u1", "v2", 0, None).await.unwrap();
+        let key_id = created.key_id;
 
-        let key = store.get_key(&key_id).await.expect("key exists");
+        let key = store.get_key(&key_id).await.unwrap().expect("key exists");
         assert!(
             key.secret_encrypted
                 .as_deref()
                 .is_some_and(|blob| blob.starts_with("v2:"))
         );
         assert_eq!(
-            store.decrypt_secret(&key_id).await.as_deref(),
+            store.decrypt_secret(&key_id).await.unwrap().as_deref(),
             Some(secret.as_str())
         );
     }
@@ -1640,7 +1929,8 @@ mod tests {
     async fn in_memory_v1_secret_is_verified_and_rewrapped() {
         let cipher = test_cipher();
         let store = KeyStore::with_cipher(cipher.clone());
-        let (key_id, secret) = store.create_key("u1", "legacy", 0, None).await.unwrap();
+        let (secret, created) = store.create_key("u1", "legacy", 0, None).await.unwrap();
+        let key_id = created.key_id;
         let legacy = cipher.encrypt_v1(&secret).unwrap();
         store
             .keys
@@ -1651,12 +1941,13 @@ mod tests {
             .secret_encrypted = Some(legacy);
 
         assert_eq!(
-            store.decrypt_secret(&key_id).await.as_deref(),
+            store.decrypt_secret(&key_id).await.unwrap().as_deref(),
             Some(secret.as_str())
         );
         let rewrapped = store
             .get_key(&key_id)
             .await
+            .unwrap()
             .unwrap()
             .secret_encrypted
             .unwrap();
@@ -1671,7 +1962,8 @@ mod tests {
     async fn hash_mismatch_never_returns_or_rewraps_secret() {
         let cipher = test_cipher();
         let store = KeyStore::with_cipher(cipher.clone());
-        let (key_id, secret) = store.create_key("u1", "legacy", 0, None).await.unwrap();
+        let (secret, created) = store.create_key("u1", "legacy", 0, None).await.unwrap();
+        let key_id = created.key_id;
         let legacy = cipher.encrypt_v1(&secret).unwrap();
         {
             let mut keys = store.keys.write().unwrap();
@@ -1680,9 +1972,14 @@ mod tests {
             key.secret_encrypted = Some(legacy.clone());
         }
 
-        assert_eq!(store.decrypt_secret(&key_id).await, None);
+        assert_eq!(store.decrypt_secret(&key_id).await.unwrap(), None);
         assert_eq!(
-            store.get_key(&key_id).await.unwrap().secret_encrypted,
+            store
+                .get_key(&key_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .secret_encrypted,
             Some(legacy)
         );
     }
@@ -1691,8 +1988,10 @@ mod tests {
     async fn swapped_v2_store_envelopes_are_rejected() {
         let cipher = test_cipher();
         let store = KeyStore::with_cipher(cipher);
-        let (key_a, _) = store.create_key("u1", "a", 0, None).await.unwrap();
-        let (key_b, _) = store.create_key("u1", "b", 0, None).await.unwrap();
+        let (_, key_a) = store.create_key("u1", "a", 0, None).await.unwrap();
+        let (_, key_b) = store.create_key("u1", "b", 0, None).await.unwrap();
+        let key_a = key_a.key_id;
+        let key_b = key_b.key_id;
         {
             let mut keys = store.keys.write().unwrap();
             let envelope_a = keys[&key_a].secret_encrypted.clone();
@@ -1701,23 +2000,31 @@ mod tests {
             keys.get_mut(&key_b).unwrap().secret_encrypted = envelope_a;
         }
 
-        assert_eq!(store.decrypt_secret(&key_a).await, None);
-        assert_eq!(store.decrypt_secret(&key_b).await, None);
+        assert_eq!(store.decrypt_secret(&key_a).await.unwrap(), None);
+        assert_eq!(store.decrypt_secret(&key_b).await.unwrap(), None);
     }
 
     #[tokio::test]
     async fn in_memory_expiry_rejects() {
         let store = KeyStore::new();
-        let (key_id, secret) = store.create_key("u1", "exp", 1, None).await.unwrap();
+        let (secret, created) = store.create_key("u1", "exp", 1, None).await.unwrap();
+        let key_id = created.key_id;
         // expiry is now+1s; sleep 1.2s to force it
         tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
-        assert!(store.resolve_credentials(&key_id, &secret).await.is_none());
+        assert!(
+            store
+                .resolve_credentials(&key_id, &secret)
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[tokio::test]
     async fn in_memory_public_key_and_delete() {
         let store = KeyStore::new();
-        let (key_id, _secret) = store.create_key("u1", "enc", 0, None).await.unwrap();
+        let (_, created) = store.create_key("u1", "enc", 0, None).await.unwrap();
+        let key_id = created.key_id;
         assert!(
             store
                 .set_public_key(&key_id, "u1", TEST_PUBLIC_KEY_PEM)
@@ -1730,16 +2037,16 @@ mod tests {
                 .await
                 .unwrap()
         );
-        let key = store.get_key(&key_id).await.expect("key exists");
+        let key = store.get_key(&key_id).await.unwrap().expect("key exists");
         assert_eq!(
             key.public_key_pem.as_deref(),
             Some(TEST_PUBLIC_KEY_PEM.trim())
         );
-        let keys = store.list_for_user("u1").await;
+        let keys = store.list_for_user("u1").await.unwrap();
         assert_eq!(keys.len(), 1);
         assert!(keys[0].secret_hash.is_empty());
-        assert!(store.delete_key(&key_id, "u1").await);
-        assert!(store.get_key(&key_id).await.is_none());
+        assert!(store.delete_key(&key_id, "u1").await.unwrap());
+        assert!(store.get_key(&key_id).await.unwrap().is_none());
     }
 
     fn temp_keys_file() -> PathBuf {
@@ -1748,33 +2055,254 @@ mod tests {
         path
     }
 
+    fn pause_next_persist(
+        store: &FileKeyStore,
+    ) -> (
+        std::sync::mpsc::Receiver<()>,
+        std::sync::mpsc::SyncSender<()>,
+    ) {
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let (resume_tx, resume_rx) = std::sync::mpsc::sync_channel(1);
+        *store.persist_hook.lock().unwrap() = Some(PersistTestHook {
+            entered: entered_tx,
+            resume: resume_rx,
+        });
+        (entered_rx, resume_tx)
+    }
+
+    #[tokio::test]
+    async fn file_store_rejects_corrupt_snapshot_without_overwriting_it() {
+        let path = temp_keys_file();
+        let payload = b"{not-valid-json";
+        std::fs::write(&path, payload).unwrap();
+
+        let error = FileKeyStore::new(path.clone()).unwrap_err();
+
+        assert!(error.to_string().contains("invalid as current and legacy"));
+        assert_eq!(std::fs::read(&path).unwrap(), payload);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn file_store_rejects_unreadable_snapshot_path_without_overwriting_it() {
+        let path = temp_keys_file();
+        std::fs::create_dir_all(&path).unwrap();
+        let marker = path.join("marker");
+        std::fs::write(&marker, "unchanged").unwrap();
+
+        let error = FileKeyStore::new(path.clone()).unwrap_err();
+
+        assert!(error.to_string().contains("snapshot read failed"));
+        assert_eq!(std::fs::read_to_string(marker).unwrap(), "unchanged");
+        std::fs::remove_dir_all(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn file_store_loads_legacy_bare_key_map() {
+        let path = temp_keys_file();
+        let key = build_api_key(
+            "s4_legacy",
+            "u1",
+            "legacy",
+            sha256_hash("secret"),
+            None,
+            chrono_now(),
+            None,
+            None,
+        );
+        std::fs::write(
+            &path,
+            serde_json::to_vec(&HashMap::from([(key.key_id.clone(), key.clone())])).unwrap(),
+        )
+        .unwrap();
+
+        let store = FileKeyStore::new(path.clone()).unwrap();
+
+        assert_eq!(store.get_key(&key.key_id).await.unwrap(), Some(key));
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn file_store_creation_establishes_snapshot_parent_directory() {
+        let root = std::env::temp_dir().join(format!("s4-file-parent-{}", Uuid::new_v4()));
+        let path = root.join("nested").join("keys.json");
+        assert!(!root.exists());
+
+        let store = FileKeyStore::new(path.clone()).unwrap();
+
+        assert!(path.parent().unwrap().is_dir());
+        assert!(store.list_for_user("u1").await.unwrap().is_empty());
+        drop(store);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn file_readers_never_observe_failed_persisted_mutations() {
+        let parent = std::env::temp_dir().join(format!("s4-file-visibility-{}", Uuid::new_v4()));
+        let durable_parent = parent.with_extension("durable");
+        std::fs::create_dir_all(&parent).unwrap();
+        let path = parent.join("keys.json");
+        let store = Arc::new(FileKeyStore::new(path.clone()).unwrap());
+        let (secret, created) = store.create_key("u1", "persisted", 0, None).await.unwrap();
+        let key_id = created.key_id;
+        let token = store
+            .create_mcp_token("u1", "persisted", 0)
+            .await
+            .unwrap()
+            .0;
+        let token_hash = sha256_hash(&token);
+        std::fs::rename(&parent, &durable_parent).unwrap();
+        std::fs::write(&parent, "not a directory").unwrap();
+
+        let (entered, resume) = pause_next_persist(&store);
+        let create_store = store.clone();
+        let create =
+            tokio::spawn(async move { create_store.create_key("u1", "tentative", 0, None).await });
+        entered
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        let read_store = store.clone();
+        let read = tokio::spawn(async move { read_store.list_for_user("u1").await });
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert!(!read.is_finished(), "API key creation must remain hidden");
+        resume.send(()).unwrap();
+        assert!(create.await.unwrap().is_err());
+        assert_eq!(read.await.unwrap().unwrap().len(), 1);
+
+        let (entered, resume) = pause_next_persist(&store);
+        let set_store = store.clone();
+        let set_key = key_id.clone();
+        let set = tokio::spawn(async move {
+            set_store
+                .set_public_key(&set_key, "u1", TEST_PUBLIC_KEY_PEM)
+                .await
+        });
+        entered
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        let read_store = store.clone();
+        let read_key = key_id.clone();
+        let read = tokio::spawn(async move { read_store.get_key(&read_key).await });
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert!(!read.is_finished(), "public key update must remain hidden");
+        resume.send(()).unwrap();
+        assert!(set.await.unwrap().is_err());
+        assert!(
+            read.await
+                .unwrap()
+                .unwrap()
+                .unwrap()
+                .public_key_pem
+                .is_none()
+        );
+
+        let (entered, resume) = pause_next_persist(&store);
+        let delete_store = store.clone();
+        let delete_key = key_id.clone();
+        let delete = tokio::spawn(async move { delete_store.delete_key(&delete_key, "u1").await });
+        entered
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        let read_store = store.clone();
+        let read_key = key_id.clone();
+        let read_secret = secret.clone();
+        let read = tokio::spawn(async move {
+            read_store
+                .resolve_credentials(&read_key, &read_secret)
+                .await
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert!(!read.is_finished(), "API key deletion must remain hidden");
+        resume.send(()).unwrap();
+        assert!(delete.await.unwrap().is_err());
+        assert!(read.await.unwrap().unwrap().is_some());
+
+        let (entered, resume) = pause_next_persist(&store);
+        let create_store = store.clone();
+        let create =
+            tokio::spawn(async move { create_store.create_mcp_token("u1", "tentative", 0).await });
+        entered
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        let read_store = store.clone();
+        let read = tokio::spawn(async move { read_store.list_mcp_tokens("u1").await });
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert!(!read.is_finished(), "MCP token creation must remain hidden");
+        resume.send(()).unwrap();
+        assert!(create.await.unwrap().is_err());
+        assert_eq!(read.await.unwrap().unwrap().len(), 1);
+
+        let (entered, resume) = pause_next_persist(&store);
+        let delete_store = store.clone();
+        let delete_hash = token_hash.clone();
+        let delete =
+            tokio::spawn(async move { delete_store.delete_mcp_token(&delete_hash, "u1").await });
+        entered
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        let read_store = store.clone();
+        let read_token = token.clone();
+        let read = tokio::spawn(async move { read_store.resolve_mcp_token(&read_token).await });
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert!(!read.is_finished(), "MCP token deletion must remain hidden");
+        resume.send(()).unwrap();
+        assert!(delete.await.unwrap().is_err());
+        assert_eq!(read.await.unwrap().unwrap().as_deref(), Some("u1"));
+
+        std::fs::remove_file(&parent).unwrap();
+        std::fs::rename(&durable_parent, &parent).unwrap();
+        drop(store);
+        let restarted = FileKeyStore::new(path).unwrap();
+        assert!(
+            restarted
+                .resolve_credentials(&key_id, &secret)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(
+            restarted
+                .resolve_mcp_token(&token)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("u1")
+        );
+        std::fs::remove_dir_all(parent).unwrap();
+    }
+
     #[tokio::test]
     async fn file_key_store_persists_across_restarts() {
         let path = temp_keys_file();
-        let store = FileKeyStore::new(path.clone());
-        let (key_id, secret) = store.create_key("u1", "persist", 0, None).await.unwrap();
+        let store = FileKeyStore::new(path.clone()).unwrap();
+        let (secret, created) = store.create_key("u1", "persist", 0, None).await.unwrap();
+        let key_id = created.key_id;
         drop(store);
 
         // A fresh store on the same path must see the same key.
-        let reloaded = FileKeyStore::new(path.clone());
+        let reloaded = FileKeyStore::new(path.clone()).unwrap();
         let (uid, _pk) = reloaded
             .resolve_credentials(&key_id, &secret)
             .await
+            .unwrap()
             .expect("credentials survive a restart");
         assert_eq!(uid, "u1");
-        assert!(reloaded.list_for_user("u1").await.len() == 1);
-        assert!(reloaded.delete_key(&key_id, "u1").await);
+        assert!(reloaded.list_for_user("u1").await.unwrap().len() == 1);
+        assert!(reloaded.delete_key(&key_id, "u1").await.unwrap());
         drop(reloaded);
 
-        let empty = FileKeyStore::new(path);
-        assert!(empty.get_key(&key_id).await.is_none());
+        let empty = FileKeyStore::new(path).unwrap();
+        assert!(empty.get_key(&key_id).await.unwrap().is_none());
     }
 
     #[tokio::test]
     async fn file_key_store_rolls_back_key_when_persist_fails() {
         let blocking_parent = temp_keys_file();
+        std::fs::create_dir_all(&blocking_parent).unwrap();
+        let path = blocking_parent.join("keys.json");
+        let store = FileKeyStore::new(path).unwrap();
+        std::fs::remove_dir_all(&blocking_parent).unwrap();
         std::fs::write(&blocking_parent, "not a directory").unwrap();
-        let store = FileKeyStore::new(blocking_parent.join("keys.json"));
 
         let error = store
             .create_key("u1", "persist-error", 0, None)
@@ -1792,8 +2320,8 @@ mod tests {
         let durable_parent = parent.with_extension("durable");
         std::fs::create_dir_all(&parent).unwrap();
         let path = parent.join("keys.json");
-        let store = FileKeyStore::new(path.clone());
-        let (key_id, _) = store
+        let store = FileKeyStore::new(path.clone()).unwrap();
+        let (_, created) = store
             .create_key(
                 "u1",
                 "persisted-public-key",
@@ -1802,6 +2330,7 @@ mod tests {
             )
             .await
             .unwrap();
+        let key_id = created.key_id;
         std::fs::rename(&parent, &durable_parent).unwrap();
         std::fs::write(&parent, "not a directory").unwrap();
 
@@ -1816,6 +2345,7 @@ mod tests {
                 .get_key(&key_id)
                 .await
                 .unwrap()
+                .unwrap()
                 .public_key_pem
                 .as_deref(),
             Some(TEST_PUBLIC_KEY_PEM.trim())
@@ -1824,11 +2354,12 @@ mod tests {
         std::fs::rename(&durable_parent, &parent).unwrap();
         drop(store);
 
-        let restarted = FileKeyStore::new(path);
+        let restarted = FileKeyStore::new(path).unwrap();
         assert_eq!(
             restarted
                 .get_key(&key_id)
                 .await
+                .unwrap()
                 .unwrap()
                 .public_key_pem
                 .as_deref(),
@@ -1843,22 +2374,30 @@ mod tests {
         let durable_parent = parent.with_extension("durable");
         std::fs::create_dir_all(&parent).unwrap();
         let path = parent.join("keys.json");
-        let store = FileKeyStore::new(path.clone());
-        let (key_id, secret) = store.create_key("u1", "delete", 0, None).await.unwrap();
+        let store = FileKeyStore::new(path.clone()).unwrap();
+        let (secret, created) = store.create_key("u1", "delete", 0, None).await.unwrap();
+        let key_id = created.key_id;
         std::fs::rename(&parent, &durable_parent).unwrap();
         std::fs::write(&parent, "not a directory").unwrap();
 
-        assert!(!store.delete_key(&key_id, "u1").await);
-        assert!(store.resolve_credentials(&key_id, &secret).await.is_some());
+        assert!(store.delete_key(&key_id, "u1").await.is_err());
+        assert!(
+            store
+                .resolve_credentials(&key_id, &secret)
+                .await
+                .unwrap()
+                .is_some()
+        );
         std::fs::remove_file(&parent).unwrap();
         std::fs::rename(&durable_parent, &parent).unwrap();
         drop(store);
 
-        let restarted = FileKeyStore::new(path);
+        let restarted = FileKeyStore::new(path).unwrap();
         assert!(
             restarted
                 .resolve_credentials(&key_id, &secret)
                 .await
+                .unwrap()
                 .is_some(),
             "failed revocation must not be acknowledged only in memory"
         );
@@ -1871,7 +2410,7 @@ mod tests {
         let durable_parent = parent.with_extension("durable");
         std::fs::create_dir_all(&parent).unwrap();
         let path = parent.join("keys.json");
-        let store = FileKeyStore::new(path.clone());
+        let store = FileKeyStore::new(path.clone()).unwrap();
         let persisted_token = store
             .create_mcp_token("u1", "persisted", 0)
             .await
@@ -1882,32 +2421,38 @@ mod tests {
         std::fs::write(&parent, "not a directory").unwrap();
 
         assert!(store.create_mcp_token("u1", "rejected", 0).await.is_err());
-        assert!(!store.delete_mcp_token(&persisted_hash, "u1").await);
+        assert!(store.delete_mcp_token(&persisted_hash, "u1").await.is_err());
         assert_eq!(
-            store.resolve_mcp_token(&persisted_token).await.as_deref(),
+            store
+                .resolve_mcp_token(&persisted_token)
+                .await
+                .unwrap()
+                .as_deref(),
             Some("u1")
         );
         std::fs::remove_file(&parent).unwrap();
         std::fs::rename(&durable_parent, &parent).unwrap();
         drop(store);
 
-        let restarted = FileKeyStore::new(path);
+        let restarted = FileKeyStore::new(path).unwrap();
         assert_eq!(
             restarted
                 .resolve_mcp_token(&persisted_token)
                 .await
+                .unwrap()
                 .as_deref(),
             Some("u1")
         );
-        assert_eq!(restarted.list_mcp_tokens("u1").await.len(), 1);
+        assert_eq!(restarted.list_mcp_tokens("u1").await.unwrap().len(), 1);
         std::fs::remove_dir_all(parent).unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn file_key_store_serializes_public_key_set_before_successful_delete() {
         let path = temp_keys_file();
-        let store = Arc::new(FileKeyStore::new(path.clone()));
-        let (key_id, secret) = store.create_key("u1", "race", 0, None).await.unwrap();
+        let store = Arc::new(FileKeyStore::new(path.clone()).unwrap());
+        let (secret, created) = store.create_key("u1", "race", 0, None).await.unwrap();
+        let key_id = created.key_id;
         let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
         let (resume_tx, resume_rx) = std::sync::mpsc::sync_channel(1);
         *store.persist_hook.lock().unwrap() = Some(PersistTestHook {
@@ -1937,15 +2482,22 @@ mod tests {
 
         resume_tx.send(()).unwrap();
         assert!(set_task.await.unwrap().unwrap());
-        assert!(delete_task.await.unwrap());
-        assert!(store.resolve_credentials(&key_id, &secret).await.is_none());
+        assert!(delete_task.await.unwrap().unwrap());
+        assert!(
+            store
+                .resolve_credentials(&key_id, &secret)
+                .await
+                .unwrap()
+                .is_none()
+        );
         drop(store);
 
-        let restarted = FileKeyStore::new(path.clone());
+        let restarted = FileKeyStore::new(path.clone()).unwrap();
         assert!(
             restarted
                 .resolve_credentials(&key_id, &secret)
                 .await
+                .unwrap()
                 .is_none(),
             "a successfully revoked key must never reappear after restart"
         );
@@ -1955,7 +2507,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn file_key_store_serializes_api_key_and_mcp_creation_snapshots() {
         let path = temp_keys_file();
-        let store = Arc::new(FileKeyStore::new(path.clone()));
+        let store = Arc::new(FileKeyStore::new(path.clone()).unwrap());
         let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
         let (resume_tx, resume_rx) = std::sync::mpsc::sync_channel(1);
         *store.persist_hook.lock().unwrap() = Some(PersistTestHook {
@@ -1982,19 +2534,25 @@ mod tests {
         );
 
         resume_tx.send(()).unwrap();
-        let (key_id, secret) = key_task.await.unwrap().unwrap();
+        let (secret, created) = key_task.await.unwrap().unwrap();
+        let key_id = created.key_id;
         let token = mcp_task.await.unwrap().unwrap().0;
         drop(store);
 
-        let restarted = FileKeyStore::new(path.clone());
+        let restarted = FileKeyStore::new(path.clone()).unwrap();
         assert!(
             restarted
                 .resolve_credentials(&key_id, &secret)
                 .await
+                .unwrap()
                 .is_some()
         );
         assert_eq!(
-            restarted.resolve_mcp_token(&token).await.as_deref(),
+            restarted
+                .resolve_mcp_token(&token)
+                .await
+                .unwrap()
+                .as_deref(),
             Some("u1")
         );
         std::fs::remove_file(path).unwrap();
@@ -2004,8 +2562,9 @@ mod tests {
     async fn file_key_store_serializes_secret_rewrap_and_mcp_creation() {
         let path = temp_keys_file();
         let cipher = test_cipher();
-        let store = Arc::new(FileKeyStore::with_cipher(path.clone(), cipher.clone()));
-        let (key_id, secret) = store.create_key("u1", "legacy", 0, None).await.unwrap();
+        let store = Arc::new(FileKeyStore::with_cipher(path.clone(), cipher.clone()).unwrap());
+        let (secret, created) = store.create_key("u1", "legacy", 0, None).await.unwrap();
+        let key_id = created.key_id;
         let legacy = cipher.encrypt_v1(&secret).unwrap();
         store
             .keys
@@ -2039,17 +2598,24 @@ mod tests {
         );
 
         resume_tx.send(()).unwrap();
-        assert_eq!(rewrap_task.await.unwrap().as_deref(), Some(secret.as_str()));
+        assert_eq!(
+            rewrap_task.await.unwrap().unwrap().as_deref(),
+            Some(secret.as_str())
+        );
         let token = mcp_task.await.unwrap().unwrap().0;
         drop(store);
 
-        let restarted = FileKeyStore::with_cipher(path.clone(), cipher);
+        let restarted = FileKeyStore::with_cipher(path.clone(), cipher).unwrap();
         assert_eq!(
-            restarted.decrypt_secret(&key_id).await.as_deref(),
+            restarted.decrypt_secret(&key_id).await.unwrap().as_deref(),
             Some(secret.as_str())
         );
         assert_eq!(
-            restarted.resolve_mcp_token(&token).await.as_deref(),
+            restarted
+                .resolve_mcp_token(&token)
+                .await
+                .unwrap()
+                .as_deref(),
             Some("u1")
         );
         std::fs::remove_file(path).unwrap();
@@ -2058,7 +2624,7 @@ mod tests {
     #[tokio::test]
     async fn file_key_store_mcp_delete_does_not_self_deadlock_and_persists() {
         let path = temp_keys_file();
-        let store = FileKeyStore::new(path.clone());
+        let store = FileKeyStore::new(path.clone()).unwrap();
         let token = store.create_mcp_token("u1", "delete", 0).await.unwrap().0;
         let token_hash = sha256_hash(&token);
 
@@ -2069,18 +2635,19 @@ mod tests {
             )
             .await
             .expect("MCP delete must not deadlock")
+            .unwrap()
         );
         drop(store);
 
-        let restarted = FileKeyStore::new(path.clone());
-        assert!(restarted.resolve_mcp_token(&token).await.is_none());
+        let restarted = FileKeyStore::new(path.clone()).unwrap();
+        assert!(restarted.resolve_mcp_token(&token).await.unwrap().is_none());
         std::fs::remove_file(path).unwrap();
     }
 
     #[tokio::test]
     async fn configured_cipher_failure_does_not_create_or_persist_file_key() {
         let path = temp_keys_file();
-        let store = FileKeyStore::with_cipher(path.clone(), failing_cipher());
+        let store = FileKeyStore::with_cipher(path.clone(), failing_cipher()).unwrap();
 
         let error = store
             .create_key("u1", "encryption-error", 0, None)
@@ -2139,6 +2706,80 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn postgres_reads_lists_resolves_and_deletes_propagate_database_errors() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(std::time::Duration::from_millis(50))
+            .connect_lazy("postgresql://postgres:postgres@127.0.0.1:1/s4")
+            .unwrap();
+        let store = PostgresKeyStore::with_cipher(pool, test_cipher());
+
+        assert!(
+            store
+                .get_key("s4_missing")
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("Postgres API key lookup failed")
+        );
+        assert!(
+            store
+                .decrypt_secret("s4_missing")
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("Postgres API key lookup failed")
+        );
+        assert!(
+            store
+                .resolve_credentials("s4_missing", "s4s_missing")
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("Postgres API key lookup failed")
+        );
+        assert!(
+            store
+                .list_for_user("u1")
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("Postgres API key list failed")
+        );
+        assert!(
+            store
+                .delete_key("s4_missing", "u1")
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("Postgres API key delete failed")
+        );
+        assert!(
+            store
+                .resolve_mcp_token("s4m_missing")
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("Postgres MCP token lookup failed")
+        );
+        assert!(
+            store
+                .list_mcp_tokens("u1")
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("Postgres MCP token list failed")
+        );
+        assert!(
+            store
+                .delete_mcp_token(&"a".repeat(64), "u1")
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("Postgres MCP token delete failed")
+        );
+    }
+
+    #[tokio::test]
     async fn postgres_configured_cipher_failure_prevents_insert() {
         let pool = sqlx::postgres::PgPoolOptions::new()
             .acquire_timeout(std::time::Duration::from_millis(50))
@@ -2157,8 +2798,9 @@ mod tests {
     #[tokio::test]
     async fn file_key_store_persists_public_key_and_expiry() {
         let path = temp_keys_file();
-        let store = FileKeyStore::new(path.clone());
-        let (key_id, _secret) = store.create_key("u1", "enc", 3600, None).await.unwrap();
+        let store = FileKeyStore::new(path.clone()).unwrap();
+        let (_, created) = store.create_key("u1", "enc", 3600, None).await.unwrap();
+        let key_id = created.key_id;
         assert!(
             store
                 .set_public_key(&key_id, "u1", TEST_PUBLIC_KEY_PEM)
@@ -2173,8 +2815,12 @@ mod tests {
         );
         drop(store);
 
-        let reloaded = FileKeyStore::new(path);
-        let key = reloaded.get_key(&key_id).await.expect("key exists");
+        let reloaded = FileKeyStore::new(path).unwrap();
+        let key = reloaded
+            .get_key(&key_id)
+            .await
+            .unwrap()
+            .expect("key exists");
         assert_eq!(
             key.public_key_pem.as_deref(),
             Some(TEST_PUBLIC_KEY_PEM.trim())
@@ -2186,8 +2832,9 @@ mod tests {
     async fn file_key_store_persists_v1_rewrap() {
         let path = temp_keys_file();
         let cipher = test_cipher();
-        let store = FileKeyStore::with_cipher(path.clone(), cipher.clone());
-        let (key_id, secret) = store.create_key("u1", "legacy", 0, None).await.unwrap();
+        let store = FileKeyStore::with_cipher(path.clone(), cipher.clone()).unwrap();
+        let (secret, created) = store.create_key("u1", "legacy", 0, None).await.unwrap();
+        let key_id = created.key_id;
         let legacy = cipher.encrypt_v1(&secret).unwrap();
         store
             .keys
@@ -2199,21 +2846,22 @@ mod tests {
         store.persist().unwrap();
 
         assert_eq!(
-            store.decrypt_secret(&key_id).await.as_deref(),
+            store.decrypt_secret(&key_id).await.unwrap().as_deref(),
             Some(secret.as_str())
         );
         drop(store);
 
-        let reloaded = FileKeyStore::with_cipher(path.clone(), cipher);
+        let reloaded = FileKeyStore::with_cipher(path.clone(), cipher).unwrap();
         let envelope = reloaded
             .get_key(&key_id)
             .await
+            .unwrap()
             .unwrap()
             .secret_encrypted
             .unwrap();
         assert!(envelope.starts_with("v2:"));
         assert_eq!(
-            reloaded.decrypt_secret(&key_id).await.as_deref(),
+            reloaded.decrypt_secret(&key_id).await.unwrap().as_deref(),
             Some(secret.as_str())
         );
         let _ = std::fs::remove_file(path);

--- a/crates/gateway/tests/db_keys_test.rs
+++ b/crates/gateway/tests/db_keys_test.rs
@@ -435,17 +435,22 @@ fn postgres_secret_envelope_roundtrip() {
         ))));
         let store = PostgresKeyStore::with_cipher(pool, cipher);
         let user = format!("unit-{}", uuid::Uuid::new_v4());
-        let (key_id, secret) = store
+        let (secret, created) = store
             .create_key(&user, "encrypted", 0, None)
             .await
             .expect("create encrypted Postgres API key");
+        let key_id = created.key_id;
 
-        let persisted = store.get_key(&key_id).await.expect("persisted key");
+        let persisted = store
+            .get_key(&key_id)
+            .await
+            .expect("read persisted key")
+            .expect("persisted key");
         let envelope = persisted.secret_encrypted.expect("encrypted secret");
         assert!(envelope.starts_with("v2:"));
         assert!(!envelope.contains(&secret));
         assert_eq!(
-            store.decrypt_secret(&key_id).await.as_deref(),
+            store.decrypt_secret(&key_id).await.unwrap().as_deref(),
             Some(secret.as_str())
         );
         delete_api_key(&db, &key_id).await;
@@ -936,15 +941,16 @@ fn postgres_v1_secret_is_rewrapped_to_identity_bound_v2() {
         ))));
         let store = PostgresKeyStore::with_cipher(pool, cipher.clone());
         let user = format!("unit-v1-{}", uuid::Uuid::new_v4());
-        let (key_id, secret) = store
+        let (secret, created) = store
             .create_key(&user, "legacy-rewrap", 0, None)
             .await
             .expect("create Postgres API key");
+        let key_id = created.key_id;
         let legacy = v1_envelope(&secret);
         update_secret_state(&db, &key_id, None, &legacy).await;
 
         assert_eq!(
-            store.decrypt_secret(&key_id).await.as_deref(),
+            store.decrypt_secret(&key_id).await.unwrap().as_deref(),
             Some(secret.as_str())
         );
 
@@ -970,15 +976,16 @@ fn postgres_v1_hash_mismatch_returns_none_without_rewrap() {
         ))));
         let store = PostgresKeyStore::with_cipher(pool, cipher);
         let user = format!("unit-v1-hash-{}", uuid::Uuid::new_v4());
-        let (key_id, secret) = store
+        let (secret, created) = store
             .create_key(&user, "legacy-hash-mismatch", 0, None)
             .await
             .expect("create Postgres API key");
+        let key_id = created.key_id;
         let legacy = v1_envelope(&secret);
         let mismatched_hash = sha256_hash("different-secret");
         update_secret_state(&db, &key_id, Some(&mismatched_hash), &legacy).await;
 
-        assert_eq!(store.decrypt_secret(&key_id).await, None);
+        assert_eq!(store.decrypt_secret(&key_id).await.unwrap(), None);
 
         let persisted = fetch_api_key(&db, &key_id).await;
         assert_eq!(persisted.secret_hash, mismatched_hash);
@@ -993,10 +1000,11 @@ fn postgres_v1_rewrap_cas_accepts_concurrent_matching_v2() {
         let db = sea_db(pool.clone());
         let initial_store = PostgresKeyStore::new(pool.clone());
         let user = format!("unit-v1-cas-{}", uuid::Uuid::new_v4());
-        let (key_id, secret) = initial_store
+        let (secret, created) = initial_store
             .create_key(&user, "legacy-cas", 0, None)
             .await
             .expect("create hash-only Postgres API key");
+        let key_id = created.key_id;
         let legacy = v1_envelope(&secret);
         update_secret_state(&db, &key_id, None, &legacy).await;
 
@@ -1029,7 +1037,11 @@ fn postgres_v1_rewrap_cas_accepts_concurrent_matching_v2() {
         release_tx.send(()).expect("release legacy rewrap");
 
         assert_eq!(
-            decrypt.await.expect("join legacy decrypt").as_deref(),
+            decrypt
+                .await
+                .expect("join legacy decrypt")
+                .unwrap()
+                .as_deref(),
             Some(secret.as_str())
         );
         let persisted = fetch_api_key(&db, &key_id).await;
@@ -1043,13 +1055,21 @@ fn postgres_key_roundtrip() {
     with_pool(|pool| async move {
         let store = PostgresKeyStore::new(pool);
         let user = format!("unit-{}", uuid::Uuid::new_v4());
-        let (key_id, secret) = store
+        let (secret, created) = store
             .create_key(&user, "roundtrip", 0, None)
             .await
             .expect("create Postgres API key");
+        let key_id = created.key_id.clone();
+        let persisted = store
+            .get_key(&key_id)
+            .await
+            .expect("read persisted key")
+            .expect("persisted key");
+        assert_eq!(created, persisted);
         let (uid, pk) = store
             .resolve_credentials(&key_id, &secret)
             .await
+            .unwrap()
             .expect("valid credentials resolve");
         assert_eq!(uid, user);
         assert!(pk.is_none());
@@ -1057,23 +1077,25 @@ fn postgres_key_roundtrip() {
             store
                 .resolve_credentials(&key_id, "wrong-secret")
                 .await
+                .unwrap()
                 .is_none()
         );
         assert!(
             store
                 .resolve_credentials("missing-key", &secret)
                 .await
+                .unwrap()
                 .is_none()
         );
 
-        let keys = store.list_for_user(&user).await;
+        let keys = store.list_for_user(&user).await.unwrap();
         assert_eq!(keys.len(), 1);
         assert!(keys[0].secret_hash.is_empty(), "list must strip the hash");
         assert_eq!(keys[0].label, "roundtrip");
 
-        assert!(store.delete_key(&key_id, &user).await);
-        assert!(!store.delete_key(&key_id, &user).await);
-        assert!(store.get_key(&key_id).await.is_none());
+        assert!(store.delete_key(&key_id, &user).await.unwrap());
+        assert!(!store.delete_key(&key_id, &user).await.unwrap());
+        assert!(store.get_key(&key_id).await.unwrap().is_none());
     });
 }
 
@@ -1083,10 +1105,11 @@ fn postgres_public_key_binding() {
         let db = sea_db(pool.clone());
         let store = PostgresKeyStore::new(pool);
         let user = format!("unit-{}", uuid::Uuid::new_v4());
-        let (key_id, secret) = store
+        let (secret, created) = store
             .create_key(&user, "enc", 0, None)
             .await
             .expect("create Postgres API key");
+        let key_id = created.key_id;
         assert!(
             store
                 .set_public_key(&key_id, &user, TEST_PUBLIC_KEY_PEM)
@@ -1103,6 +1126,7 @@ fn postgres_public_key_binding() {
         let (uid, pk) = store
             .resolve_credentials(&key_id, &secret)
             .await
+            .unwrap()
             .expect("resolve after binding");
         assert_eq!(uid, user);
         assert_eq!(pk.as_deref(), Some(TEST_PUBLIC_KEY_PEM.trim()));
@@ -1116,13 +1140,18 @@ fn postgres_expired_key_rejected() {
         let db = sea_db(pool.clone());
         let store = PostgresKeyStore::new(pool);
         let user = format!("unit-{}", uuid::Uuid::new_v4());
-        let (key_id, secret) = store
+        let (secret, created) = store
             .create_key(&user, "exp", 1, None)
             .await
             .expect("create Postgres API key");
+        let key_id = created.key_id;
         tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
         assert!(
-            store.resolve_credentials(&key_id, &secret).await.is_none(),
+            store
+                .resolve_credentials(&key_id, &secret)
+                .await
+                .unwrap()
+                .is_none(),
             "expired key must be rejected"
         );
         delete_api_key(&db, &key_id).await;
@@ -1141,6 +1170,7 @@ fn postgres_mcp_creation_returns_persisted_metadata() {
         let listed = store
             .list_mcp_tokens(&user)
             .await
+            .unwrap()
             .into_iter()
             .find(|candidate| candidate.token_hash == created.token_hash)
             .expect("persisted MCP token is listed");
@@ -1149,7 +1179,12 @@ fn postgres_mcp_creation_returns_persisted_metadata() {
         assert_eq!(created, listed);
         assert_eq!(created.label, "agent");
         assert!(created.expires_at.is_some());
-        assert!(store.delete_mcp_token(&created.token_hash, &user).await);
+        assert!(
+            store
+                .delete_mcp_token(&created.token_hash, &user)
+                .await
+                .unwrap()
+        );
     });
 }
 
@@ -1390,11 +1425,12 @@ fn router_staged_multipart_flow_is_durable_and_idempotent() {
         )
         .await
         .expect("build_state with durable staged multipart");
-        let (ak, sk) = state
+        let (sk, created) = state
             .keys
             .create_key("test-user", "multipart-test", 0, None)
             .await
             .expect("create test API key");
+        let ak = created.key_id;
         let app = build_router(state.clone());
         let hdrs = auth_headers(&ak, &sk);
 

--- a/crates/gateway/tests/s3_frontdoor_test.rs
+++ b/crates/gateway/tests/s3_frontdoor_test.rs
@@ -14,13 +14,13 @@ use s4_gateway::backend::{PresignedHttpPolicy, TokioAddressResolver};
 use s4_gateway::control::{
     AuthenticatedRequestContext, ControlPlane, NoopControlPlane, RequestKind, StreamingWriteMode,
 };
-use s4_gateway::key_cipher::default_wrapping;
+use s4_gateway::key_cipher::{KeyWrapping, LocalKeyWrapping, SecretCipher, default_wrapping};
 use s4_gateway::object::BodyLimits;
 use s4_gateway::server::{AppState, StreamingReadMode, build_router, build_state};
 use s4_gateway::sigv4::SigV4Policy;
 use s4_gateway::store::{
-    FileKeyStore, KeyRepository, MAX_CREDENTIAL_LABEL_BYTES, MAX_CREDENTIAL_TTL_SECONDS,
-    MAX_PUBLIC_KEY_PEM_BYTES,
+    FileKeyStore, KeyRepository, KeyStore, MAX_CREDENTIAL_LABEL_BYTES, MAX_CREDENTIAL_TTL_SECONDS,
+    MAX_PUBLIC_KEY_PEM_BYTES, PostgresKeyStore,
 };
 use s4_gateway::transaction::SpoolQuota;
 use s4_gateway::workspace_storage::InMemoryWorkspaceStorageRepository;
@@ -287,13 +287,16 @@ async fn backend_api_requires_real_auth_rejects_unsupported_config_and_never_ret
 }
 
 #[tokio::test]
-async fn create_key_persistence_failure_returns_internal_error_without_secret() {
+async fn create_key_persistence_failure_returns_unavailable_without_secret() {
     let mut state = test_state().await;
     let blocking_parent =
         std::env::temp_dir().join(format!("s4-create-key-failure-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&blocking_parent).unwrap();
+    let file_store = FileKeyStore::new(blocking_parent.join("keys.json")).unwrap();
+    std::fs::remove_dir_all(&blocking_parent).unwrap();
     std::fs::write(&blocking_parent, "not a directory").unwrap();
     let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
-    state_mut.keys = Arc::new(FileKeyStore::new(blocking_parent.join("keys.json")));
+    state_mut.keys = Arc::new(file_store);
     state_mut.auth_disabled = true;
     let app = build_router(state);
 
@@ -305,7 +308,7 @@ async fn create_key_persistence_failure_returns_internal_error_without_secret() 
         .unwrap();
     let response = app.oneshot(request).await.unwrap();
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     let body = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await
         .unwrap();
@@ -315,18 +318,19 @@ async fn create_key_persistence_failure_returns_internal_error_without_secret() 
 }
 
 #[tokio::test]
-async fn public_key_persistence_failure_returns_generic_500_and_rolls_back() {
+async fn public_key_persistence_failure_returns_generic_503_and_rolls_back() {
     let mut state = test_state().await;
     let parent =
         std::env::temp_dir().join(format!("s4-public-key-handler-{}", uuid::Uuid::new_v4()));
     let durable_parent = parent.with_extension("durable");
     std::fs::create_dir_all(&parent).unwrap();
     let path = parent.join("keys.json");
-    let file_store = Arc::new(FileKeyStore::new(path.clone()));
-    let (key_id, secret_key) = file_store
+    let file_store = Arc::new(FileKeyStore::new(path.clone()).unwrap());
+    let (secret_key, created) = file_store
         .create_key("test-user", "persist-failure", 0, None)
         .await
         .unwrap();
+    let key_id = created.key_id;
     Arc::get_mut(&mut state)
         .expect("test state is uniquely owned")
         .keys = file_store.clone();
@@ -340,7 +344,7 @@ async fn public_key_persistence_failure_returns_generic_500_and_rolls_back() {
     );
     let response = app.oneshot(request).await.unwrap();
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     let body = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await
         .unwrap();
@@ -352,6 +356,7 @@ async fn public_key_persistence_failure_returns_generic_500_and_rolls_back() {
             .get_key(&key_id)
             .await
             .unwrap()
+            .unwrap()
             .public_key_pem
             .is_none(),
         "failed persistence must roll back the in-memory value"
@@ -360,11 +365,12 @@ async fn public_key_persistence_failure_returns_generic_500_and_rolls_back() {
     std::fs::rename(&durable_parent, &parent).unwrap();
     drop(file_store);
 
-    let restarted = FileKeyStore::new(path);
+    let restarted = FileKeyStore::new(path).unwrap();
     assert!(
         restarted
             .get_key(&key_id)
             .await
+            .unwrap()
             .unwrap()
             .public_key_pem
             .is_none(),
@@ -373,16 +379,143 @@ async fn public_key_persistence_failure_returns_generic_500_and_rolls_back() {
     std::fs::remove_dir_all(parent).unwrap();
 }
 
+fn unavailable_key_store() -> Arc<dyn KeyRepository> {
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .acquire_timeout(Duration::from_millis(25))
+        .connect_lazy("postgresql://postgres:postgres@127.0.0.1:1/s4")
+        .unwrap();
+    Arc::new(PostgresKeyStore::new(pool))
+}
+
+#[derive(Debug)]
+struct FailingUnwrapWrapping(LocalKeyWrapping);
+
+impl KeyWrapping for FailingUnwrapWrapping {
+    fn wrap(&self, dek: &[u8]) -> anyhow::Result<Vec<u8>> {
+        self.0.wrap(dek)
+    }
+
+    fn unwrap(&self, _wrapped: &[u8]) -> anyhow::Result<Vec<u8>> {
+        Err(anyhow::anyhow!("wrapping provider unavailable"))
+    }
+}
+
+#[tokio::test]
+async fn dashboard_credential_repository_failures_return_generic_503() {
+    let mut state = test_state().await;
+    let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
+    state_mut.keys = unavailable_key_store();
+    state_mut.auth_disabled = true;
+    let app = build_router(state);
+    let requests = [
+        Request::builder()
+            .uri("/dashboard/api/me")
+            .body(Body::empty())
+            .unwrap(),
+        Request::builder()
+            .uri("/dashboard/api/keys")
+            .body(Body::empty())
+            .unwrap(),
+        Request::builder()
+            .method("POST")
+            .uri("/dashboard/api/keys")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(r#"{"label":"unavailable"}"#))
+            .unwrap(),
+        Request::builder()
+            .method("DELETE")
+            .uri("/dashboard/api/keys")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(r#"{"key_id":"s4_missing"}"#))
+            .unwrap(),
+        Request::builder()
+            .uri("/dashboard/api/mcp-tokens")
+            .body(Body::empty())
+            .unwrap(),
+        Request::builder()
+            .method("POST")
+            .uri("/dashboard/api/mcp-tokens")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(r#"{"label":"unavailable"}"#))
+            .unwrap(),
+        Request::builder()
+            .method("DELETE")
+            .uri("/dashboard/api/mcp-tokens")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(format!(
+                r#"{{"token_hash":"{}"}}"#,
+                "a".repeat(64)
+            )))
+            .unwrap(),
+        add_headers(
+            public_key_request("s4_missing", TEST_PUBLIC_KEY_PEM),
+            &auth_headers("s4_missing", "s4s_missing"),
+        ),
+    ];
+
+    for request in requests {
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&body);
+        assert!(!body.contains("s4s_"));
+        assert!(!body.contains("s4m_"));
+        assert!(!body.contains("Postgres"));
+        assert!(!body.contains("127.0.0.1"));
+    }
+}
+
+#[tokio::test]
+async fn credential_authentication_store_failures_return_s3_service_unavailable() {
+    let mut state = test_state().await;
+    Arc::get_mut(&mut state)
+        .expect("test state is uniquely owned")
+        .keys = unavailable_key_store();
+    let app = build_router(state);
+    let requests = [
+        add_headers(
+            Request::builder()
+                .method("PUT")
+                .uri("/outage/key.txt")
+                .body(Body::from("sensitive"))
+                .unwrap(),
+            &auth_headers("s4_missing", "s4s_missing"),
+        ),
+        Request::builder()
+            .method("PUT")
+            .uri("/outage/token.txt")
+            .header("authorization", "Bearer s4m_missing")
+            .body(Body::from("sensitive"))
+            .unwrap(),
+    ];
+
+    for request in requests {
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&body);
+        assert!(body.contains("<Code>ServiceUnavailable</Code>"));
+        assert!(!body.contains("sensitive"));
+        assert!(!body.contains("Postgres"));
+        assert!(!body.contains("127.0.0.1"));
+    }
+}
+
 async fn make_key(state: &Arc<AppState>) -> (String, String) {
     make_key_for(state, "test-user").await
 }
 
 async fn make_key_for(state: &Arc<AppState>, user_id: &str) -> (String, String) {
-    state
+    let (secret, created) = state
         .keys
         .create_key(user_id, "sigv4-test", 0, None)
         .await
-        .expect("create test API key")
+        .expect("create test API key");
+    (created.key_id, secret)
 }
 
 fn configure_dashboard_jwt(state: &mut Arc<AppState>, user_id: &str) -> String {
@@ -540,6 +673,7 @@ async fn public_key_mutation_rejects_unauthenticated_requests_in_production_and_
                 .get_key(&key_id)
                 .await
                 .unwrap()
+                .unwrap()
                 .public_key_pem
                 .is_none(),
             "rejected request must not mutate the key"
@@ -581,6 +715,7 @@ async fn public_key_mutation_rejects_incomplete_or_invalid_api_key_credentials()
                 .keys
                 .get_key(&key_id)
                 .await
+                .unwrap()
                 .unwrap()
                 .public_key_pem
                 .is_none(),
@@ -644,6 +779,7 @@ async fn public_key_mutation_rejects_duplicate_security_headers_without_mutation
                 .keys
                 .get_key(&key_id)
                 .await
+                .unwrap()
                 .unwrap()
                 .public_key_pem
                 .is_none(),
@@ -714,6 +850,7 @@ async fn public_key_mutation_rejects_mixed_credential_classes_without_mutation()
                 .get_key(&key_id)
                 .await
                 .unwrap()
+                .unwrap()
                 .public_key_pem
                 .is_none(),
             "mixed credential classes must not mutate the key"
@@ -755,6 +892,7 @@ async fn public_key_mutation_accepts_own_key_via_headers_and_bearer() {
             .get_key(&header_key)
             .await
             .unwrap()
+            .unwrap()
             .public_key_pem
             .as_deref(),
         Some(TEST_PUBLIC_KEY_PEM.trim())
@@ -764,6 +902,7 @@ async fn public_key_mutation_accepts_own_key_via_headers_and_bearer() {
             .keys
             .get_key(&bearer_key)
             .await
+            .unwrap()
             .unwrap()
             .public_key_pem
             .as_deref(),
@@ -790,6 +929,7 @@ async fn local_public_key_mutation_accepts_real_target_credentials() {
             .keys
             .get_key(&key_id)
             .await
+            .unwrap()
             .unwrap()
             .public_key_pem
             .as_deref(),
@@ -821,6 +961,7 @@ async fn public_key_mutation_rejects_invalid_pem_before_persistence() {
             .keys
             .get_key(&key_id)
             .await
+            .unwrap()
             .unwrap()
             .public_key_pem
             .is_none()
@@ -857,6 +998,7 @@ async fn api_key_public_key_mutation_hides_and_rejects_sibling_and_foreign_keys(
                 .keys
                 .get_key(key_id)
                 .await
+                .unwrap()
                 .unwrap()
                 .public_key_pem
                 .is_none(),
@@ -903,6 +1045,7 @@ async fn jwt_public_key_mutation_is_scoped_to_dashboard_user_ownership() {
             .get_key(&owned_key)
             .await
             .unwrap()
+            .unwrap()
             .public_key_pem
             .as_deref(),
         Some(TEST_PUBLIC_KEY_PEM.trim())
@@ -913,6 +1056,7 @@ async fn jwt_public_key_mutation_is_scoped_to_dashboard_user_ownership() {
             .get_key(&second_owned_key)
             .await
             .unwrap()
+            .unwrap()
             .public_key_pem
             .as_deref(),
         Some(TEST_CERTIFICATE_PEM.trim())
@@ -922,6 +1066,7 @@ async fn jwt_public_key_mutation_is_scoped_to_dashboard_user_ownership() {
             .keys
             .get_key(&foreign_key)
             .await
+            .unwrap()
             .unwrap()
             .public_key_pem
             .is_none(),
@@ -961,6 +1106,7 @@ async fn mcp_tokens_cannot_mutate_public_keys() {
                 .keys
                 .get_key(&key_id)
                 .await
+                .unwrap()
                 .unwrap()
                 .public_key_pem
                 .is_none(),
@@ -1004,6 +1150,7 @@ async fn create_key_still_accepts_an_initial_public_key() {
             .keys
             .get_key(key_id)
             .await
+            .unwrap()
             .unwrap()
             .public_key_pem
             .as_deref(),
@@ -2652,6 +2799,42 @@ async fn sigv4_signed_request_accepted_and_rejected() {
 }
 
 #[tokio::test]
+async fn sigv4_wrapping_provider_failure_returns_generic_service_unavailable() {
+    let mut state = test_state().await;
+    let cipher = Arc::new(SecretCipher::new(Arc::new(FailingUnwrapWrapping(
+        LocalKeyWrapping::with_kek([7; 32]),
+    ))));
+    let store = Arc::new(KeyStore::with_cipher(cipher));
+    let (secret, created) = store
+        .create_key("test-user", "unwrap-outage", 0, None)
+        .await
+        .unwrap();
+    Arc::get_mut(&mut state)
+        .expect("test state is uniquely owned")
+        .keys = store;
+    let app = build_router(state);
+    let request = signed_request(
+        &created.key_id,
+        &secret,
+        "PUT",
+        "http://s4.local/outage/unwrap.txt",
+        b"sensitive",
+        &[],
+    );
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8_lossy(&body);
+    assert!(body.contains("<Code>ServiceUnavailable</Code>"));
+    assert!(!body.contains("wrapping"));
+    assert!(!body.contains("sensitive"));
+}
+
+#[tokio::test]
 async fn sigv4_signed_semantic_headers_accept_and_detect_mutation_or_removal() {
     enum HeaderChange {
         None,
@@ -3154,16 +3337,18 @@ async fn managed_storage_isolates_users() {
     // can act as the other. The namespace prefix itself is exercised
     // end-to-end against real B2 by e2e-b2.sh / e2e-hosted.sh.
     let (app, state) = router().await;
-    let (ak1, sk1) = state
+    let (sk1, created1) = state
         .keys
         .create_key("user-one", "ns-test", 0, None)
         .await
         .expect("create user-one API key");
-    let (ak2, sk2) = state
+    let ak1 = created1.key_id;
+    let (sk2, created2) = state
         .keys
         .create_key("user-two", "ns-test", 0, None)
         .await
         .expect("create user-two API key");
+    let ak2 = created2.key_id;
     let h1 = auth_headers(&ak1, &sk1);
     let h2 = auth_headers(&ak2, &sk2);
 
@@ -3488,11 +3673,12 @@ boto3.client(
 async fn non_expiring_key_works() {
     let (app, state) = router().await;
     // expires_in=0 means never expires.
-    let (ak, sk) = state
+    let (sk, created) = state
         .keys
         .create_key("never-exp", "exp", 0, None)
         .await
         .expect("create non-expiring API key");
+    let ak = created.key_id;
     let hdrs = auth_headers(&ak, &sk);
     let put = add_headers(
         Request::builder()
@@ -3565,8 +3751,20 @@ async fn mcp_token_roundtrip_and_auth() {
 
     // Delete works (returns 200/204).
     let hash = s4_gateway::store::sha256_hash(&token);
-    assert!(state.keys.delete_mcp_token(&hash, "mcp-user").await);
-    assert!(!state.keys.delete_mcp_token(&hash, "mcp-user").await);
+    assert!(
+        state
+            .keys
+            .delete_mcp_token(&hash, "mcp-user")
+            .await
+            .unwrap()
+    );
+    assert!(
+        !state
+            .keys
+            .delete_mcp_token(&hash, "mcp-user")
+            .await
+            .unwrap()
+    );
 }
 
 #[tokio::test]
@@ -3600,8 +3798,8 @@ async fn mcp_token_identity_is_per_user() {
     );
 
     // Tokens resolve to distinct users.
-    let uid1 = state.keys.resolve_mcp_token(&t1).await.unwrap();
-    let uid2 = state.keys.resolve_mcp_token(&t2).await.unwrap();
+    let uid1 = state.keys.resolve_mcp_token(&t1).await.unwrap().unwrap();
+    let uid2 = state.keys.resolve_mcp_token(&t2).await.unwrap().unwrap();
     assert_ne!(uid1, uid2, "tokens must bind to distinct users");
     assert_eq!(uid1, "user-a");
 }

--- a/docs/security.md
+++ b/docs/security.md
@@ -139,6 +139,22 @@ X.509 certificate carrying an RSA key between 2048 and 4096 bits, matching the
 formats consumed by the envelope-encryption filter. Credential JSON endpoints
 also have route-specific body limits; oversized requests receive `413`.
 
+Credential creation returns plaintext only after the repository has committed
+the new credential. File-backed mutations remain hidden from concurrent readers
+until snapshot persistence succeeds, and failed mutations restore the prior
+state before readers resume. Repository failures are reported as service
+unavailable; they are never treated as a missing credential, an empty list, or
+an authentication denial.
+
+The file-backed repository writes and synchronizes a permission-restricted
+temporary snapshot, then atomically renames it as the mutation commit boundary.
+It attempts to synchronize the parent directory after rename; failure is warned
+but cannot make the already-published snapshot uncommitted. This provides
+committed atomic visibility, not an absolute power-loss durability guarantee.
+Missing snapshots start empty; unreadable or invalid snapshots stop startup
+instead of being replaced. This repository is a single gateway-instance
+abstraction and does not provide multi-process locking.
+
 ### Key-wrapping providers
 
 | Provider | Durability | When to use |
@@ -153,6 +169,11 @@ a KMS/Vault-backed wrapper can be supplied by an embedding deployment without
 changing the engine. `is_durable()` is the load-bearing flag: **durable staging
 fails closed when the active wrapping is not durable** (see §7), because a lost
 DEK would permanently strand staged tenant data.
+
+`SecretCipher::decrypt` retains its public compatibility behavior and collapses
+invalid data or wrapping failures to `None`. Credential repositories use
+`decrypt_result` instead, allowing operational KMS/Vault failures to become a
+generic service-unavailable response rather than an authentication denial.
 
 > **Non-local deployments must use a durable KMS/Vault-backed wrapping.**
 > Running with auth enabled while the active wrapping is the local KEK or an


### PR DESCRIPTION
## Security impact
Credential repository outages now fail closed as generic `503 Service Unavailable` responses instead of being misclassified as missing credentials, empty lists, not-found mutations, or authentication denial. Plaintext API keys and MCP tokens are returned only after persistence commits.

File-backed mutations remain hidden from concurrent readers until an atomic snapshot rename commits; pre-commit failures roll memory back before readers resume. Corrupt or unreadable snapshots now stop startup instead of loading as an empty repository. KMS/Vault unwrap and legacy rewrap failures propagate through the new fallible cipher path.

## Behavior
- repository reads, resolves, lists, and deletes return explicit errors
- dashboard and S3 auth paths map repository failures to generic `503` responses
- Postgres query and mutation failures are no longer swallowed
- Postgres creation returns committed metadata without a risky follow-up read
- file snapshots use mode `0600`, file sync, atomic rename, and best-effort parent-directory sync
- existing `SecretCipher::decrypt -> Option` callers remain source-compatible; repositories use `decrypt_result`
- `FileKeyStore::new` and `with_cipher` are now fallible public Rust APIs

## Validation
- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- three independent focused reviews found no blocking issues
- full compile and runtime suites are delegated to CI to avoid rebuilding the removed local workspace target