### PR TITLE
feat(gateway): add opt-in Avro OCF processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "apache-avro"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312c1ea69e5fe9966e0029fb95aca8790100b85aff4f0d3b00a9337c74069a9c"
+dependencies = [
+ "bigdecimal",
+ "bon",
+ "crc32fast",
+ "digest 0.11.3",
+ "log",
+ "miniz_oxide 0.9.1",
+ "num-bigint",
+ "ouroboros",
+ "quad-rand",
+ "rand 0.10.2",
+ "regex-lite",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "snap",
+ "strum 0.28.0",
+ "thiserror 2.0.20",
+ "uuid",
+ "zstd",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +948,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3fac94a66da67200398458a25412bcc3f9b6443b5119a6cad9cf3ccfcd8cc6"
+dependencies = [
+ "bon-macros",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4654961ad0494e4774c5c60b4cb4cd0ae9b9d92d039d901638b1dba97ebebf5"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease 0.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "borsh"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,8 +1139,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1584,6 +1636,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,7 +2036,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "zlib-rs",
 ]
 
@@ -2687,6 +2773,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,6 +3150,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3132,6 +3233,7 @@ checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -3519,6 +3621,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
+dependencies = [
+ "proc-macro2",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3634,6 +3746,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "quad-rand"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
 name = "quick-error"
@@ -4272,6 +4390,7 @@ dependencies = [
  "aes-gcm",
  "aes-siv",
  "anyhow",
+ "apache-avro",
  "async-trait",
  "aws-config",
  "aws-credential-types",
@@ -4283,6 +4402,7 @@ dependencies = [
  "axum",
  "base64",
  "bytes",
+ "chrono",
  "crc",
  "csv-core",
  "dirs",
@@ -4293,6 +4413,7 @@ dependencies = [
  "jsonwebtoken",
  "libc",
  "md-5 0.10.6",
+ "num-bigint",
  "pin-project-lite",
  "pollster",
  "proptest",
@@ -4344,11 +4465,12 @@ name = "s4-wasm-runtime"
 version = "0.3.5"
 dependencies = [
  "anyhow",
+ "hex",
  "rand 0.8.7",
  "s4-error",
+ "sha2 0.10.9",
  "wasmtime",
  "wasmtime-wasi",
- "wit-bindgen 0.60.0",
  "zeroize",
 ]
 
@@ -4434,7 +4556,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.20",
  "time",
  "tracing",
@@ -4549,6 +4671,16 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4745,6 +4877,12 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
 
 [[package]]
 name = "socket2"
@@ -5052,6 +5190,27 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "subtle"
@@ -6652,7 +6811,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap",
- "prettyplease",
+ "prettyplease 0.2.37",
  "syn 2.0.119",
  "wasm-metadata",
  "wit-bindgen-core",
@@ -6667,7 +6826,7 @@ checksum = "d689c4bc9d6af067c651cfba444766343c9a4bdef15fad1e2efab95c0c277af0"
 dependencies = [
  "anyhow",
  "macro-string",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ s4ctl plugin reorder pii-default my-filter
 
 Full guide: [docs/plugins.md](docs/plugins.md).
 
+Typed binary codecs use a separate schema-aware reductor contract, not the
+byte-oriented plugin pipeline. See [docs/binary-adapters.md](docs/binary-adapters.md)
+when adding a custom logical-type adapter.
+
+The in-progress Avro OCF boundary and its supported subset are documented in
+[docs/avro.md](docs/avro.md).
+
 ## Usage examples
 
 Everything below is copy-paste runnable.

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -55,6 +55,9 @@ utoipa = { workspace = true, features = ["axum_extras"] }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
 tower-http = { version = "0.6", features = ["cors"] }
 thiserror.workspace = true
+apache-avro = { version = "0.22", features = ["snappy", "zstandard"] }
+chrono = "0.4"
+num-bigint = "0.4"
 
 [dev-dependencies]
 libc = "0.2"

--- a/crates/gateway/src/avro.rs
+++ b/crates/gateway/src/avro.rs
@@ -1,0 +1,1002 @@
+//! Avro Object Container File conversion at the binary-codec boundary.
+//!
+//! This module intentionally has no HTTP or storage dependency. Callers stream
+//! decoded values through the typed binary pump and only commit encoded output
+//! after the pump succeeds.
+
+use std::collections::BTreeMap;
+use std::io::{self, Read};
+
+use apache_avro::{Codec, Reader, Schema, Writer, types::Value as AvroValue};
+use chrono::{DateTime, Duration, NaiveDate, NaiveTime, SecondsFormat, Timelike, Utc};
+use num_bigint::{BigInt, Sign};
+use s4_error::{S4Error, codes};
+use serde_json::{Value as JsonValue, json};
+
+use crate::binary_ir::{
+    BinaryIrLimits, MapEntry, SchemaField, SchemaIr, SchemaKind, SchemaNode, Value, ValueField,
+    ValueIr,
+};
+use crate::binary_pump::{BinaryPump, BinaryTransform};
+use crate::binary_reductor::BinaryReductor;
+
+pub const DEFAULT_MAX_AVRO_SOURCE_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug)]
+pub struct AvroLimits {
+    pub max_source_bytes: usize,
+    pub ir: BinaryIrLimits,
+}
+
+impl Default for AvroLimits {
+    fn default() -> Self {
+        Self {
+            max_source_bytes: DEFAULT_MAX_AVRO_SOURCE_BYTES,
+            ir: BinaryIrLimits::default(),
+        }
+    }
+}
+
+/// Decodes one OCF source and invokes `emit` once per logical record.
+///
+/// The source reader is capped before the Avro library sees bytes; each emitted
+/// value is separately validated against the bounded S4 IR schema.
+pub fn decode_ocf<R, F>(source: R, limits: AvroLimits, mut emit: F) -> Result<SchemaIr, S4Error>
+where
+    R: Read,
+    F: FnMut(ValueIr) -> Result<(), S4Error>,
+{
+    validate_limits(limits)?;
+    let mut reader =
+        Reader::new(LimitedReader::new(source, limits.max_source_bytes)).map_err(avro_error)?;
+    let schema = schema_from_avro(reader.writer_schema(), limits.ir)?;
+    for value in &mut reader {
+        let value = avro_value_to_ir(value.map_err(avro_error)?, &schema.root)?;
+        let value = ValueIr::new(value);
+        value.validate(&schema, limits.ir)?;
+        emit(value)?;
+    }
+    Ok(schema)
+}
+
+/// Encodes validated IR records to an Avro OCF using Zstandard output blocks.
+pub fn encode_ocf(
+    schema: &SchemaIr,
+    values: &[ValueIr],
+    limits: AvroLimits,
+) -> Result<Vec<u8>, S4Error> {
+    validate_limits(limits)?;
+    schema.validate(limits.ir)?;
+    let avro_schema = Schema::parse(&schema_to_avro_json(&schema.root)?).map_err(avro_error)?;
+    let mut writer = Writer::with_codec(
+        &avro_schema,
+        Vec::new(),
+        Codec::Zstandard(Default::default()),
+    )
+    .map_err(avro_error)?;
+    for value in values {
+        value.validate(schema, limits.ir)?;
+        writer
+            .append_value(ir_value_to_avro(&value.root, &schema.root)?)
+            .map_err(avro_error)?;
+    }
+    writer.into_inner().map_err(avro_error)
+}
+
+/// Runs an OCF source through a planned typed binary transform and emits a new
+/// OCF only after every accepted value has passed schema validation.
+pub fn process_ocf<R, Reductor, Transform>(
+    source: R,
+    limits: AvroLimits,
+    pump: &mut BinaryPump<Reductor, Transform>,
+) -> Result<Vec<u8>, S4Error>
+where
+    R: Read,
+    Reductor: BinaryReductor,
+    Transform: BinaryTransform,
+{
+    validate_limits(limits)?;
+    let mut reader =
+        Reader::new(LimitedReader::new(source, limits.max_source_bytes)).map_err(avro_error)?;
+    let input_schema = schema_from_avro(reader.writer_schema(), limits.ir)?;
+    let output_schema = pump.plan(&input_schema)?.clone();
+    let output_avro_schema =
+        Schema::parse(&schema_to_avro_json(&output_schema.root)?).map_err(avro_error)?;
+    let mut writer = Writer::with_codec(
+        &output_avro_schema,
+        Vec::new(),
+        Codec::Zstandard(Default::default()),
+    )
+    .map_err(avro_error)?;
+
+    for value in &mut reader {
+        let value = ValueIr::new(avro_value_to_ir(
+            value.map_err(avro_error)?,
+            &input_schema.root,
+        )?);
+        value.validate(&input_schema, limits.ir)?;
+        let Some(value) = pump.process(value)? else {
+            continue;
+        };
+        value.validate(&output_schema, limits.ir)?;
+        writer
+            .append_value(ir_value_to_avro(&value.root, &output_schema.root)?)
+            .map_err(avro_error)?;
+    }
+    writer.into_inner().map_err(avro_error)
+}
+
+pub fn schema_from_avro(schema: &Schema, limits: BinaryIrLimits) -> Result<SchemaIr, S4Error> {
+    let raw = serde_json::to_value(schema).map_err(avro_error)?;
+    let schema = SchemaIr::new(schema_node_from_json(&raw)?);
+    schema.validate(limits)?;
+    Ok(schema)
+}
+
+fn schema_node_from_json(raw: &JsonValue) -> Result<SchemaNode, S4Error> {
+    if let Some(kind) = raw.as_str() {
+        return primitive_schema(kind);
+    }
+    if let Some(variants) = raw.as_array() {
+        if variants.len() != 2 {
+            return Err(unsupported(
+                "Avro unions must contain exactly null and one type",
+            ));
+        }
+        let non_null = variants
+            .iter()
+            .find(|variant| !variant.is_string() || variant.as_str() != Some("null"))
+            .ok_or_else(|| unsupported("Avro nullable union is missing its value type"))?;
+        if !variants
+            .iter()
+            .any(|variant| variant.as_str() == Some("null"))
+        {
+            return Err(unsupported("Avro unions must contain null"));
+        }
+        let mut node = schema_node_from_json(non_null)?;
+        if matches!(node.kind, SchemaKind::Null) {
+            return Err(unsupported("Avro union cannot contain null twice"));
+        }
+        node.nullable = true;
+        return Ok(node);
+    }
+
+    let object = raw
+        .as_object()
+        .ok_or_else(|| unsupported("Avro schema must be a string, object, or nullable union"))?;
+    let kind = object
+        .get("type")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| unsupported("Avro schema type is missing"))?;
+    if let Some(logical_type) = object.get("logicalType").and_then(JsonValue::as_str) {
+        return match (kind, logical_type) {
+            ("int", "date") => Ok(SchemaNode::required(SchemaKind::Date)),
+            ("int", "time-millis") | ("long", "time-micros") => {
+                Ok(SchemaNode::required(SchemaKind::Time))
+            }
+            ("long", "timestamp-millis")
+            | ("long", "timestamp-micros")
+            | ("long", "timestamp-nanos") => Ok(SchemaNode::required(SchemaKind::Timestamp)),
+            ("string", "uuid") => Ok(SchemaNode::required(SchemaKind::Uuid)),
+            ("bytes", "decimal") => {
+                let precision = object
+                    .get("precision")
+                    .and_then(JsonValue::as_u64)
+                    .and_then(|value| u32::try_from(value).ok())
+                    .ok_or_else(|| unsupported("Avro decimal precision is missing"))?;
+                let scale = object
+                    .get("scale")
+                    .and_then(JsonValue::as_u64)
+                    .and_then(|value| u32::try_from(value).ok())
+                    .unwrap_or(0);
+                Ok(SchemaNode::required(SchemaKind::Decimal {
+                    precision,
+                    scale,
+                }))
+            }
+            _ => Err(unsupported(format!(
+                "unsupported Avro logical type {logical_type:?} for {kind:?}"
+            ))),
+        };
+    }
+    match kind {
+        "record" => {
+            let fields = object
+                .get("fields")
+                .and_then(JsonValue::as_array)
+                .ok_or_else(|| unsupported("Avro record fields are missing"))?
+                .iter()
+                .map(|field| {
+                    let field = field
+                        .as_object()
+                        .ok_or_else(|| unsupported("Avro record field must be an object"))?;
+                    let name = field
+                        .get("name")
+                        .and_then(JsonValue::as_str)
+                        .filter(|name| !name.is_empty())
+                        .ok_or_else(|| unsupported("Avro record field name is missing"))?;
+                    let kind = field
+                        .get("type")
+                        .ok_or_else(|| unsupported("Avro record field type is missing"))?;
+                    Ok(SchemaField {
+                        name: name.to_string(),
+                        schema: schema_node_from_json(kind)?,
+                    })
+                })
+                .collect::<Result<Vec<_>, S4Error>>()?;
+            Ok(SchemaNode::required(SchemaKind::Record { fields }))
+        }
+        "array" => Ok(SchemaNode::required(SchemaKind::Array {
+            items: Box::new(schema_node_from_json(
+                object
+                    .get("items")
+                    .ok_or_else(|| unsupported("Avro array items are missing"))?,
+            )?),
+        })),
+        "map" => Ok(SchemaNode::required(SchemaKind::Map {
+            values: Box::new(schema_node_from_json(
+                object
+                    .get("values")
+                    .ok_or_else(|| unsupported("Avro map values are missing"))?,
+            )?),
+        })),
+        "enum" | "fixed" | "duration" => Err(unsupported(format!(
+            "Avro {kind} schemas are not supported"
+        ))),
+        primitive => primitive_schema(primitive),
+    }
+}
+
+fn primitive_schema(kind: &str) -> Result<SchemaNode, S4Error> {
+    let kind = match kind {
+        "null" => SchemaKind::Null,
+        "boolean" => SchemaKind::Boolean,
+        "int" => SchemaKind::I32,
+        "long" => SchemaKind::I64,
+        "float" => SchemaKind::F32,
+        "double" => SchemaKind::F64,
+        "bytes" => SchemaKind::Bytes,
+        "string" => SchemaKind::String,
+        other => {
+            return Err(unsupported(format!(
+                "unsupported Avro schema type {other:?}"
+            )));
+        }
+    };
+    Ok(SchemaNode::required(kind))
+}
+
+fn schema_to_avro_json(root: &SchemaNode) -> Result<JsonValue, S4Error> {
+    let mut records = 0_u32;
+    schema_node_to_json(root, &mut records)
+}
+
+fn schema_node_to_json(node: &SchemaNode, records: &mut u32) -> Result<JsonValue, S4Error> {
+    let raw = match &node.kind {
+        SchemaKind::Null => json!("null"),
+        SchemaKind::Boolean => json!("boolean"),
+        SchemaKind::I32 => json!("int"),
+        SchemaKind::I64 => json!("long"),
+        SchemaKind::F32 => json!("float"),
+        SchemaKind::F64 => json!("double"),
+        SchemaKind::String => json!("string"),
+        SchemaKind::Bytes => json!("bytes"),
+        SchemaKind::Array { items } => {
+            json!({"type":"array","items":schema_node_to_json(items, records)?})
+        }
+        SchemaKind::Map { values } => {
+            json!({"type":"map","values":schema_node_to_json(values, records)?})
+        }
+        SchemaKind::Record { fields } => {
+            let name = format!("s4_record_{records}");
+            *records = records.saturating_add(1);
+            let fields = fields
+                .iter()
+                .map(|field| Ok(json!({"name":field.name,"type":schema_node_to_json(&field.schema, records)?})))
+                .collect::<Result<Vec<_>, S4Error>>()?;
+            json!({"type":"record","name":name,"fields":fields})
+        }
+        SchemaKind::Date => json!({"type":"int","logicalType":"date"}),
+        SchemaKind::Time => json!({"type":"long","logicalType":"time-micros"}),
+        SchemaKind::Timestamp => json!({"type":"long","logicalType":"timestamp-micros"}),
+        SchemaKind::Uuid => json!({"type":"string","logicalType":"uuid"}),
+        SchemaKind::Decimal { precision, scale } => json!({
+            "type":"bytes",
+            "logicalType":"decimal",
+            "precision":precision,
+            "scale":scale,
+        }),
+        SchemaKind::Custom { .. } => {
+            return Err(unsupported(
+                "custom IR types need a binary reductor before Avro encoding",
+            ));
+        }
+    };
+    Ok(if node.nullable {
+        json!(["null", raw])
+    } else {
+        raw
+    })
+}
+
+fn avro_value_to_ir(value: AvroValue, schema: &SchemaNode) -> Result<Value, S4Error> {
+    let value = match value {
+        AvroValue::Union(_, value) => *value,
+        value => value,
+    };
+    if schema.nullable && matches!(value, AvroValue::Null) {
+        return Ok(Value::Null);
+    }
+    match (&schema.kind, value) {
+        (SchemaKind::Null, AvroValue::Null) => Ok(Value::Null),
+        (SchemaKind::Boolean, AvroValue::Boolean(value)) => Ok(Value::Boolean { value }),
+        (SchemaKind::I32, AvroValue::Int(value)) => Ok(Value::I32 { value }),
+        (SchemaKind::I64, AvroValue::Long(value)) => Ok(Value::I64 { value }),
+        (SchemaKind::F32, AvroValue::Float(value)) => Ok(Value::F32 { value }),
+        (SchemaKind::F64, AvroValue::Double(value)) => Ok(Value::F64 { value }),
+        (SchemaKind::String, AvroValue::String(value)) => Ok(Value::String { value }),
+        (SchemaKind::Bytes, AvroValue::Bytes(value)) => Ok(Value::Bytes { value }),
+        (SchemaKind::Date, AvroValue::Date(value)) => Ok(Value::Date {
+            value: date_from_epoch_days(value)?,
+        }),
+        (SchemaKind::Time, AvroValue::TimeMillis(value)) => Ok(Value::Time {
+            value: time_from_micros(i64::from(value) * 1_000)?,
+        }),
+        (SchemaKind::Time, AvroValue::TimeMicros(value)) => Ok(Value::Time {
+            value: time_from_micros(value)?,
+        }),
+        (SchemaKind::Timestamp, AvroValue::TimestampMillis(value)) => Ok(Value::Timestamp {
+            value: timestamp_from_micros(value * 1_000)?,
+        }),
+        (SchemaKind::Timestamp, AvroValue::TimestampMicros(value)) => Ok(Value::Timestamp {
+            value: timestamp_from_micros(value)?,
+        }),
+        (SchemaKind::Timestamp, AvroValue::TimestampNanos(value)) => Ok(Value::Timestamp {
+            value: timestamp_from_nanos(value)?,
+        }),
+        (SchemaKind::Uuid, AvroValue::Uuid(value)) => Ok(Value::Uuid {
+            value: value.to_string(),
+        }),
+        (SchemaKind::Decimal { scale, .. }, AvroValue::Decimal(value)) => Ok(Value::Decimal {
+            value: unscaled_to_decimal_string(&BigInt::from(value), *scale),
+        }),
+        (SchemaKind::Decimal { scale, .. }, AvroValue::Bytes(value)) => Ok(Value::Decimal {
+            value: unscaled_to_decimal_string(&BigInt::from_signed_bytes_be(&value), *scale),
+        }),
+        (SchemaKind::Array { items }, AvroValue::Array(values)) => Ok(Value::Array {
+            items: values
+                .into_iter()
+                .map(|value| avro_value_to_ir(value, items))
+                .collect::<Result<Vec<_>, _>>()?,
+        }),
+        (SchemaKind::Map { values }, AvroValue::Map(entries)) => Ok(Value::Map {
+            entries: entries
+                .into_iter()
+                .collect::<BTreeMap<_, _>>()
+                .into_iter()
+                .map(|(key, value)| {
+                    Ok(MapEntry {
+                        key,
+                        value: avro_value_to_ir(value, values)?,
+                    })
+                })
+                .collect::<Result<Vec<_>, S4Error>>()?,
+        }),
+        (SchemaKind::Record { fields }, AvroValue::Record(values)) => Ok(Value::Record {
+            fields: fields
+                .iter()
+                .map(|field| {
+                    let value = values
+                        .iter()
+                        .find(|(name, _)| name == &field.name)
+                        .map(|(_, value)| value.clone())
+                        .ok_or_else(|| {
+                            unsupported(format!("Avro record is missing field {:?}", field.name))
+                        })?;
+                    Ok(ValueField {
+                        name: field.name.clone(),
+                        value: avro_value_to_ir(value, &field.schema)?,
+                    })
+                })
+                .collect::<Result<Vec<_>, S4Error>>()?,
+        }),
+        _ => Err(unsupported(
+            "Avro value does not match its supported schema",
+        )),
+    }
+}
+
+fn ir_value_to_avro(value: &Value, schema: &SchemaNode) -> Result<AvroValue, S4Error> {
+    if schema.nullable {
+        if matches!(value, Value::Null) {
+            return Ok(AvroValue::Union(0, Box::new(AvroValue::Null)));
+        }
+        return Ok(AvroValue::Union(
+            1,
+            Box::new(ir_value_to_avro_required(value, schema)?),
+        ));
+    }
+    ir_value_to_avro_required(value, schema)
+}
+
+fn ir_value_to_avro_required(value: &Value, schema: &SchemaNode) -> Result<AvroValue, S4Error> {
+    match (&schema.kind, value) {
+        (SchemaKind::Null, Value::Null) => Ok(AvroValue::Null),
+        (SchemaKind::Boolean, Value::Boolean { value }) => Ok(AvroValue::Boolean(*value)),
+        (SchemaKind::I32, Value::I32 { value }) => Ok(AvroValue::Int(*value)),
+        (SchemaKind::I64, Value::I64 { value }) => Ok(AvroValue::Long(*value)),
+        (SchemaKind::F32, Value::F32 { value }) => Ok(AvroValue::Float(*value)),
+        (SchemaKind::F64, Value::F64 { value }) => Ok(AvroValue::Double(*value)),
+        (SchemaKind::String, Value::String { value }) => Ok(AvroValue::String(value.clone())),
+        (SchemaKind::Bytes, Value::Bytes { value }) => Ok(AvroValue::Bytes(value.clone())),
+        (SchemaKind::Date, Value::Date { value }) => {
+            Ok(AvroValue::Date(date_to_epoch_days(value)?))
+        }
+        (SchemaKind::Time, Value::Time { value }) => {
+            Ok(AvroValue::TimeMicros(time_to_micros(value)?))
+        }
+        (SchemaKind::Timestamp, Value::Timestamp { value }) => {
+            Ok(AvroValue::TimestampMicros(timestamp_to_micros(value)?))
+        }
+        (SchemaKind::Uuid, Value::Uuid { value }) => Ok(AvroValue::Uuid(
+            uuid::Uuid::parse_str(value).map_err(|_| unsupported("invalid UUID IR value"))?,
+        )),
+        (SchemaKind::Decimal { precision, scale }, Value::Decimal { value }) => {
+            let unscaled = decimal_to_unscaled(value, *scale)?;
+            Ok(AvroValue::Decimal(apache_avro::Decimal::from(
+                decimal_to_bytes(&unscaled, *precision),
+            )))
+        }
+        (SchemaKind::Array { items }, Value::Array { items: values }) => Ok(AvroValue::Array(
+            values
+                .iter()
+                .map(|value| ir_value_to_avro(value, items))
+                .collect::<Result<_, _>>()?,
+        )),
+        (SchemaKind::Map { values }, Value::Map { entries }) => Ok(AvroValue::Map(
+            entries
+                .iter()
+                .map(|entry| Ok((entry.key.clone(), ir_value_to_avro(&entry.value, values)?)))
+                .collect::<Result<_, S4Error>>()?,
+        )),
+        (SchemaKind::Record { fields }, Value::Record { fields: values }) => Ok(AvroValue::Record(
+            fields
+                .iter()
+                .map(|field| {
+                    let value = values
+                        .iter()
+                        .find(|candidate| candidate.name == field.name)
+                        .ok_or_else(|| {
+                            unsupported(format!("IR record is missing field {:?}", field.name))
+                        })?;
+                    Ok((
+                        field.name.clone(),
+                        ir_value_to_avro(&value.value, &field.schema)?,
+                    ))
+                })
+                .collect::<Result<_, S4Error>>()?,
+        )),
+        _ => Err(unsupported(
+            "IR value does not match its supported Avro schema",
+        )),
+    }
+}
+
+fn decimal_to_unscaled(value: &str, scale: u32) -> Result<BigInt, S4Error> {
+    let (negative, unsigned) = match value.strip_prefix('-') {
+        Some(unsigned) => (true, unsigned),
+        None => (false, value),
+    };
+    let (integer, fraction) = match unsigned.split_once('.') {
+        Some((integer, fraction)) => (integer, fraction),
+        None => (unsigned, ""),
+    };
+    if fraction.len() as u32 > scale {
+        return Err(unsupported(
+            "decimal fractional digits exceed the schema scale",
+        ));
+    }
+    let mut digits = String::with_capacity(integer.len() + scale as usize + 1);
+    digits.push_str(integer);
+    digits.push_str(fraction);
+    for _ in (fraction.len() as u32)..scale {
+        digits.push('0');
+    }
+    let mut unscaled = BigInt::parse_bytes(digits.as_bytes(), 10)
+        .ok_or_else(|| unsupported("invalid decimal IR value"))?;
+    if negative {
+        unscaled = -unscaled;
+    }
+    Ok(unscaled)
+}
+
+fn unscaled_to_decimal_string(unscaled: &BigInt, scale: u32) -> String {
+    let negative = unscaled.sign() == Sign::Minus;
+    let digits = unscaled.magnitude().to_str_radix(10);
+    let scale = scale as usize;
+    let sign = if negative { "-" } else { "" };
+    if scale == 0 {
+        return format!("{sign}{digits}");
+    }
+    if digits.len() > scale {
+        let split = digits.len() - scale;
+        format!("{sign}{}.{}", &digits[..split], &digits[split..])
+    } else {
+        let fraction = format!("{:0>width$}", digits, width = scale);
+        format!("{sign}0.{fraction}")
+    }
+}
+
+fn decimal_to_bytes(unscaled: &BigInt, precision: u32) -> Vec<u8> {
+    let minimal = unscaled.to_signed_bytes_be();
+    let required = min_decimal_len(precision);
+    if minimal.len() >= required {
+        return minimal;
+    }
+    let pad = if unscaled.sign() == Sign::Minus {
+        0xFF
+    } else {
+        0x00
+    };
+    let mut bytes = vec![pad; required];
+    bytes[required - minimal.len()..].copy_from_slice(&minimal);
+    bytes
+}
+
+fn min_decimal_len(precision: u32) -> usize {
+    let mut len = 1_usize;
+    while (((2.0_f64).powi(8 * len as i32 - 1) - 1.0).log10().floor() as u32) < precision {
+        len += 1;
+    }
+    len
+}
+
+fn date_from_epoch_days(days: i32) -> Result<String, S4Error> {
+    NaiveDate::from_ymd_opt(1970, 1, 1)
+        .and_then(|epoch| epoch.checked_add_signed(Duration::days(i64::from(days))))
+        .map(|date| date.format("%F").to_string())
+        .ok_or_else(|| unsupported("Avro date is outside the supported calendar range"))
+}
+
+fn date_to_epoch_days(value: &str) -> Result<i32, S4Error> {
+    let date =
+        NaiveDate::parse_from_str(value, "%F").map_err(|_| unsupported("invalid date IR value"))?;
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).expect("1970-01-01 is valid");
+    i32::try_from(date.signed_duration_since(epoch).num_days())
+        .map_err(|_| unsupported("date is outside the Avro i32 day range"))
+}
+
+fn time_from_micros(micros: i64) -> Result<String, S4Error> {
+    let micros_per_day = 86_400_000_000_i64;
+    if !(0..micros_per_day).contains(&micros) {
+        return Err(unsupported("Avro time is outside one UTC day"));
+    }
+    let seconds = u32::try_from(micros / 1_000_000).expect("bounded to one day");
+    let nanoseconds = u32::try_from((micros % 1_000_000) * 1_000).expect("subsecond is bounded");
+    NaiveTime::from_num_seconds_from_midnight_opt(seconds, nanoseconds)
+        .map(|time| time.format("%H:%M:%S%.f").to_string())
+        .ok_or_else(|| unsupported("invalid Avro time"))
+}
+
+fn time_to_micros(value: &str) -> Result<i64, S4Error> {
+    let time = NaiveTime::parse_from_str(value, "%H:%M:%S%.f")
+        .map_err(|_| unsupported("invalid time IR value"))?;
+    Ok(i64::from(time.num_seconds_from_midnight()) * 1_000_000
+        + i64::from(time.nanosecond() / 1_000))
+}
+
+fn timestamp_from_micros(micros: i64) -> Result<String, S4Error> {
+    DateTime::from_timestamp_micros(micros)
+        .map(|timestamp| timestamp.to_rfc3339_opts(SecondsFormat::AutoSi, true))
+        .ok_or_else(|| unsupported("Avro timestamp is outside the supported range"))
+}
+
+fn timestamp_from_nanos(nanos: i64) -> Result<String, S4Error> {
+    let seconds = nanos.div_euclid(1_000_000_000);
+    let nanoseconds = u32::try_from(nanos.rem_euclid(1_000_000_000)).expect("remainder is bounded");
+    DateTime::from_timestamp(seconds, nanoseconds)
+        .map(|timestamp| timestamp.to_rfc3339_opts(SecondsFormat::AutoSi, true))
+        .ok_or_else(|| unsupported("Avro timestamp is outside the supported range"))
+}
+
+fn timestamp_to_micros(value: &str) -> Result<i64, S4Error> {
+    Ok(DateTime::parse_from_rfc3339(value)
+        .map_err(|_| unsupported("invalid timestamp IR value"))?
+        .with_timezone(&Utc)
+        .timestamp_micros())
+}
+
+fn validate_limits(limits: AvroLimits) -> Result<(), S4Error> {
+    if limits.max_source_bytes == 0 {
+        return Err(S4Error::new(
+            codes::CONFIG_INVALID,
+            "Avro source byte limit must be greater than zero",
+        ));
+    }
+    Ok(())
+}
+
+fn avro_error(error: impl std::fmt::Display) -> S4Error {
+    S4Error::new(
+        codes::UNSUPPORTED_FORMAT,
+        format!("invalid Avro OCF: {error}"),
+    )
+}
+
+fn unsupported(message: impl Into<String>) -> S4Error {
+    S4Error::new(codes::UNSUPPORTED_FORMAT, message)
+}
+
+struct LimitedReader<R> {
+    inner: R,
+    remaining: usize,
+}
+
+impl<R> LimitedReader<R> {
+    fn new(inner: R, maximum: usize) -> Self {
+        Self {
+            inner,
+            remaining: maximum,
+        }
+    }
+}
+
+impl<R: Read> Read for LimitedReader<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if buffer.is_empty() {
+            return Ok(0);
+        }
+        if self.remaining == 0 {
+            return match self.inner.read(&mut buffer[..1])? {
+                0 => Ok(0),
+                _ => Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Avro source exceeds configured byte limit",
+                )),
+            };
+        }
+        let maximum = buffer.len().min(self.remaining);
+        let read = self.inner.read(&mut buffer[..maximum])?;
+        self.remaining -= read;
+        Ok(read)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::binary_pump::{BinaryTransform, EnvelopeBinaryTransform};
+    use crate::binary_reductor::CommonTypeBinaryReductor;
+    use rand::rngs::OsRng;
+    use rsa::RsaPrivateKey;
+    use rsa::pkcs8::EncodePublicKey;
+
+    const SCHEMA: &str = r#"{
+        "type":"record","name":"customer","fields":[
+          {"name":"id","type":"long"},
+          {"name":"email","type":["null","string"]},
+          {"name":"labels","type":{"type":"map","values":"string"}},
+          {"name":"events","type":{"type":"array","items":{"type":"record","name":"event","fields":[{"name":"name","type":"string"}]}}}
+        ]
+    }"#;
+
+    fn input() -> Vec<u8> {
+        let schema = Schema::parse_str(SCHEMA).unwrap();
+        let values = [
+            AvroValue::Record(vec![
+                ("id".to_string(), AvroValue::Long(7)),
+                (
+                    "email".to_string(),
+                    AvroValue::Union(
+                        1,
+                        Box::new(AvroValue::String("ada@example.com".to_string())),
+                    ),
+                ),
+                (
+                    "labels".to_string(),
+                    AvroValue::Map(
+                        BTreeMap::from([(
+                            "role".to_string(),
+                            AvroValue::String("admin".to_string()),
+                        )])
+                        .into_iter()
+                        .collect(),
+                    ),
+                ),
+                (
+                    "events".to_string(),
+                    AvroValue::Array(vec![AvroValue::Record(vec![(
+                        "name".to_string(),
+                        AvroValue::String("login".to_string()),
+                    )])]),
+                ),
+            ]),
+            AvroValue::Record(vec![
+                ("id".to_string(), AvroValue::Long(8)),
+                (
+                    "email".to_string(),
+                    AvroValue::Union(0, Box::new(AvroValue::Null)),
+                ),
+                ("labels".to_string(), AvroValue::Map(Default::default())),
+                ("events".to_string(), AvroValue::Array(Vec::new())),
+            ]),
+        ];
+        let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null).unwrap();
+        for value in values {
+            writer.append_value(value).unwrap();
+        }
+        writer.into_inner().unwrap()
+    }
+
+    struct ChunkedReader {
+        bytes: Vec<u8>,
+        offset: usize,
+        chunk_size: usize,
+    }
+
+    impl ChunkedReader {
+        fn new(bytes: Vec<u8>, chunk_size: usize) -> Self {
+            Self {
+                bytes,
+                offset: 0,
+                chunk_size,
+            }
+        }
+    }
+
+    impl Read for ChunkedReader {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            if self.offset == self.bytes.len() {
+                return Ok(0);
+            }
+            let length = (self.bytes.len() - self.offset)
+                .min(self.chunk_size)
+                .min(buffer.len());
+            buffer[..length].copy_from_slice(&self.bytes[self.offset..self.offset + length]);
+            self.offset += length;
+            Ok(length)
+        }
+    }
+
+    #[test]
+    fn ocf_round_trip_preserves_supported_schema_and_values() {
+        let mut values = Vec::new();
+        let schema = decode_ocf(input().as_slice(), AvroLimits::default(), |value| {
+            values.push(value);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(values.len(), 2);
+        assert!(matches!(schema.root.kind, SchemaKind::Record { .. }));
+
+        let output = encode_ocf(&schema, &values, AvroLimits::default()).unwrap();
+        assert!(output.starts_with(b"Obj\x01"));
+        let mut decoded = Vec::new();
+        let output_schema = decode_ocf(output.as_slice(), AvroLimits::default(), |value| {
+            decoded.push(value);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(output_schema, schema);
+        assert_eq!(decoded, values);
+    }
+
+    #[test]
+    fn source_limit_fails_before_ocf_bytes_are_unbounded() {
+        let error = decode_ocf(
+            input().as_slice(),
+            AvroLimits {
+                max_source_bytes: 4,
+                ..AvroLimits::default()
+            },
+            |_| Ok(()),
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), codes::UNSUPPORTED_FORMAT);
+    }
+
+    #[test]
+    fn source_limit_allows_an_ocf_with_exactly_the_configured_size() {
+        let input = input();
+        let mut records = 0;
+        decode_ocf(
+            input.as_slice(),
+            AvroLimits {
+                max_source_bytes: input.len(),
+                ..AvroLimits::default()
+            },
+            |_| {
+                records += 1;
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(records, 2);
+    }
+
+    #[test]
+    fn ocf_decoding_is_invariant_across_transport_chunk_sizes() {
+        let input = input();
+        for chunk_size in 1..=32 {
+            let mut values = Vec::new();
+            decode_ocf(
+                ChunkedReader::new(input.clone(), chunk_size),
+                AvroLimits::default(),
+                |value| {
+                    values.push(value);
+                    Ok(())
+                },
+            )
+            .unwrap();
+            assert_eq!(values.len(), 2, "chunk size {chunk_size}");
+        }
+    }
+
+    #[test]
+    fn unsupported_union_is_rejected() {
+        let schema = Schema::parse_str(r#"["null","string","long"]"#).unwrap();
+        let error = schema_from_avro(&schema, BinaryIrLimits::default()).unwrap_err();
+        assert_eq!(error.code(), codes::UNSUPPORTED_FORMAT);
+    }
+
+    #[test]
+    fn logical_date_is_mapped_to_typed_ir() {
+        let schema = Schema::parse_str(r#"{"type":"int","logicalType":"date"}"#).unwrap();
+        let schema = schema_from_avro(&schema, BinaryIrLimits::default()).unwrap();
+        assert_eq!(schema.root.kind, SchemaKind::Date);
+    }
+
+    #[test]
+    fn supported_logical_values_round_trip_through_ocf() {
+        let cases = vec![
+            (
+                SchemaIr::new(SchemaNode::required(SchemaKind::Date)),
+                ValueIr::new(Value::Date {
+                    value: "2026-08-30".to_string(),
+                }),
+            ),
+            (
+                SchemaIr::new(SchemaNode::required(SchemaKind::Time)),
+                ValueIr::new(Value::Time {
+                    value: "12:34:56.789".to_string(),
+                }),
+            ),
+            (
+                SchemaIr::new(SchemaNode::required(SchemaKind::Timestamp)),
+                ValueIr::new(Value::Timestamp {
+                    value: "2026-08-30T12:34:56.789Z".to_string(),
+                }),
+            ),
+            (
+                SchemaIr::new(SchemaNode::required(SchemaKind::Uuid)),
+                ValueIr::new(Value::Uuid {
+                    value: "d5ed6eb6-89be-4aab-84a0-f1e4a12d50f8".to_string(),
+                }),
+            ),
+            (
+                SchemaIr::new(SchemaNode::required(SchemaKind::Decimal {
+                    precision: 20,
+                    scale: 4,
+                })),
+                ValueIr::new(Value::Decimal {
+                    value: "123.4500".to_string(),
+                }),
+            ),
+            (
+                SchemaIr::new(SchemaNode::required(SchemaKind::Decimal {
+                    precision: 20,
+                    scale: 4,
+                })),
+                ValueIr::new(Value::Decimal {
+                    value: "-0.0500".to_string(),
+                }),
+            ),
+        ];
+        for (schema, value) in cases {
+            let output =
+                encode_ocf(&schema, std::slice::from_ref(&value), AvroLimits::default()).unwrap();
+            let mut decoded = Vec::new();
+            let decoded_schema = decode_ocf(output.as_slice(), AvroLimits::default(), |value| {
+                decoded.push(value);
+                Ok(())
+            })
+            .unwrap();
+            assert_eq!(decoded_schema, schema);
+            assert_eq!(decoded, vec![value]);
+        }
+    }
+
+    struct Uppercase;
+
+    impl BinaryTransform for Uppercase {
+        fn output_schema(&mut self, input_schema: &SchemaIr) -> Result<SchemaIr, S4Error> {
+            Ok(input_schema.clone())
+        }
+
+        fn transform(
+            &mut self,
+            value: ValueIr,
+            _input_schema: &SchemaIr,
+            _output_schema: &SchemaIr,
+        ) -> Result<Option<ValueIr>, S4Error> {
+            let Value::Record { mut fields } = value.root else {
+                return Err(S4Error::new(codes::INTERNAL, "test expects a record"));
+            };
+            match &mut fields[1].value {
+                Value::String { value } => *value = value.to_uppercase(),
+                Value::Null => {}
+                _ => {
+                    return Err(S4Error::new(
+                        codes::INTERNAL,
+                        "test expects an optional email string",
+                    ));
+                }
+            }
+            Ok(Some(ValueIr::new(Value::Record { fields })))
+        }
+    }
+
+    #[test]
+    fn process_ocf_routes_each_record_through_the_typed_pump() {
+        let mut pump = BinaryPump::new(
+            CommonTypeBinaryReductor::default(),
+            Uppercase,
+            BinaryIrLimits::default(),
+        );
+        let output = process_ocf(input().as_slice(), AvroLimits::default(), &mut pump).unwrap();
+        let mut values = Vec::new();
+        decode_ocf(output.as_slice(), AvroLimits::default(), |value| {
+            values.push(value);
+            Ok(())
+        })
+        .unwrap();
+        let Value::Record { fields } = &values[0].root else {
+            panic!("expected record");
+        };
+        assert_eq!(
+            fields[1].value,
+            Value::String {
+                value: "ADA@EXAMPLE.COM".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn process_ocf_emits_the_typed_envelope_schema() {
+        let private_key = RsaPrivateKey::new(&mut OsRng, 2048).unwrap();
+        let public_pem = private_key
+            .to_public_key()
+            .to_public_key_pem(Default::default())
+            .unwrap();
+        let target =
+            crate::binary_ir::SchemaPath(vec![crate::binary_ir::SchemaPathSegment::Field(
+                "email".to_string(),
+            )]);
+        let mut pump = BinaryPump::new(
+            CommonTypeBinaryReductor::default(),
+            EnvelopeBinaryTransform::new(vec![target], Some(&public_pem)).unwrap(),
+            BinaryIrLimits::default(),
+        );
+        let output = process_ocf(input().as_slice(), AvroLimits::default(), &mut pump).unwrap();
+        assert!(
+            !output
+                .windows(b"ada@example.com".len())
+                .any(|bytes| bytes == b"ada@example.com")
+        );
+
+        let mut values = Vec::new();
+        let schema = decode_ocf(output.as_slice(), AvroLimits::default(), |value| {
+            values.push(value);
+            Ok(())
+        })
+        .unwrap();
+        let SchemaKind::Record { fields } = &schema.root.kind else {
+            panic!("expected record schema");
+        };
+        assert!(matches!(fields[1].schema.kind, SchemaKind::Record { .. }));
+        let Value::Record { fields } = &values[0].root else {
+            panic!("expected record value");
+        };
+        assert!(matches!(fields[1].value, Value::Record { .. }));
+    }
+}

--- a/crates/gateway/src/binary_pump.rs
+++ b/crates/gateway/src/binary_pump.rs
@@ -1,0 +1,682 @@
+//! Schema-aware reduction, transformation, restoration, and validation.
+
+use std::cmp::Ordering;
+
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::{Aes256Gcm, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use rand::RngCore;
+use rand::rngs::OsRng;
+use rsa::Oaep;
+use rsa::RsaPublicKey;
+use rsa::pkcs8::DecodePublicKey;
+use s4_error::{S4Error, codes};
+use sha2::Sha256;
+use zeroize::Zeroize;
+
+use crate::binary_ir::{
+    BinaryIrLimits, SchemaField, SchemaIr, SchemaKind, SchemaNode, SchemaPath, SchemaPathSegment,
+    Value, ValueField, ValueIr,
+};
+use crate::binary_reductor::{BinaryReductionPlan, BinaryReductor, BinaryRestorePlan};
+
+/// A typed binary transform declares its output schema before processing data.
+///
+/// This intentionally differs from the byte-oriented text filter contract: an
+/// encoder must know the resulting binary schema before it can accept records.
+pub trait BinaryTransform {
+    fn output_schema(&mut self, input_schema: &SchemaIr) -> Result<SchemaIr, S4Error>;
+
+    /// Returns `None` when the record is deliberately dropped.
+    fn transform(
+        &mut self,
+        value: ValueIr,
+        input_schema: &SchemaIr,
+        output_schema: &SchemaIr,
+    ) -> Result<Option<ValueIr>, S4Error>;
+}
+
+#[derive(Default)]
+pub struct IdentityBinaryTransform;
+
+impl BinaryTransform for IdentityBinaryTransform {
+    fn output_schema(&mut self, input_schema: &SchemaIr) -> Result<SchemaIr, S4Error> {
+        Ok(input_schema.clone())
+    }
+
+    fn transform(
+        &mut self,
+        value: ValueIr,
+        _input_schema: &SchemaIr,
+        _output_schema: &SchemaIr,
+    ) -> Result<Option<ValueIr>, S4Error> {
+        Ok(Some(value))
+    }
+}
+
+/// Replaces explicitly selected string values with S4 envelope records.
+///
+/// A missing public key deliberately redacts instead of producing a malformed
+/// envelope. No private key is accepted or retained by this transform.
+#[derive(Debug)]
+pub struct EnvelopeBinaryTransform {
+    targets: Vec<SchemaPath>,
+    public_key: Option<RsaPublicKey>,
+}
+
+impl EnvelopeBinaryTransform {
+    pub fn new(targets: Vec<SchemaPath>, public_key_pem: Option<&str>) -> Result<Self, S4Error> {
+        let targets = canonicalize_targets(targets)?;
+        let public_key = public_key_pem.map(parse_public_key).transpose()?;
+        Ok(Self {
+            targets,
+            public_key,
+        })
+    }
+
+    pub fn targets(&self) -> &[SchemaPath] {
+        &self.targets
+    }
+}
+
+/// Parses `x-s4-encrypt-fields`: comma-separated paths such as
+/// `email,contacts[*].email` or `$.email`.
+pub fn parse_envelope_targets(value: &str) -> Result<Vec<SchemaPath>, S4Error> {
+    let mut paths = Vec::new();
+    for raw_path in value
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let raw_path = raw_path.strip_prefix("$.").unwrap_or(raw_path);
+        if raw_path.is_empty() {
+            return Err(transform_error("envelope target must not be the root path"));
+        }
+        let mut segments = Vec::new();
+        for segment in raw_path.split('.') {
+            let (field, array) = segment
+                .strip_suffix("[*]")
+                .map_or((segment, false), |field| (field, true));
+            if field.is_empty()
+                || !field
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+            {
+                return Err(transform_error(
+                    "envelope target contains an invalid field name",
+                ));
+            }
+            segments.push(SchemaPathSegment::Field(field.to_string()));
+            if array {
+                segments.push(SchemaPathSegment::ArrayElement);
+            }
+        }
+        paths.push(SchemaPath(segments));
+    }
+    canonicalize_targets(paths)
+}
+
+impl BinaryTransform for EnvelopeBinaryTransform {
+    fn output_schema(&mut self, input_schema: &SchemaIr) -> Result<SchemaIr, S4Error> {
+        let mut output = input_schema.clone();
+        if self.public_key.is_none() {
+            return Ok(output);
+        }
+        for target in &self.targets {
+            replace_schema_at_path(&mut output.root, target.segments(), target)?;
+        }
+        Ok(output)
+    }
+
+    fn transform(
+        &mut self,
+        mut value: ValueIr,
+        input_schema: &SchemaIr,
+        _output_schema: &SchemaIr,
+    ) -> Result<Option<ValueIr>, S4Error> {
+        for target in &self.targets {
+            let node = input_schema.node_at_path(target).ok_or_else(|| {
+                transform_error(format!("envelope target {target} does not exist"))
+            })?;
+            if !matches!(&node.kind, SchemaKind::String) {
+                return Err(transform_error(format!(
+                    "envelope target {target} must be a string schema"
+                )));
+            }
+            transform_values_at_path(&mut value.root, target.segments(), target, &self.public_key)?;
+        }
+        Ok(Some(value))
+    }
+}
+
+fn envelope_schema(nullable: bool) -> SchemaNode {
+    SchemaNode {
+        nullable,
+        kind: SchemaKind::Record {
+            fields: ["alg", "iv", "enc_dek", "ct", "tag"]
+                .into_iter()
+                .map(|name| SchemaField {
+                    name: name.to_string(),
+                    schema: SchemaNode::required(SchemaKind::String),
+                })
+                .collect(),
+        },
+    }
+}
+
+fn replace_schema_at_path(
+    node: &mut SchemaNode,
+    segments: &[SchemaPathSegment],
+    target: &SchemaPath,
+) -> Result<(), S4Error> {
+    let Some((segment, remaining)) = segments.split_first() else {
+        if !matches!(&node.kind, SchemaKind::String) {
+            return Err(transform_error(format!(
+                "envelope target {target} must be a string schema"
+            )));
+        }
+        *node = envelope_schema(node.nullable);
+        return Ok(());
+    };
+    match (&mut node.kind, segment) {
+        (SchemaKind::Array { items }, SchemaPathSegment::ArrayElement) => {
+            replace_schema_at_path(items, remaining, target)
+        }
+        (SchemaKind::Map { values }, SchemaPathSegment::MapValue) => {
+            replace_schema_at_path(values, remaining, target)
+        }
+        (SchemaKind::Record { fields }, SchemaPathSegment::Field(name)) => {
+            let field = fields
+                .iter_mut()
+                .find(|field| field.name == *name)
+                .ok_or_else(|| {
+                    transform_error(format!("envelope target {target} does not exist"))
+                })?;
+            replace_schema_at_path(&mut field.schema, remaining, target)
+        }
+        (SchemaKind::Custom { value, .. }, SchemaPathSegment::LogicalValue) => {
+            replace_schema_at_path(value, remaining, target)
+        }
+        _ => Err(transform_error(format!(
+            "envelope target {target} does not match the input schema"
+        ))),
+    }
+}
+
+fn transform_values_at_path(
+    value: &mut Value,
+    segments: &[SchemaPathSegment],
+    target: &SchemaPath,
+    public_key: &Option<RsaPublicKey>,
+) -> Result<(), S4Error> {
+    let Some((segment, remaining)) = segments.split_first() else {
+        let Value::String { value: plaintext } = value else {
+            if matches!(value, Value::Null) {
+                return Ok(());
+            }
+            return Err(transform_error(format!(
+                "envelope target {target} does not contain a string value"
+            )));
+        };
+        *value = match public_key {
+            Some(public_key) => encrypt_string(plaintext, public_key)?,
+            None => Value::String {
+                value: "[REDACTED]".to_string(),
+            },
+        };
+        return Ok(());
+    };
+    match (value, segment) {
+        (Value::Array { items }, SchemaPathSegment::ArrayElement) => {
+            for item in items {
+                transform_values_at_path(item, remaining, target, public_key)?;
+            }
+            Ok(())
+        }
+        (Value::Map { entries }, SchemaPathSegment::MapValue) => {
+            for entry in entries {
+                transform_values_at_path(&mut entry.value, remaining, target, public_key)?;
+            }
+            Ok(())
+        }
+        (Value::Record { fields }, SchemaPathSegment::Field(name)) => {
+            let field = fields
+                .iter_mut()
+                .find(|field| field.name == *name)
+                .ok_or_else(|| {
+                    transform_error(format!(
+                        "envelope target {target} does not exist in a value"
+                    ))
+                })?;
+            transform_values_at_path(&mut field.value, remaining, target, public_key)
+        }
+        (Value::Custom { value, .. }, SchemaPathSegment::LogicalValue) => {
+            transform_values_at_path(value, remaining, target, public_key)
+        }
+        _ => Err(transform_error(format!(
+            "envelope target {target} does not match an input value"
+        ))),
+    }
+}
+
+fn encrypt_string(plaintext: &str, public_key: &RsaPublicKey) -> Result<Value, S4Error> {
+    let mut dek = [0_u8; 32];
+    let mut iv = [0_u8; 12];
+    OsRng.fill_bytes(&mut dek);
+    OsRng.fill_bytes(&mut iv);
+    let result = (|| {
+        let encrypted_dek = public_key
+            .encrypt(&mut OsRng, Oaep::new::<Sha256>(), &dek)
+            .map_err(|_| transform_error("envelope DEK wrapping failed"))?;
+        let cipher = Aes256Gcm::new_from_slice(&dek)
+            .map_err(|_| transform_error("envelope cipher initialization failed"))?;
+        let ciphertext = cipher
+            .encrypt(Nonce::from_slice(&iv), plaintext.as_bytes())
+            .map_err(|_| transform_error("envelope encryption failed"))?;
+        let tag_start = ciphertext.len().checked_sub(16).ok_or_else(|| {
+            transform_error("envelope ciphertext is missing an authentication tag")
+        })?;
+        Ok(Value::Record {
+            fields: vec![
+                string_field("alg", "RSA-OAEP/AES-256-GCM".to_string()),
+                string_field("iv", BASE64.encode(iv)),
+                string_field("enc_dek", BASE64.encode(encrypted_dek)),
+                string_field("ct", BASE64.encode(&ciphertext[..tag_start])),
+                string_field("tag", BASE64.encode(&ciphertext[tag_start..])),
+            ],
+        })
+    })();
+    dek.zeroize();
+    result
+}
+
+fn string_field(name: &str, value: String) -> ValueField {
+    ValueField {
+        name: name.to_string(),
+        value: Value::String { value },
+    }
+}
+
+fn parse_public_key(pem: &str) -> Result<RsaPublicKey, S4Error> {
+    let pem = pem.trim();
+    if pem.is_empty() {
+        return Err(transform_error("envelope public key must not be empty"));
+    }
+    if let Ok(key) = RsaPublicKey::from_public_key_pem(pem) {
+        return Ok(key);
+    }
+    let (_, certificate) = x509_parser::pem::parse_x509_pem(pem.as_bytes())
+        .map_err(|_| transform_error("envelope public key must be RSA SPKI or X.509 PEM"))?;
+    let certificate = certificate
+        .parse_x509()
+        .map_err(|_| transform_error("envelope public key must be RSA SPKI or X.509 PEM"))?;
+    RsaPublicKey::from_public_key_der(certificate.public_key().raw)
+        .map_err(|_| transform_error("envelope public key must be RSA SPKI or X.509 PEM"))
+}
+
+fn canonicalize_targets(mut targets: Vec<SchemaPath>) -> Result<Vec<SchemaPath>, S4Error> {
+    targets.sort_by(compare_paths);
+    for pair in targets.windows(2) {
+        if path_is_prefix(&pair[0], &pair[1]) {
+            return Err(transform_error(format!(
+                "envelope targets {} and {} overlap",
+                pair[0], pair[1]
+            )));
+        }
+    }
+    Ok(targets)
+}
+
+fn compare_paths(left: &SchemaPath, right: &SchemaPath) -> Ordering {
+    left.segments()
+        .iter()
+        .map(segment_sort_key)
+        .cmp(right.segments().iter().map(segment_sort_key))
+}
+
+fn segment_sort_key(segment: &SchemaPathSegment) -> (u8, &str) {
+    match segment {
+        SchemaPathSegment::Field(name) => (0, name),
+        SchemaPathSegment::ArrayElement => (1, ""),
+        SchemaPathSegment::MapValue => (2, ""),
+        SchemaPathSegment::LogicalValue => (3, ""),
+    }
+}
+
+fn path_is_prefix(prefix: &SchemaPath, path: &SchemaPath) -> bool {
+    prefix.segments().len() <= path.segments().len()
+        && prefix
+            .segments()
+            .iter()
+            .zip(path.segments())
+            .all(|(left, right)| left == right)
+}
+
+fn transform_error(message: impl Into<String>) -> S4Error {
+    S4Error::new(codes::CONFIG_INVALID, message)
+}
+
+pub struct BinaryPump<R, T> {
+    reductor: R,
+    transform: T,
+    limits: BinaryIrLimits,
+    plans: Option<(BinaryReductionPlan, BinaryRestorePlan)>,
+}
+
+impl<R, T> BinaryPump<R, T>
+where
+    R: BinaryReductor,
+    T: BinaryTransform,
+{
+    pub fn new(reductor: R, transform: T, limits: BinaryIrLimits) -> Self {
+        Self {
+            reductor,
+            transform,
+            limits,
+            plans: None,
+        }
+    }
+
+    /// Freezes all schemas before the first value is accepted.
+    pub fn plan(&mut self, source_schema: &SchemaIr) -> Result<&SchemaIr, S4Error> {
+        source_schema.validate(self.limits)?;
+        let reduction = self.reductor.plan(source_schema)?;
+        let transformed = self.transform.output_schema(reduction.reduced_schema())?;
+        transformed.validate(self.limits)?;
+        let restoration = self.reductor.plan_restore(&reduction, &transformed)?;
+        self.plans = Some((reduction, restoration));
+        Ok(self
+            .plans
+            .as_ref()
+            .expect("binary pump plans were just installed")
+            .1
+            .output_schema())
+    }
+
+    pub fn process(&mut self, source_value: ValueIr) -> Result<Option<ValueIr>, S4Error> {
+        let (reduction, restoration) = self.plans.clone().ok_or_else(|| {
+            S4Error::new(
+                codes::CONFIG_INVALID,
+                "binary pump must be planned before processing values",
+            )
+        })?;
+        source_value.validate(reduction.source_schema(), self.limits)?;
+        let reduced = self.reductor.reduce(&reduction, &source_value)?;
+        let transformed = self.transform.transform(
+            reduced,
+            reduction.reduced_schema(),
+            restoration.transformed_reduced_schema(),
+        )?;
+        let Some(transformed) = transformed else {
+            return Ok(None);
+        };
+        transformed.validate(restoration.transformed_reduced_schema(), self.limits)?;
+        let restored = self.reductor.restore(&restoration, &transformed)?;
+        restored.validate(restoration.output_schema(), self.limits)?;
+        Ok(Some(restored))
+    }
+
+    pub fn output_schema(&self) -> Option<&SchemaIr> {
+        self.plans
+            .as_ref()
+            .map(|(_, restore)| restore.output_schema())
+    }
+
+    pub fn into_parts(self) -> (R, T) {
+        (self.reductor, self.transform)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::binary_ir::{SchemaKind, SchemaNode, Value};
+    use crate::binary_reductor::CommonTypeBinaryReductor;
+    use aes_gcm::aead::Aead;
+    use aes_gcm::{Aes256Gcm, Nonce};
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use rand::rngs::OsRng;
+    use rsa::Oaep;
+    use rsa::RsaPrivateKey;
+    use rsa::pkcs8::EncodePublicKey;
+    use sha2::Sha256;
+
+    fn string_schema() -> SchemaIr {
+        SchemaIr::new(SchemaNode::required(SchemaKind::String))
+    }
+
+    struct Uppercase;
+
+    impl BinaryTransform for Uppercase {
+        fn output_schema(&mut self, input_schema: &SchemaIr) -> Result<SchemaIr, S4Error> {
+            Ok(input_schema.clone())
+        }
+
+        fn transform(
+            &mut self,
+            value: ValueIr,
+            _input_schema: &SchemaIr,
+            _output_schema: &SchemaIr,
+        ) -> Result<Option<ValueIr>, S4Error> {
+            let Value::String { value } = value.root else {
+                return Err(S4Error::new(codes::INTERNAL, "test expects a string"));
+            };
+            Ok(Some(ValueIr::new(Value::String {
+                value: value.to_uppercase(),
+            })))
+        }
+    }
+
+    struct InvalidTransform;
+
+    impl BinaryTransform for InvalidTransform {
+        fn output_schema(&mut self, input_schema: &SchemaIr) -> Result<SchemaIr, S4Error> {
+            Ok(input_schema.clone())
+        }
+
+        fn transform(
+            &mut self,
+            _value: ValueIr,
+            _input_schema: &SchemaIr,
+            _output_schema: &SchemaIr,
+        ) -> Result<Option<ValueIr>, S4Error> {
+            Ok(Some(ValueIr::new(Value::I64 { value: 1 })))
+        }
+    }
+
+    #[test]
+    fn plans_before_processing_and_validates_typed_output() {
+        let schema = string_schema();
+        let mut pump = BinaryPump::new(
+            CommonTypeBinaryReductor::default(),
+            Uppercase,
+            BinaryIrLimits::default(),
+        );
+        let value = ValueIr::new(Value::String {
+            value: "Ada".to_string(),
+        });
+        assert_eq!(
+            pump.process(value.clone()).unwrap_err().code(),
+            codes::CONFIG_INVALID
+        );
+        assert_eq!(pump.plan(&schema).unwrap(), &schema);
+        assert_eq!(
+            pump.process(value).unwrap(),
+            Some(ValueIr::new(Value::String {
+                value: "ADA".to_string(),
+            }))
+        );
+    }
+
+    #[test]
+    fn rejects_a_transform_that_violates_its_declared_schema() {
+        let mut pump = BinaryPump::new(
+            CommonTypeBinaryReductor::default(),
+            InvalidTransform,
+            BinaryIrLimits::default(),
+        );
+        let schema = string_schema();
+        pump.plan(&schema).unwrap();
+        assert!(
+            pump.process(ValueIr::new(Value::String {
+                value: "Ada".to_string(),
+            }))
+            .is_err()
+        );
+    }
+
+    fn email_schema() -> SchemaIr {
+        SchemaIr::new(SchemaNode::required(SchemaKind::Record {
+            fields: vec![
+                SchemaField {
+                    name: "email".to_string(),
+                    schema: SchemaNode::required(SchemaKind::String),
+                },
+                SchemaField {
+                    name: "note".to_string(),
+                    schema: SchemaNode::required(SchemaKind::String),
+                },
+            ],
+        }))
+    }
+
+    fn email_value() -> ValueIr {
+        ValueIr::new(Value::Record {
+            fields: vec![
+                ValueField {
+                    name: "email".to_string(),
+                    value: Value::String {
+                        value: "ada@example.com".to_string(),
+                    },
+                },
+                ValueField {
+                    name: "note".to_string(),
+                    value: Value::String {
+                        value: "keep".to_string(),
+                    },
+                },
+            ],
+        })
+    }
+
+    fn email_target() -> SchemaPath {
+        SchemaPath(vec![SchemaPathSegment::Field("email".to_string())])
+    }
+
+    #[test]
+    fn envelope_without_a_public_key_redacts_and_preserves_schema() {
+        let schema = email_schema();
+        let mut pump = BinaryPump::new(
+            CommonTypeBinaryReductor::default(),
+            EnvelopeBinaryTransform::new(vec![email_target()], None).unwrap(),
+            BinaryIrLimits::default(),
+        );
+        assert_eq!(pump.plan(&schema).unwrap(), &schema);
+        let output = pump.process(email_value()).unwrap().unwrap();
+        let Value::Record { fields } = output.root else {
+            panic!("expected record");
+        };
+        assert_eq!(
+            fields[0].value,
+            Value::String {
+                value: "[REDACTED]".to_string(),
+            }
+        );
+        assert_eq!(
+            fields[1].value,
+            Value::String {
+                value: "keep".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn envelope_with_a_public_key_changes_schema_and_round_trips_cryptographically() {
+        let private_key = RsaPrivateKey::new(&mut OsRng, 2048).unwrap();
+        let public_pem = private_key
+            .to_public_key()
+            .to_public_key_pem(Default::default())
+            .unwrap();
+        let schema = email_schema();
+        let mut pump = BinaryPump::new(
+            CommonTypeBinaryReductor::default(),
+            EnvelopeBinaryTransform::new(vec![email_target()], Some(&public_pem)).unwrap(),
+            BinaryIrLimits::default(),
+        );
+        let output_schema = pump.plan(&schema).unwrap();
+        let SchemaKind::Record { fields } = &output_schema.root.kind else {
+            panic!("expected record schema");
+        };
+        assert!(matches!(fields[0].schema.kind, SchemaKind::Record { .. }));
+
+        let output = pump.process(email_value()).unwrap().unwrap();
+        let Value::Record { fields } = output.root else {
+            panic!("expected output record");
+        };
+        let Value::Record { fields: envelope } = &fields[0].value else {
+            panic!("expected envelope record");
+        };
+        let contents = envelope
+            .iter()
+            .map(|field| {
+                let Value::String { value } = &field.value else {
+                    panic!("envelope values must be strings");
+                };
+                (field.name.as_str(), value.as_str())
+            })
+            .collect::<std::collections::HashMap<_, _>>();
+        assert_eq!(contents["alg"], "RSA-OAEP/AES-256-GCM");
+        assert!(!contents["ct"].contains("ada@example.com"));
+
+        let dek = private_key
+            .decrypt(
+                Oaep::new::<Sha256>(),
+                &BASE64.decode(contents["enc_dek"]).unwrap(),
+            )
+            .unwrap();
+        let mut ciphertext = BASE64.decode(contents["ct"]).unwrap();
+        ciphertext.extend(BASE64.decode(contents["tag"]).unwrap());
+        let plaintext = Aes256Gcm::new_from_slice(&dek)
+            .unwrap()
+            .decrypt(
+                Nonce::from_slice(&BASE64.decode(contents["iv"]).unwrap()),
+                ciphertext.as_ref(),
+            )
+            .unwrap();
+        assert_eq!(plaintext, b"ada@example.com");
+    }
+
+    #[test]
+    fn envelope_target_paths_must_not_overlap() {
+        let error = EnvelopeBinaryTransform::new(
+            vec![
+                SchemaPath(vec![SchemaPathSegment::Field("contacts".to_string())]),
+                SchemaPath(vec![
+                    SchemaPathSegment::Field("contacts".to_string()),
+                    SchemaPathSegment::ArrayElement,
+                ]),
+            ],
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), codes::CONFIG_INVALID);
+    }
+
+    #[test]
+    fn parses_header_targets_into_schema_paths() {
+        assert_eq!(
+            parse_envelope_targets("$.email,contacts[*].email").unwrap(),
+            vec![
+                SchemaPath(vec![
+                    SchemaPathSegment::Field("contacts".to_string()),
+                    SchemaPathSegment::ArrayElement,
+                    SchemaPathSegment::Field("email".to_string()),
+                ]),
+                SchemaPath(vec![SchemaPathSegment::Field("email".to_string())]),
+            ]
+        );
+        assert!(parse_envelope_targets("contacts..email").is_err());
+    }
+}

--- a/crates/gateway/src/binary_reductor.rs
+++ b/crates/gateway/src/binary_reductor.rs
@@ -5,8 +5,14 @@
 
 use std::cmp::Ordering;
 use std::sync::Arc;
+use std::time::Instant;
 
 use s4_error::{S4Error, codes};
+use s4_wasm_runtime::{
+    BinaryReductorEngine as WasmBinaryReductorEngine,
+    BinaryReductorPathSegment as WasmBinaryReductorPathSegment,
+    BinaryReductorSession as WasmBinaryReductorSession, CancellationToken,
+};
 use sha2::{Digest, Sha256};
 
 use crate::binary_ir::{
@@ -311,6 +317,303 @@ impl BinaryReductor for CommonTypeBinaryReductor {
     }
 }
 
+/// Adapter from the bounded `s4:binary-reductor` runtime world to the typed
+/// gateway contract used by binary codecs.
+///
+/// The runtime bounds byte-oriented guest calls. This adapter is responsible
+/// for parsing canonical IR, binding plans to the component digest, and making
+/// sure a guest changes schema only at paths it explicitly owns.
+pub struct WasmBinaryReductor {
+    session: WasmBinaryReductorSession,
+    owner: ReductorOwner,
+    limits: BinaryIrLimits,
+}
+
+impl WasmBinaryReductor {
+    pub fn start(
+        engine: &WasmBinaryReductorEngine,
+        limits: BinaryIrLimits,
+    ) -> Result<Self, S4Error> {
+        Self::start_with_cancellation(engine, limits, CancellationToken::new())
+    }
+
+    pub fn start_with_cancellation(
+        engine: &WasmBinaryReductorEngine,
+        limits: BinaryIrLimits,
+        cancellation: CancellationToken,
+    ) -> Result<Self, S4Error> {
+        let session = engine.start_session_with_cancellation(cancellation)?;
+        Ok(Self {
+            session,
+            owner: ReductorOwner(Arc::from(engine.component_digest())),
+            limits,
+        })
+    }
+
+    pub fn start_with_control(
+        engine: &WasmBinaryReductorEngine,
+        limits: BinaryIrLimits,
+        cancellation: CancellationToken,
+        object_deadline: Instant,
+    ) -> Result<Self, S4Error> {
+        let session = engine.start_session_with_control(cancellation, object_deadline)?;
+        Ok(Self {
+            session,
+            owner: ReductorOwner(Arc::from(engine.component_digest())),
+            limits,
+        })
+    }
+
+    pub fn component_digest(&self) -> &str {
+        self.owner
+            .component_digest()
+            .expect("Wasm reductors always have a component digest")
+    }
+
+    pub fn fuel_consumed(&self) -> u64 {
+        self.session.fuel_consumed()
+    }
+}
+
+impl BinaryReductor for WasmBinaryReductor {
+    fn plan(&mut self, source_schema: &SchemaIr) -> Result<BinaryReductionPlan, S4Error> {
+        source_schema.validate(self.limits)?;
+        let source_encoded = source_schema.to_canonical_json(self.limits)?;
+        let planned = self.session.plan(&source_encoded)?;
+        let claims = canonicalize_claims(convert_wasm_claims(planned.claims))?;
+        validate_claims_against_schema(source_schema, &claims)?;
+        let reduced_schema =
+            SchemaIr::from_canonical_json(&planned.reduced_schema_ir, self.limits)?;
+        ensure_schema_changes_are_claimed(source_schema, &reduced_schema, &claims)?;
+
+        BinaryReductionPlan::new(
+            self.owner.clone(),
+            source_schema.clone(),
+            reduced_schema,
+            claims.clone(),
+            claims,
+            planned.plan,
+            self.limits,
+        )
+    }
+
+    fn plan_restore(
+        &mut self,
+        plan: &BinaryReductionPlan,
+        transformed_reduced_schema: &SchemaIr,
+    ) -> Result<BinaryRestorePlan, S4Error> {
+        ensure_owner(plan, &self.owner)?;
+        transformed_reduced_schema.validate(self.limits)?;
+        let source_encoded = plan.source_schema().to_canonical_json(self.limits)?;
+        let transformed_encoded = transformed_reduced_schema.to_canonical_json(self.limits)?;
+        let planned =
+            self.session
+                .plan_restore(&source_encoded, &transformed_encoded, plan.opaque_plan())?;
+        let output_schema = SchemaIr::from_canonical_json(&planned.output_schema_ir, self.limits)?;
+        ensure_schema_changes_are_claimed(
+            transformed_reduced_schema,
+            &output_schema,
+            plan.claims(),
+        )?;
+
+        BinaryRestorePlan::new(
+            plan,
+            transformed_reduced_schema.clone(),
+            output_schema,
+            planned.restore_plan,
+            self.limits,
+        )
+    }
+
+    fn reduce(
+        &mut self,
+        plan: &BinaryReductionPlan,
+        source_value: &ValueIr,
+    ) -> Result<ValueIr, S4Error> {
+        ensure_owner(plan, &self.owner)?;
+        source_value.validate(plan.source_schema(), self.limits)?;
+        let source_encoded = source_value.to_canonical_json(plan.source_schema(), self.limits)?;
+        let reduced_encoded = self.session.reduce(plan.opaque_plan(), &source_encoded)?;
+        ValueIr::from_canonical_json(&reduced_encoded, plan.reduced_schema(), self.limits)
+    }
+
+    fn restore(
+        &mut self,
+        plan: &BinaryRestorePlan,
+        transformed_value: &ValueIr,
+    ) -> Result<ValueIr, S4Error> {
+        ensure_owner(&plan.reduction, &self.owner)?;
+        transformed_value.validate(plan.transformed_reduced_schema(), self.limits)?;
+        let transformed_encoded =
+            transformed_value.to_canonical_json(plan.transformed_reduced_schema(), self.limits)?;
+        let restored_encoded = self
+            .session
+            .restore(plan.opaque_restore_plan(), &transformed_encoded)?;
+        ValueIr::from_canonical_json(&restored_encoded, plan.output_schema(), self.limits)
+    }
+}
+
+fn convert_wasm_claims(
+    claims: Vec<s4_wasm_runtime::BinaryReductorClaim>,
+) -> Vec<BinaryReductorClaim> {
+    claims
+        .into_iter()
+        .map(|claim| {
+            BinaryReductorClaim::new(
+                SchemaPath(
+                    claim
+                        .path
+                        .into_iter()
+                        .map(|segment| match segment {
+                            WasmBinaryReductorPathSegment::Field(name) => {
+                                SchemaPathSegment::Field(name)
+                            }
+                            WasmBinaryReductorPathSegment::ArrayElement => {
+                                SchemaPathSegment::ArrayElement
+                            }
+                            WasmBinaryReductorPathSegment::MapValue => SchemaPathSegment::MapValue,
+                            WasmBinaryReductorPathSegment::LogicalValue => {
+                                SchemaPathSegment::LogicalValue
+                            }
+                        })
+                        .collect(),
+                ),
+                claim.type_id,
+            )
+        })
+        .collect()
+}
+
+fn validate_claims_against_schema(
+    schema: &SchemaIr,
+    claims: &[BinaryReductorClaim],
+) -> Result<(), S4Error> {
+    for claim in claims {
+        let node = schema.node_at_path(claim.path()).ok_or_else(|| {
+            claim_error(format!(
+                "reductor claimed nonexistent schema path {}",
+                claim.path()
+            ))
+        })?;
+        match &node.kind {
+            SchemaKind::Custom { type_id, .. } if type_id == claim.type_id() => {}
+            SchemaKind::Custom { type_id, .. } => {
+                return Err(claim_error(format!(
+                    "reductor claimed type {:?} at {}, but the schema declares {:?}",
+                    claim.type_id(),
+                    claim.path(),
+                    type_id
+                )));
+            }
+            SchemaKind::Record { .. } => {}
+            _ => {
+                return Err(claim_error(format!(
+                    "reductor claim at {} must target a custom logical value or record",
+                    claim.path()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ensure_schema_changes_are_claimed(
+    source: &SchemaIr,
+    transformed: &SchemaIr,
+    claims: &[BinaryReductorClaim],
+) -> Result<(), S4Error> {
+    let mut path = SchemaPath::root();
+    ensure_node_changes_are_claimed(&source.root, &transformed.root, claims, &mut path)
+}
+
+fn ensure_node_changes_are_claimed(
+    source: &crate::binary_ir::SchemaNode,
+    transformed: &crate::binary_ir::SchemaNode,
+    claims: &[BinaryReductorClaim],
+    path: &mut SchemaPath,
+) -> Result<(), S4Error> {
+    if claims
+        .iter()
+        .any(|claim| path_is_prefix(claim.path(), path))
+    {
+        return Ok(());
+    }
+    if source.nullable != transformed.nullable {
+        return Err(unclaimed_schema_change(path));
+    }
+    match (&source.kind, &transformed.kind) {
+        (SchemaKind::Array { items: source }, SchemaKind::Array { items: transformed }) => {
+            path.0.push(SchemaPathSegment::ArrayElement);
+            let result = ensure_node_changes_are_claimed(source, transformed, claims, path);
+            path.0.pop();
+            result
+        }
+        (
+            SchemaKind::Map { values: source },
+            SchemaKind::Map {
+                values: transformed,
+            },
+        ) => {
+            path.0.push(SchemaPathSegment::MapValue);
+            let result = ensure_node_changes_are_claimed(source, transformed, claims, path);
+            path.0.pop();
+            result
+        }
+        (
+            SchemaKind::Record {
+                fields: source_fields,
+            },
+            SchemaKind::Record {
+                fields: transformed_fields,
+            },
+        ) => {
+            if source_fields.len() != transformed_fields.len() {
+                return Err(unclaimed_schema_change(path));
+            }
+            for (source_field, transformed_field) in source_fields.iter().zip(transformed_fields) {
+                if source_field.name != transformed_field.name {
+                    return Err(unclaimed_schema_change(path));
+                }
+                path.0
+                    .push(SchemaPathSegment::Field(source_field.name.clone()));
+                let result = ensure_node_changes_are_claimed(
+                    &source_field.schema,
+                    &transformed_field.schema,
+                    claims,
+                    path,
+                );
+                path.0.pop();
+                result?;
+            }
+            Ok(())
+        }
+        (
+            SchemaKind::Custom {
+                type_id: source_type,
+                value: source_value,
+            },
+            SchemaKind::Custom {
+                type_id: transformed_type,
+                value: transformed_value,
+            },
+        ) if source_type == transformed_type => {
+            path.0.push(SchemaPathSegment::LogicalValue);
+            let result =
+                ensure_node_changes_are_claimed(source_value, transformed_value, claims, path);
+            path.0.pop();
+            result
+        }
+        _ if source == transformed => Ok(()),
+        _ => Err(unclaimed_schema_change(path)),
+    }
+}
+
+fn unclaimed_schema_change(path: &SchemaPath) -> S4Error {
+    plan_error(format!(
+        "reductor changed schema outside its declared claims at {path}"
+    ))
+}
+
 fn reject_unclaimed_custom_nodes(
     schema: &SchemaIr,
     claims: &[BinaryReductorClaim],
@@ -465,6 +768,7 @@ fn usize_bytes(value: usize) -> [u8; 8] {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use std::sync::Arc;
 
     use super::*;
@@ -554,6 +858,32 @@ mod tests {
         }))
     }
 
+    fn guest_custom_schema() -> SchemaIr {
+        SchemaIr::new(required(SchemaKind::Custom {
+            type_id: "vendor.money".to_string(),
+            value: Box::new(required(SchemaKind::String)),
+        }))
+    }
+
+    fn guest_custom_value() -> ValueIr {
+        ValueIr::new(Value::Custom {
+            type_id: "vendor.money".to_string(),
+            value: Box::new(Value::String {
+                value: "12.34".to_string(),
+            }),
+        })
+    }
+
+    fn test_reductor_component() -> Vec<u8> {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("target")
+            .join("test-components")
+            .join("test-binary-reductor.component.wasm");
+        std::fs::read(path).expect("test component missing; run just build-filters")
+    }
+
     #[test]
     fn trait_is_object_safe() {
         fn accept(_: &mut dyn BinaryReductor) {}
@@ -634,5 +964,63 @@ mod tests {
             .plan(&SchemaIr::new(required(SchemaKind::String)))
             .unwrap();
         assert_ne!(first.plan_hash(), other.plan_hash());
+    }
+
+    #[test]
+    fn wasm_adapter_validates_and_round_trips_custom_values() {
+        let engine = WasmBinaryReductorEngine::new(&test_reductor_component()).unwrap();
+        let mut reductor = WasmBinaryReductor::start(&engine, BinaryIrLimits::default()).unwrap();
+        let source_schema = guest_custom_schema();
+        let source_value = guest_custom_value();
+
+        let plan = reductor.plan(&source_schema).unwrap();
+        assert_eq!(plan.claims().len(), 1);
+        assert_eq!(plan.claims()[0].path(), &SchemaPath::root());
+        assert_eq!(plan.claims()[0].type_id(), "vendor.money");
+        assert_eq!(plan.component_digest(), Some(engine.component_digest()));
+        assert_eq!(plan.reduced_schema().root.kind, SchemaKind::String);
+
+        let reduced = reductor.reduce(&plan, &source_value).unwrap();
+        assert_eq!(
+            reduced,
+            ValueIr::new(Value::String {
+                value: "12.34".to_string(),
+            })
+        );
+
+        let restore_plan = reductor.plan_restore(&plan, plan.reduced_schema()).unwrap();
+        let restored = reductor.restore(&restore_plan, &reduced).unwrap();
+        assert_eq!(restored, source_value);
+        assert_eq!(restore_plan.output_schema(), &source_schema);
+        assert!(reductor.fuel_consumed() > 0);
+    }
+
+    #[test]
+    fn wasm_adapter_rejects_claims_that_do_not_match_the_source_schema() {
+        let engine = WasmBinaryReductorEngine::new(&test_reductor_component()).unwrap();
+        let mut reductor = WasmBinaryReductor::start(&engine, BinaryIrLimits::default()).unwrap();
+
+        let error = reductor.plan(&custom_schema()).unwrap_err();
+        assert_eq!(error.code(), codes::WASM_REDUCTOR_CLAIM);
+        assert!(error.message().contains("$.custom"));
+    }
+
+    #[test]
+    fn schema_changes_outside_wasm_claims_are_rejected() {
+        let source = SchemaIr::new(required(SchemaKind::String));
+        let transformed = SchemaIr::new(required(SchemaKind::I64));
+
+        let error = ensure_schema_changes_are_claimed(&source, &transformed, &[]).unwrap_err();
+        assert_eq!(error.code(), codes::WASM_REDUCTOR_PLAN);
+        assert!(error.message().contains('$'));
+    }
+
+    #[test]
+    fn schema_changes_inside_a_wasm_claim_are_allowed() {
+        let source = guest_custom_schema();
+        let transformed = SchemaIr::new(required(SchemaKind::String));
+        let claims = vec![BinaryReductorClaim::new(SchemaPath::root(), "vendor.money")];
+
+        ensure_schema_changes_are_claimed(&source, &transformed, &claims).unwrap();
     }
 }

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod avro;
 pub mod backend;
 pub mod binary_ir;
+pub mod binary_pump;
 pub mod binary_reductor;
 pub mod control;
 pub mod entity;

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -121,6 +121,8 @@ pub struct AppState {
     pub spool_quota: Arc<SpoolQuota>,
     /// Unsafe transformed reads are allowed only with encrypted durable staging.
     pub transformed_read_spool_enabled: bool,
+    /// Enables the opt-in Avro OCF processing path. Disabled by default.
+    pub binary_avro_enabled: bool,
     pub dev_memory_max_object_bytes: usize,
     pub dev_memory_streaming_enabled: bool,
     demo_pipelines: DemoPipelines,
@@ -572,6 +574,11 @@ impl StreamingReadMode {
 fn transformed_read_spool_enabled() -> bool {
     std::env::var("S4_TRANSFORMED_READ_SPOOL")
         .is_ok_and(|value| value.eq_ignore_ascii_case("encrypted"))
+}
+
+fn binary_avro_enabled() -> bool {
+    std::env::var("S4_ENABLE_AVRO")
+        .is_ok_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
 }
 
 /// Imported plugins are unsafe by default. Operators may opt known component
@@ -2802,6 +2809,23 @@ async fn streaming_single_put(
             "Content-Encoding is unsupported for transformed streaming".to_string(),
         ));
     }
+    if is_avro_content_type(headers) {
+        if !state.binary_avro_enabled {
+            return Err(StreamingPutError::Unsupported(
+                "Avro processing is disabled; set S4_ENABLE_AVRO=true".to_string(),
+            ));
+        }
+        return streaming_avro_single_put(
+            state,
+            authentication,
+            backend,
+            authorization,
+            headers,
+            body,
+            key,
+        )
+        .await;
+    }
     let (format, content_type) = streaming_format(headers)?;
     let sink = begin_streaming_sink(
         state,
@@ -2956,6 +2980,153 @@ async fn streaming_single_put(
             }
         }
     }
+}
+
+fn avro_media_type(content_type: &str) -> Option<String> {
+    let media_type = content_type
+        .split(';')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    matches!(
+        media_type.as_str(),
+        "application/avro" | "application/x-avro" | "application/vnd.apache.avro+binary"
+    )
+    .then_some(media_type)
+}
+
+fn is_avro_content_type(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(avro_media_type)
+        .is_some()
+}
+
+fn avro_pump(
+    auth: &Auth,
+    headers: &HeaderMap,
+    limits: crate::avro::AvroLimits,
+) -> Result<
+    crate::binary_pump::BinaryPump<
+        crate::binary_reductor::CommonTypeBinaryReductor,
+        crate::binary_pump::EnvelopeBinaryTransform,
+    >,
+    s4_error::S4Error,
+> {
+    let targets = headers
+        .get("x-s4-encrypt-fields")
+        .map(|value| {
+            value
+                .to_str()
+                .map_err(|_| {
+                    s4_error::S4Error::new(
+                        s4_error::codes::CONFIG_INVALID,
+                        "invalid x-s4-encrypt-fields",
+                    )
+                })
+                .and_then(crate::binary_pump::parse_envelope_targets)
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let transform =
+        crate::binary_pump::EnvelopeBinaryTransform::new(targets, auth.public_key_pem.as_deref())?;
+    Ok(crate::binary_pump::BinaryPump::new(
+        crate::binary_reductor::CommonTypeBinaryReductor::default(),
+        transform,
+        limits.ir,
+    ))
+}
+
+async fn streaming_avro_single_put(
+    state: &AppState,
+    mut authentication: HeaderAuthentication,
+    backend: ResolvedBackend,
+    authorization: &UsageAuthorization,
+    headers: &HeaderMap,
+    mut body: axum::body::Body,
+    key: &str,
+) -> Result<(Auth, StoredObjectMeta, u64, u64), StreamingPutError> {
+    use http_body_util::BodyExt as _;
+    use sha2::Digest as _;
+
+    let content_type = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| StreamingPutError::InvalidRequest("Content-Type is required".to_string()))?
+        .split(';')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    let mut input = Vec::new();
+    let mut input_bytes = 0_u64;
+    while let Some(frame) = body
+        .frame()
+        .await
+        .transpose()
+        .map_err(|_| StreamingPutError::Transport)?
+    {
+        let data = frame
+            .into_data()
+            .map_err(|_| StreamingPutError::Transport)?;
+        if data.len() > state.source_body_limits.max_frame_bytes {
+            return Err(StreamingPutError::SourceFrameTooLarge);
+        }
+        let decoded = if let Some(verifier) = &mut authentication.body_verifier {
+            verifier.push(&data).map_err(StreamingPutError::Integrity)?
+        } else {
+            vec![data]
+        };
+        for chunk in decoded {
+            input_bytes = input_bytes
+                .checked_add(chunk.len() as u64)
+                .ok_or(StreamingPutError::InputTooLarge)?;
+            if input_bytes > state.source_body_limits.max_bytes {
+                return Err(StreamingPutError::InputTooLarge);
+            }
+            input.extend_from_slice(&chunk);
+        }
+    }
+    if let Some(verifier) = authentication.body_verifier.take() {
+        let verified = verifier.finish().map_err(StreamingPutError::Integrity)?;
+        if verified != input_bytes {
+            return Err(StreamingPutError::Integrity(
+                IntegrityError::DecodedLengthMismatch,
+            ));
+        }
+    }
+
+    let limits = crate::avro::AvroLimits {
+        max_source_bytes: state.source_body_limits.max_bytes.min(64 * 1024 * 1024) as usize,
+        ..crate::avro::AvroLimits::default()
+    };
+    let mut pump = avro_pump(&authentication.auth, headers, limits)?;
+    let output = crate::avro::process_ocf(input.as_slice(), limits, &mut pump)?;
+    let output_bytes = u64::try_from(output.len()).map_err(|_| StreamingPutError::InputTooLarge)?;
+    let sink = begin_streaming_sink(
+        state,
+        backend,
+        AuthorizedOperation {
+            auth: &authentication.auth,
+            authorization,
+        },
+        authorization.bucket(),
+        key,
+        &content_type,
+    )
+    .await?;
+    let mut sink_guard = SinkAbortGuard::new(sink);
+    let digest = hex::encode(sha2::Sha256::digest(&output));
+    let stored = {
+        let mut sink = sink_guard.sink.lock().await;
+        sink.write(bytes::Bytes::from(output)).await?;
+        sink.verify_output(output_bytes, &digest).await?;
+        sink.complete().await?
+    };
+    sink_guard.disarm();
+    Ok((authentication.auth, stored, input_bytes, output_bytes))
 }
 
 #[derive(Debug)]
@@ -3454,6 +3625,26 @@ async fn complete_staged_multipart(
         .ok_or_else(|| {
             MultipartCompletionError::Invalid("multipart Content-Type is missing".to_string())
         })?;
+    if let Some(avro_media) = avro_media_type(content_type) {
+        if !state.binary_avro_enabled {
+            return Err(MultipartCompletionError::Streaming(
+                StreamingPutError::Unsupported(
+                    "Avro processing is disabled; set S4_ENABLE_AVRO=true".to_string(),
+                ),
+            ));
+        }
+        return complete_staged_avro_multipart(
+            state,
+            staging,
+            identity,
+            upload,
+            lease,
+            operation,
+            backend,
+            &avro_media,
+        )
+        .await;
+    }
     let (format, content_type) = streaming_format_content_type(content_type)?;
     renew_and_fence_completion(staging, identity, lease).await?;
     let mut sink = begin_streaming_sink(
@@ -3792,6 +3983,118 @@ fn recovered_multipart_result(
         source_bytes,
         size_bytes,
     })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn complete_staged_avro_multipart(
+    state: &AppState,
+    staging: &MultipartStaging,
+    identity: &MultipartIdentity,
+    upload: &MultipartUpload,
+    lease: &CompletionLease,
+    operation: AuthorizedOperation<'_>,
+    backend: ResolvedBackend,
+    content_type: &str,
+) -> Result<MultipartCompletionResult, MultipartCompletionError> {
+    use sha2::Digest as _;
+
+    let max_source_bytes = state.source_body_limits.max_bytes.min(64 * 1024 * 1024) as usize;
+    let mut input = Vec::new();
+    let mut input_bytes = 0_u64;
+    for part in &lease.selected_parts {
+        renew_and_fence_completion(staging, identity, lease).await?;
+        let body = staging.artifacts.get(&part.artifact_key).await?;
+        renew_and_fence_completion(staging, identity, lease).await?;
+        let mut reader = EncryptedPartReader::open(
+            body.into_async_read(),
+            identity,
+            part,
+            &upload.snapshot,
+            staging.wrapping.clone(),
+        )
+        .await?;
+        let mut part_bytes = 0_u64;
+        let mut part_sha256 = sha2::Sha256::new();
+        let mut part_md5 = Md5::new();
+        loop {
+            renew_and_fence_completion(staging, identity, lease).await?;
+            let Some(chunk) = reader.next_chunk().await? else {
+                break;
+            };
+            part_bytes = part_bytes.checked_add(chunk.len() as u64).ok_or_else(|| {
+                MultipartCompletionError::Invalid("multipart part is too large".to_string())
+            })?;
+            input_bytes = input_bytes.checked_add(chunk.len() as u64).ok_or_else(|| {
+                MultipartCompletionError::Invalid("multipart input is too large".to_string())
+            })?;
+            if part_bytes > part.size_bytes || input_bytes as usize > max_source_bytes {
+                return Err(MultipartCompletionError::Invalid(
+                    "multipart input exceeds its limit".to_string(),
+                ));
+            }
+            part_sha256.update(&chunk);
+            part_md5.update(&chunk);
+            input.extend_from_slice(&chunk);
+        }
+        if part_bytes != part.size_bytes
+            || hex::encode(part_sha256.finalize()) != part.checksum_sha256
+            || format!("\"{}\"", hex::encode(part_md5.finalize())) != part.etag
+        {
+            return Err(MultipartCompletionError::Invalid(
+                "staged multipart artifact does not match its committed part".to_string(),
+            ));
+        }
+    }
+    let limits = crate::avro::AvroLimits {
+        max_source_bytes,
+        ..crate::avro::AvroLimits::default()
+    };
+    let headers = HeaderMap::new();
+    let mut pump = avro_pump(operation.auth, &headers, limits)?;
+    let output = crate::avro::process_ocf(input.as_slice(), limits, &mut pump)?;
+    let output_bytes = u64::try_from(output.len())
+        .map_err(|_| MultipartCompletionError::Invalid("Avro output is too large".to_string()))?;
+    let output_digest = hex::encode(sha2::Sha256::digest(&output));
+
+    let mut sink = begin_streaming_sink(
+        state,
+        backend,
+        operation,
+        &identity.bucket,
+        &identity.key,
+        content_type,
+    )
+    .await?;
+    let result = async {
+        renew_and_fence_completion(staging, identity, lease).await?;
+        sink.write(bytes::Bytes::from(output)).await?;
+        sink.verify_output(output_bytes, &output_digest).await?;
+        renew_and_fence_completion(staging, identity, lease).await?;
+        let stored = sink.complete().await?;
+        let result = MultipartCompletionResult {
+            etag: stored.etag,
+            checksum_sha256: output_digest,
+            version_id: stored.version_id,
+            source_bytes: input_bytes,
+            size_bytes: output_bytes,
+        };
+        renew_and_fence_completion(staging, identity, lease).await?;
+        staging
+            .repository
+            .complete_completion(identity, lease.fencing_token, result.clone(), now_ms())
+            .await?;
+        Ok(result)
+    }
+    .await;
+
+    if result.is_err()
+        && renew_and_fence_completion(staging, identity, lease)
+            .await
+            .is_ok()
+    {
+        let _ = sink.abort().await;
+    }
+    result
 }
 
 async fn reconcile_staged_artifacts(staging: &MultipartStaging) -> Result<(), StagingError> {
@@ -4341,6 +4644,34 @@ fn transformed_response_headers(
     headers
 }
 
+fn avro_read_preflight(
+    headers: &HeaderMap,
+    params: &S3Query,
+    metadata: &ObjectMetadata,
+) -> Option<TransformedReadError> {
+    if headers.contains_key(header::RANGE) {
+        return Some(TransformedReadError::InvalidRequest(
+            "Range is not supported for transformed reads".to_string(),
+        ));
+    }
+    if params.part_number.is_some() {
+        return Some(TransformedReadError::InvalidRequest(
+            "part-number reads are not supported for transformed reads".to_string(),
+        ));
+    }
+    if let Some(encoding) = metadata.headers.get(header::CONTENT_ENCODING)
+        && !encoding
+            .to_str()
+            .map(|value| value.eq_ignore_ascii_case("identity"))
+            .unwrap_or(false)
+    {
+        return Some(TransformedReadError::InvalidRequest(
+            "Content-Encoding is unsupported for transformed reads".to_string(),
+        ));
+    }
+    None
+}
+
 fn transformed_read_preflight(
     headers: &HeaderMap,
     params: &S3Query,
@@ -4501,6 +4832,118 @@ fn transformed_session(
             .and_then(|value| value.to_str().ok())
             .map(ToOwned::to_owned),
     }
+}
+
+async fn collect_opened_object(
+    object: &mut OpenedObject,
+    max_bytes: usize,
+) -> Result<Vec<u8>, TransformedReadError> {
+    let mut output = Vec::new();
+    while let Some(frame) = object.body.frame().await {
+        let frame = frame.map_err(|error| TransformedReadError::Source(error.to_string()))?;
+        let data = frame.into_data().map_err(|frame| {
+            if frame.into_trailers().is_ok() {
+                TransformedReadError::Source(
+                    "source trailers are not valid for transformed reads".to_string(),
+                )
+            } else {
+                TransformedReadError::Source("source returned a non-data frame".to_string())
+            }
+        })?;
+        if output.len().saturating_add(data.len()) > max_bytes {
+            object.cancellation.cancel();
+            return Err(TransformedReadError::Source(
+                "Avro source exceeds the configured byte limit".to_string(),
+            ));
+        }
+        output.extend_from_slice(&data);
+    }
+    Ok(output)
+}
+
+async fn serve_spooled_bytes(
+    state: &AppState,
+    bytes: Vec<u8>,
+    source_cancellation: s4_wasm_runtime::CancellationToken,
+) -> Result<(axum::body::Body, u64), TransformedReadError> {
+    let mut spool = EncryptedReadSpool::begin(
+        state.spool_config.directory.clone(),
+        state.spool_config.max_object_bytes,
+        Arc::clone(&state.spool_quota),
+    )
+    .await?;
+    if let Err(error) = spool.write(bytes::Bytes::from(bytes)).await {
+        spool.abort().await;
+        return Err(TransformedReadError::from(error));
+    }
+    spool
+        .into_body(source_cancellation)
+        .await
+        .map_err(TransformedReadError::from)
+}
+
+async fn avro_transformed_read_response(
+    state: &AppState,
+    auth: &Auth,
+    headers: &HeaderMap,
+    response_metadata: ObjectMetadata,
+    mut object: OpenedObject,
+    key: &str,
+) -> (axum::response::Response, Option<u64>) {
+    if !state.transformed_read_spool_enabled {
+        object.cancellation.cancel();
+        return (
+            transformed_read_error_response(
+                key,
+                TransformedReadError::Capacity(
+                    "unsafe transformed reads require S4_TRANSFORMED_READ_SPOOL=encrypted"
+                        .to_string(),
+                ),
+            ),
+            None,
+        );
+    }
+    let max_source_bytes = state.source_body_limits.max_bytes.min(64 * 1024 * 1024) as usize;
+    let source = match collect_opened_object(&mut object, max_source_bytes).await {
+        Ok(source) => source,
+        Err(error) => return (transformed_read_error_response(key, error), None),
+    };
+    let limits = crate::avro::AvroLimits {
+        max_source_bytes,
+        ..crate::avro::AvroLimits::default()
+    };
+    let mut pump = match avro_pump(auth, headers, limits) {
+        Ok(pump) => pump,
+        Err(error) => {
+            return (
+                transformed_read_error_response(key, TransformedReadError::Pipeline(error)),
+                None,
+            );
+        }
+    };
+    let output = match crate::avro::process_ocf(source.as_slice(), limits, &mut pump) {
+        Ok(output) => output,
+        Err(error) => {
+            return (
+                transformed_read_error_response(key, TransformedReadError::Pipeline(error)),
+                None,
+            );
+        }
+    };
+    let (body, content_length) =
+        match serve_spooled_bytes(state, output, object.cancellation.clone()).await {
+            Ok(result) => result,
+            Err(error) => return (transformed_read_error_response(key, error), None),
+        };
+    let mut response = axum::response::Response::builder().status(StatusCode::OK);
+    response
+        .headers_mut()
+        .unwrap()
+        .extend(transformed_response_headers(
+            &response_metadata,
+            Some(content_length),
+        ));
+    (response.body(body).unwrap(), Some(object.counters.bytes()))
 }
 
 async fn process_transformed_source<F, Fut>(
@@ -4982,6 +5425,47 @@ async fn s3_get(
                 .await;
             }
         };
+        if is_avro_content_type(&metadata.headers) {
+            if let Some(error) = avro_read_preflight(&headers, &params, &metadata) {
+                return transformed_read_error_response(&key, error);
+            }
+            if !state.binary_avro_enabled {
+                return transformed_read_error_response(
+                    &key,
+                    TransformedReadError::InvalidRequest(
+                        "Avro processing is disabled; set S4_ENABLE_AVRO=true".to_string(),
+                    ),
+                );
+            }
+            let object =
+                match open_backend_object(&state, backend, &auth, &bucket, &key, &headers, false)
+                    .await
+                {
+                    Ok(object) => object,
+                    Err(error) => return open_error_response(&key, error),
+                };
+            let source_bytes = content_length(&object.metadata.headers);
+            let response_metadata = object.metadata.clone();
+            let (response, completed_source_bytes) = avro_transformed_read_response(
+                &state,
+                &auth,
+                &headers,
+                response_metadata,
+                object,
+                &key,
+            )
+            .await;
+            return metered_read_response(
+                state.control.clone(),
+                &auth,
+                operation,
+                &authorization,
+                &key,
+                source_bytes.or(completed_source_bytes),
+                response,
+            )
+            .await;
+        }
         let preflight = match transformed_read_preflight(&headers, &params, &metadata) {
             Ok(preflight) => preflight,
             Err(error) => {
@@ -5143,6 +5627,22 @@ mod tests {
     use http_body::{Frame, SizeHint};
 
     use super::*;
+
+    #[test]
+    fn avro_content_types_are_distinguished_from_text_formats() {
+        for content_type in [
+            "application/avro",
+            "application/x-avro; charset=binary",
+            "application/vnd.apache.avro+binary",
+        ] {
+            let mut headers = HeaderMap::new();
+            headers.insert(header::CONTENT_TYPE, content_type.parse().unwrap());
+            assert!(is_avro_content_type(&headers));
+        }
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_TYPE, "application/json".parse().unwrap());
+        assert!(!is_avro_content_type(&headers));
+    }
 
     #[derive(Debug, Clone, Eq, PartialEq)]
     struct UsageCall {
@@ -8406,6 +8906,7 @@ pub async fn build_state(
         spool_config,
         spool_quota,
         transformed_read_spool_enabled: transformed_read_spool_enabled(),
+        binary_avro_enabled: binary_avro_enabled(),
         dev_memory_max_object_bytes,
         dev_memory_streaming_enabled,
         demo_pipelines,

--- a/docs/avro.md
+++ b/docs/avro.md
@@ -1,0 +1,84 @@
+# Avro OCF support
+
+Avro Object Container File processing is a typed binary format, intentionally
+separate from JSON/CSV text processing: an Avro writer must know the complete
+output schema before it emits the first object.
+
+## Enablement
+
+Avro processing is off by default. Operators enable it with
+`S4_ENABLE_AVRO=true`. Disabled requests are rejected before the request body is
+polled. Raw GET, HEAD, and Range passthrough for stored Avro objects do not
+require the gate; only processing (PUT, processed GET, staged multipart
+completion) does.
+
+## Supported codec subset
+
+The codec accepts:
+
+- OCF records with `null`, `boolean`, `int`, `long`, `float`, `double`, `bytes`,
+  and `string` values.
+- Records, arrays, maps with string keys, and exactly nullable unions of the
+  form `["null", T]`.
+- Logical `date`, `time-millis`, `time-micros`, `timestamp-millis`,
+  `timestamp-micros`, `timestamp-nanos`, `uuid`, and `decimal` values.
+- Nested combinations of those types, subject to S4 Schema/Value IR limits.
+
+It rejects recursive/named references, arbitrary unions, enums, and fixed
+values. Input OCF blocks may use `null`, `deflate`, `snappy`, or `zstandard`;
+generated output uses Zstandard with normalized metadata. Source input is capped
+before the Avro library reads it, and every emitted value is validated against
+the bounded S4 IR schema.
+
+## Processing model
+
+Each processed object follows this order:
+
+```text
+Avro OCF -> Schema/Value IR -> BinaryReductor -> BinaryTransform
+         -> BinaryReductor restore -> validated Schema/Value IR -> Avro OCF
+```
+
+Text `s4:filter` plugins are not inserted in this flow. They receive opaque
+bytes and cannot declare an output schema.
+
+## Envelope encryption
+
+`x-s4-encrypt-fields` selects comma-separated string schema paths, for example
+`email` or `contacts[*].email`. With an authenticated public key, selected
+fields become `RSA-OAEP/AES-256-GCM` envelope records and the Avro schema is
+evolved before encoding. Without a public key, selected fields are redacted to
+`[REDACTED]` while the string schema is preserved. Overlapping or invalid paths
+are rejected. Multipart completion uses identity processing; field selection
+applies to single PUT and processed GET.
+
+## Multipart and processed reads
+
+Staged multipart completion concatenates the encrypted parts into one OCF source
+and runs it through the same processor rather than treating parts as independent
+streams. A processed read (`x-s4-process: read`) runs the source through the
+typed pump and stages the complete output in the existing encrypted read spool
+before disclosure. Processed read failures never disclose raw source bytes.
+
+## Verify codec work
+
+```bash
+cargo test -p s4-gateway avro::tests
+cargo test -p s4-gateway binary_pump::tests
+```
+
+The suite covers OCF schema/value round trips, nullable/container records,
+logical values, decimal precision/scale, source-size boundaries, transport
+chunk invariance, unsupported schemas, and processing through a typed
+transform.
+
+## Hive-compatible layouts
+
+S4 treats a Hive partition path as an ordinary object key. For example:
+
+```text
+warehouse/customers/day=2026-08-30/part-000.avro
+```
+
+The Avro schema remains in the OCF header. S4 does not provide a Hive Metastore,
+table DDL, SQL query engine, or ORC support.

--- a/docs/binary-adapters.md
+++ b/docs/binary-adapters.md
@@ -1,0 +1,120 @@
+# Binary adapters
+
+Typed binary formats such as Avro and Parquet do not pass through the
+byte-oriented `s4:filter` plugin pipeline. A binary encoder needs its complete
+output schema before it writes the first record. Use a binary reductor when a
+format-specific logical type must be converted to an S4-supported type before a
+typed transform, then reconstructed for output.
+
+The contract is `s4:binary-reductor@0.1.0` in
+[`wit/s4-binary-reductor/world.wit`](../wit/s4-binary-reductor/world.wit).
+
+## Lifecycle
+
+For one object, the host calls the component in this order:
+
+1. `plan(source-schema-ir)` returns a reduced schema, owned claims, and an opaque
+   reduction plan.
+2. `reduce(plan, source-value-ir)` runs once per source value.
+3. The host applies schema-aware binary transforms to reduced values.
+4. `plan-restore(source-schema-ir, transformed-reduced-schema-ir, plan)` returns
+   the final output schema and an opaque restoration plan.
+5. `restore(restore-plan, transformed-value-ir)` runs once per retained value.
+
+The component only owns paths it claims. The gateway verifies that claims point
+to a custom logical value or declared record, and rejects a schema mutation
+outside a claim. Plans are bound to the SHA-256 digest of the exact component;
+do not reuse plans across component versions.
+
+## Canonical IR
+
+Schema and value inputs are canonical JSON representations of the bounded S4
+IR. The definitive Rust types and validators are in
+[`crates/gateway/src/binary_ir.rs`](../crates/gateway/src/binary_ir.rs).
+
+- A nullable Avro-like field is represented by `"nullable": true`, not an
+  arbitrary union.
+- Custom logical values use `{"type":"custom","type_id":"...","value":...}`.
+- Map keys are UTF-8 strings and map entries are canonicalized by key.
+- The gateway validates every returned schema and value before it reaches an
+  encoder. Invalid or unsupported data must return `reductor-error`, never a
+  best-effort result.
+
+The test fixture in
+[`filters/test-binary-reductor/src/lib.rs`](../filters/test-binary-reductor/src/lib.rs)
+is the smallest complete example. It reduces `vendor.money` from a custom value
+to a string and restores it after the typed transform.
+
+## Write an adapter
+
+Create a `cdylib` crate that uses the workspace-compatible `wit-bindgen` release:
+
+```toml
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = "0.60"
+```
+
+Generate bindings and implement the exported `Guest` trait:
+
+```rust
+wit_bindgen::generate!({
+    world: "binary-reductor",
+    path: "path/to/S4/wit/s4-binary-reductor/world.wit",
+});
+
+struct MyReductor;
+
+impl Guest for MyReductor {
+    // Implement plan, reduce, plan_restore, and restore.
+}
+
+export!(MyReductor);
+```
+
+Build a bare component. Binary reductors receive no WASI and no other host
+imports, so do not use the WASI adapter used by text plugins:
+
+```bash
+cargo build --release --target wasm32-unknown-unknown
+wasm-tools component new target/wasm32-unknown-unknown/release/my_reductor.wasm \
+  -o my-reductor.component.wasm
+```
+
+## Required behavior
+
+- Keep every returned IR, plan, claim, identifier, and diagnostic within the
+  host limits. The host rejects oversized output.
+- Claim each custom logical subtree that the component changes. Claims may not
+  overlap or prefix one another.
+- Treat `plan` and `plan-restore` output as immutable. Preserve all state needed
+  later in opaque plan bytes.
+- Return stable error codes and bounded diagnostics. Never include plaintext,
+  keys, or full source records in diagnostics.
+- Do not depend on filesystem, network, clocks, environment variables, or host
+  imports. The binary-reductor sandbox intentionally provides none.
+
+## Test locally
+
+From an S4 checkout:
+
+```bash
+bash scripts/build-filters.sh
+cargo test -p s4-wasm-runtime binary_reductor
+cargo test -p s4-gateway binary_reductor::tests
+```
+
+Add conformance vectors beside the fixture for each new logical type. Cover
+round trips, invalid claims, invalid plan bytes, malformed IR, fuel exhaustion,
+deadlines, cancellation, and component-digest changes before connecting an
+adapter to a codec.
+
+## Current integration boundary
+
+The Wasm runtime and gateway adapter are available to codec code. Runtime
+component selection for binary formats is intentionally separate from dashboard
+text-plugin upload: a byte filter cannot safely become a binary adapter merely
+by changing its file extension. A codec integration must explicitly select and
+pin its binary-reductor component.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 # S4 Plugins — create and consume your own
 
-Plugins are how S4 transforms data. A plugin is a WebAssembly component that receives
+Plugins are how S4 transforms text data. A plugin is a WebAssembly component that receives
 each object's payload, optionally transforms it, and returns a decision. Plugins run in
 a pipeline — the output of one is the input of the next — so you compose transforms:
 filter, then encrypt, then convert.
@@ -104,6 +104,10 @@ The default local setup preloads `pii-default` via `S4_FILTER_COMPONENT`.
 
 - Plugins are pure byte-in/byte-out. The gateway handles transport (S3 API), auth, and
   storage.
+- Plugins do not declare an output schema, so they cannot be used directly for Avro,
+  Parquet, or another typed binary format. Binary codecs use schema-aware transforms and
+  optional `s4:binary-reductor` components instead; see
+  [Binary adapters](binary-adapters.md).
 - Filters shipped in-tree: `noop` (pass-through baseline), `pii-default`,
   `email-detect`, `ssn-detect`, `card-detect`, `envelope-encrypt`, `stable-encrypt`.
 - The original WIT design is recorded in `docs/adr/0001-component-model-wit.md`.

--- a/examples/avro-demo.py
+++ b/examples/avro-demo.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Avro OCF round-trip demo: PUT, raw read, and redacted processed read.
+
+Start a local gateway with binary processing enabled and local auth:
+
+    AUTH_DISABLED=true S4_ENABLE_AVRO=true S4_TRANSFORMED_READ_SPOOL=encrypted \
+        cargo run --bin s4-gateway
+
+The gateway prints ``S4_ACCESS_KEY`` / ``S4_SECRET_KEY`` at startup. Export them
+and run this script:
+
+    export S4_ACCESS_KEY=... S4_SECRET_KEY=...
+    pip install requests fastavro
+    python examples/avro-demo.py
+
+The script uploads a small Avro OCF with ``application/avro``, reads the stored
+object back (which is a normalized OCF), and reads it again through the typed
+processor with ``x-s4-encrypt-fields: email`` and no bound public key, which
+redacts the selected string field.
+"""
+
+import io
+import os
+
+import requests
+from fastavro import reader, writer
+
+GATEWAY = os.environ.get("S4_GATEWAY_URL", "http://127.0.0.1:8080")
+ACCESS = os.environ["S4_ACCESS_KEY"]
+SECRET = os.environ["S4_SECRET_KEY"]
+BUCKET = "avro-demo"
+KEY = "customers/day=2026-08-30/part-000.avro"
+
+SCHEMA = {
+    "type": "record",
+    "name": "Customer",
+    "namespace": "s4.example",
+    "fields": [
+        {"name": "id", "type": "long"},
+        {"name": "email", "type": ["null", "string"]},
+    ],
+}
+RECORDS = [
+    {"id": 1, "email": "ada@example.com"},
+    {"id": 2, "email": None},
+]
+
+
+def auth() -> dict:
+    return {"x-s4-access-key": ACCESS, "x-s4-secret-key": SECRET}
+
+
+def encode_ocf(records: list) -> bytes:
+    buffer = io.BytesIO()
+    writer(buffer, SCHEMA, records, codec="null")
+    return buffer.getvalue()
+
+
+def decode_ocf(payload: bytes) -> list:
+    return list(reader(io.BytesIO(payload)))
+
+
+def main() -> None:
+    put = requests.put(
+        f"{GATEWAY}/{BUCKET}/{KEY}",
+        headers={**auth(), "Content-Type": "application/avro"},
+        data=encode_ocf(RECORDS),
+        timeout=60,
+    )
+    put.raise_for_status()
+    print("stored Avro OCF (PUT processed)")
+
+    raw = requests.get(f"{GATEWAY}/{BUCKET}/{KEY}", headers=auth(), timeout=60)
+    raw.raise_for_status()
+    assert raw.content[:4] == b"Obj\x01", "stored object is not an Avro OCF"
+    assert decode_ocf(raw.content) == RECORDS, "raw read must preserve records"
+    print("raw GET preserves records")
+
+    processed = requests.get(
+        f"{GATEWAY}/{BUCKET}/{KEY}",
+        headers={
+            **auth(),
+            "x-s4-process": "read",
+            "x-s4-encrypt-fields": "email",
+        },
+        timeout=60,
+    )
+    processed.raise_for_status()
+    redacted = decode_ocf(processed.content)
+    assert redacted[0]["email"] == "[REDACTED]", "email must be redacted"
+    assert redacted[1]["email"] is None, "null email must stay null"
+    print("processed GET redacts the selected field without leaking plaintext")
+
+    print("PASS: Avro PUT, raw read, and redacted processed read round trip")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds opt-in Avro OCF processing through the S3 data plane, behind the existing disabled `avro` gate (`S4_ENABLE_AVRO=true`).

- Typed Avro OCF codec (`crates/gateway/src/avro.rs`): bounded decode/encode with schema/value IR conversion for primitives, records, arrays, maps, nullable unions, and date/time/timestamp/uuid/decimal logical types; null/deflate/snappy/zstandard input, zstandard output, source-size cap.
- Typed transform pump (`crates/gateway/src/binary_pump.rs`): schema-first transforms plus RSA-OAEP/AES-256-GCM envelope encryption with explicit `x-s4-encrypt-fields` path selection and redaction fallback.
- Gated single PUT, staged multipart completion, and processed reads through the typed pump and encrypted read spool (`server.rs`).
- Docs (`docs/avro.md`, `docs/binary-adapters.md`) and a runnable fastavro example (`examples/avro-demo.py`).

Text formats and raw reads keep their existing wire behavior. Avro is disabled by default.