### PR TITLE
feat(formats): define binary reductor WIT contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.97.0
         with:
-          targets: wasm32-wasip1
+          targets: wasm32-wasip1,wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Install wasm-tools
         run: cargo install --locked wasm-tools --version 1.255.0
@@ -76,7 +76,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.97.0
         with:
-          targets: wasm32-wasip1
+          targets: wasm32-wasip1,wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Install wasm-tools
         run: cargo install --locked wasm-tools --version 1.255.0
@@ -107,7 +107,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.97.0
         with:
-          targets: wasm32-wasip1
+          targets: wasm32-wasip1,wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Install wasm-tools
         run: cargo install --locked wasm-tools --version 1.255.0
@@ -123,7 +123,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.97.0
         with:
-          targets: wasm32-wasip1
+          targets: wasm32-wasip1,wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Install wasm-tools
         run: cargo install --locked wasm-tools --version 1.255.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.97.0
         with:
-          targets: wasm32-wasip1
+          targets: wasm32-wasip1,wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Install wasm-tools
         run: cargo install --locked wasm-tools --version 1.255.0
@@ -47,7 +47,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.97.0
         with:
-          targets: wasm32-wasip1
+          targets: wasm32-wasip1,wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Install wasm-tools
         run: cargo install --locked wasm-tools --version 1.255.0
@@ -67,7 +67,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.97.0
         with:
-          targets: wasm32-wasip1
+          targets: wasm32-wasip1,wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Install wasm-tools
         run: cargo install --locked wasm-tools --version 1.255.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.97.0
         with:
-          targets: wasm32-wasip1
+          targets: wasm32-wasip1,wasm32-unknown-unknown
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.97.0
         with:
-          targets: wasm32-wasip1
+          targets: wasm32-wasip1,wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Install wasm-tools
         run: cargo install --locked wasm-tools --version 1.255.0
@@ -37,7 +37,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.97.0
         with:
-          targets: wasm32-wasip1
+          targets: wasm32-wasip1,wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Install wasm-tools
         run: cargo install --locked wasm-tools --version 1.255.0
@@ -63,7 +63,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.97.0
         with:
-          targets: wasm32-wasip1
+          targets: wasm32-wasip1,wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Install wasm-tools
         run: cargo install --locked wasm-tools --version 1.255.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "filters/envelope-encrypt",
   "filters/stable-encrypt",
   "filters/test-filter",
+  "filters/test-binary-reductor",
 ]
 
 [workspace.package]

--- a/filters/test-binary-reductor/Cargo.toml
+++ b/filters/test-binary-reductor/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "test-binary-reductor"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen.workspace = true

