### PR TITLE
docs: publish Avro support status

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ Typed binary codecs use a separate schema-aware reductor contract, not the
 byte-oriented plugin pipeline. See [docs/binary-adapters.md](docs/binary-adapters.md)
 when adding a custom logical-type adapter.
 
-The in-progress Avro OCF boundary and its supported subset are documented in
-[docs/avro.md](docs/avro.md).
+Opt-in Avro OCF processing (`S4_ENABLE_AVRO=true`) and its supported subset are
+documented in [docs/avro.md](docs/avro.md). A runnable PUT/read example is in
+[examples/avro-demo.py](examples/avro-demo.py).
 
 ## Usage examples
 


### PR DESCRIPTION
Update the README to describe merged, opt-in Avro OCF support instead of calling it in progress, and link the runnable Avro demo.\n\nThe branch is based on current main after PR #59; the prior local main pointer was safely fast-forwarded because it had no unpublished commits.