--- a/filters/test-binary-reductor/src/lib.rs
+++ b/filters/test-binary-reductor/src/lib.rs
@@ -1,0 +1,130 @@
+//! Test-only component used to verify the binary reductor host ABI.
+
+#[cfg(target_arch = "wasm32")]
+mod guest {
+    wit_bindgen::generate!({
+        world: "binary-reductor",
+        path: "../../wit/s4-binary-reductor/world.wit",
+    });
+
+    struct TestBinaryReductor;
+
+    const CUSTOM_SCHEMA_IR: &[u8] = br#"{"root":{"kind":{"type":"custom","type_id":"vendor.money","value":{"kind":{"type":"string"},"nullable":false}},"nullable":false},"version":1}"#;
+    const STRING_SCHEMA_IR: &[u8] =
+        br#"{"root":{"kind":{"type":"string"},"nullable":false},"version":1}"#;
+    const CUSTOM_VALUE_IR: &[u8] = br#"{"root":{"type":"custom","type_id":"vendor.money","value":{"type":"string","value":"12.34"}},"version":1}"#;
+    const STRING_VALUE_IR: &[u8] = br#"{"root":{"type":"string","value":"12.34"},"version":1}"#;
+    const REDUCTION_PLAN: &[u8] = b"vendor.money->string@1";
+    const RESTORATION_PLAN_PREFIX: &[u8] = b"vendor.money<-";
+
+    fn restoration_plan(schema_ir: &[u8]) -> Vec<u8> {
+        let mut plan = RESTORATION_PLAN_PREFIX.to_vec();
+        plan.extend_from_slice(schema_ir);
+        plan
+    }
+
+    impl Guest for TestBinaryReductor {
+        fn plan(source_schema_ir: Vec<u8>) -> Result<PlannedReduction, ReductorError> {
+            if source_schema_ir == b"e" {
+                return Err(ReductorError {
+                    code: "test.invalid-schema".to_string(),
+                    message: "schema was rejected".to_string(),
+                });
+            }
+            if source_schema_ir == CUSTOM_SCHEMA_IR {
+                return Ok(PlannedReduction {
+                    claims: vec![Claim {
+                        path: Vec::new(),
+                        type_id: "vendor.money".to_string(),
+                    }],
+                    reduced_schema_ir: STRING_SCHEMA_IR.to_vec(),
+                    plan: REDUCTION_PLAN.to_vec(),
+                });
+            }
+            let reduced_schema_ir = if source_schema_ir == b"s" {
+                vec![0; 9]
+            } else {
+                source_schema_ir
+            };
+            let plan = if reduced_schema_ir == b"p" {
+                vec![0; 9]
+            } else {
+                Vec::new()
+            };
+            Ok(PlannedReduction {
+                claims: vec![Claim {
+                    path: vec![PathSegment::Field("custom".to_string())],
+                    type_id: "test.custom".to_string(),
+                }],
+                reduced_schema_ir,
+                plan,
+            })
+        }
+
+        fn plan_restore(
+            source_schema_ir: Vec<u8>,
+            transformed_reduced_schema_ir: Vec<u8>,
+            plan: Vec<u8>,
+        ) -> Result<PlannedRestoration, ReductorError> {
+            if source_schema_ir == CUSTOM_SCHEMA_IR
+                && transformed_reduced_schema_ir == STRING_SCHEMA_IR
+                && plan == REDUCTION_PLAN
+            {
+                return Ok(PlannedRestoration {
+                    output_schema_ir: CUSTOM_SCHEMA_IR.to_vec(),
+                    restore_plan: restoration_plan(&transformed_reduced_schema_ir),
+                });
+            }
+            if transformed_reduced_schema_ir == b"x" {
+                Ok(PlannedRestoration {
+                    output_schema_ir: vec![0; 9],
+                    restore_plan: Vec::new(),
+                })
+            } else if transformed_reduced_schema_ir == b"r" {
+                Ok(PlannedRestoration {
+                    output_schema_ir: transformed_reduced_schema_ir,
+                    restore_plan: vec![0; 9],
+                })
+            } else {
+                Ok(PlannedRestoration {
+                    output_schema_ir: transformed_reduced_schema_ir,
+                    restore_plan: Vec::new(),
+                })
+            }
+        }
+
+        fn reduce(plan: Vec<u8>, source_value_ir: Vec<u8>) -> Result<Vec<u8>, ReductorError> {
+            if source_value_ir == b"loop" {
+                loop {
+                    std::hint::black_box(());
+                }
+            }
+            if plan == REDUCTION_PLAN && source_value_ir == CUSTOM_VALUE_IR {
+                return Ok(STRING_VALUE_IR.to_vec());
+            }
+            if source_value_ir == b"x" {
+                Ok(vec![0; 9])
+            } else {
+                Ok(source_value_ir)
+            }
+        }
+
+        fn restore(
+            restore_plan: Vec<u8>,
+            transformed_value_ir: Vec<u8>,
+        ) -> Result<Vec<u8>, ReductorError> {
+            if restore_plan == restoration_plan(STRING_SCHEMA_IR)
+                && transformed_value_ir == STRING_VALUE_IR
+            {
+                return Ok(CUSTOM_VALUE_IR.to_vec());
+            }
+            if transformed_value_ir == b"x" {
+                Ok(vec![0; 9])
+            } else {
+                Ok(transformed_value_ir)
+            }
+        }
+    }
+
+    export!(TestBinaryReductor);
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.97.0"
-targets = ["wasm32-wasip1"]
+targets = ["wasm32-wasip1", "wasm32-unknown-unknown"]

--- a/scripts/build-filters.sh
+++ b/scripts/build-filters.sh
@@ -9,6 +9,8 @@ OUT_DIR="$ROOT/target/components"
 # standard WASI interfaces (random, io, environment) when they need them.
 TARGET="wasm32-wasip1"
 BIN_DIR="$ROOT/target/$TARGET/release"
+NO_WASI_TARGET="wasm32-unknown-unknown"
+NO_WASI_BIN_DIR="$ROOT/target/$NO_WASI_TARGET/release"
 
 # Keep the adapter aligned with the workspace's Wasmtime major and verify the
 # release asset instead of depending on arbitrary Cargo registry cache state.
@@ -76,8 +78,8 @@ for entry in "${FILTERS[@]}"; do
   echo "    -> ${OUT_DIR}/${name}.component.wasm (WASI)"
 done
 
-# Failure-injection component is built for runtime tests but never placed in the
-# production auto-load directory.
+# Test components are built for runtime tests but never placed in the production
+# auto-load directory.
 TEST_OUT_DIR="$ROOT/target/test-components"
 mkdir -p "$TEST_OUT_DIR"
 cargo build --release -p test-filter --target "$TARGET"
@@ -86,4 +88,11 @@ wasm-tools component new \
   --adapt "wasi_snapshot_preview1=${ADAPTER}" \
   -o "${TEST_OUT_DIR}/test-filter.component.wasm"
 
-echo "=== All filters built (WASI) ==="
+# Binary reductors receive no host imports. Build this fixture for the bare Wasm
+# target and componentize it without a WASI adapter.
+cargo build --release -p test-binary-reductor --target "$NO_WASI_TARGET"
+wasm-tools component new \
+  "${NO_WASI_BIN_DIR}/test_binary_reductor.wasm" \
+  -o "${TEST_OUT_DIR}/test-binary-reductor.component.wasm"
+
+echo "=== All filter and runtime test components built ==="

--- a/wit/s4-binary-reductor/world.wit
+++ b/wit/s4-binary-reductor/world.wit
@@ -1,0 +1,59 @@
+package s4:binary-reductor@0.1.0;
+
+world binary-reductor {
+  variant path-segment {
+    field(string),
+    array-element,
+    map-value,
+    logical-value,
+  }
+
+  /// A canonical Schema IR path and the logical type claimed at that path.
+  record claim {
+    path: list<path-segment>,
+    type-id: string,
+  }
+
+  record planned-reduction {
+    claims: list<claim>,
+    /// Canonical, versioned S4 Schema IR bytes.
+    reduced-schema-ir: list<u8>,
+    /// An opaque component-owned plan. It may be empty for a stateless reductor;
+    /// the host persists and bounds these bytes.
+    plan: list<u8>,
+  }
+
+  record planned-restoration {
+    /// Canonical, versioned S4 Schema IR bytes after restoration.
+    output-schema-ir: list<u8>,
+    /// Opaque state derived from the source and transformed reduced schemas.
+    /// It may be empty for a stateless reductor and is passed only to restore.
+    restore-plan: list<u8>,
+  }
+
+  /// A guest-declared failure. Codes are component-defined and diagnostic;
+  /// the host maps them to stable S4 error codes.
+  record reductor-error {
+    code: string,
+    message: string,
+  }
+
+  /// Plans forward reduction. The returned plan is used by reduce and
+  /// plan-restore, but never by restore.
+  export plan: func(source-schema-ir: list<u8>) -> result<planned-reduction, reductor-error>;
+  /// Plans restoration after the reduced schema has been transformed.
+  export plan-restore: func(
+    source-schema-ir: list<u8>,
+    transformed-reduced-schema-ir: list<u8>,
+    plan: list<u8>,
+  ) -> result<planned-restoration, reductor-error>;
+  export reduce: func(
+    plan: list<u8>,
+    source-value-ir: list<u8>,
+  ) -> result<list<u8>, reductor-error>;
+  /// Restores a transformed value using only the schema-dependent restore plan.
+  export restore: func(
+    restore-plan: list<u8>,
+    transformed-value-ir: list<u8>,
+  ) -> result<list<u8>, reductor-error>;
+}


### PR DESCRIPTION
## Scope
Defines the standalone `s4:binary-reductor@0.1.0` component ABI and compiles a bare-Wasm conformance fixture. This locks the guest contract before adding the host adapter.

- `plan`, `plan-restore`, `reduce`, and `restore` operations
- canonical Schema/Value IR byte boundaries
- explicit logical-type claim paths and opaque forward/restore plans
- bounded, component-defined diagnostics
- test component covers stateless and custom-type reduction/restoration behavior
- CI, nightly, weekly, and release component builds install `wasm32-unknown-unknown` alongside WASI
- the fixture is componentized without a WASI adapter, proving the later host adapter need not link guest host imports

## Explicitly excluded
- no Wasm host adapter, component loader, S3 routing, Avro, or Parquet behavior
- no production deployment required

## Validation
- `bash -n scripts/build-filters.sh`
- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- full bare-Wasm component build and workspace validation delegated to CI