### PR TITLE
feat(mcp): publish verified stdio object server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,12 +48,20 @@ jobs:
       - name: Test workspace
         run: cargo test --workspace
 
-      - name: Build gateway release (${{ matrix.suffix }})
+      - name: Build gateway and MCP releases (${{ matrix.suffix }})
         run: |
           mkdir -p dist/components
-          cargo build --release -p s4-gateway
+          cargo build --release -p s4-gateway -p s4-mcp
           cp target/release/s4-gateway dist/s4-gateway
+          cp target/release/s4-mcp dist/s4-mcp-linux-${{ matrix.suffix }}
           cp -r target/components/. dist/components/
+
+      - name: Upload MCP binary (${{ matrix.suffix }})
+        uses: actions/upload-artifact@v4
+        with:
+          name: s4-mcp-${{ matrix.suffix }}
+          path: dist/s4-mcp-linux-${{ matrix.suffix }}
+          if-no-files-found: error
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -92,6 +100,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download MCP binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: s4-mcp-*
+          path: dist
+          merge-multiple: true
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -157,8 +172,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ github.ref_name }}" \
-            dist/s4-gateway-linux-x86_64 \
-            dist/s4-filters.tar.gz \
+             dist/s4-gateway-linux-x86_64 \
+             dist/s4-mcp-linux-amd64 \
+             dist/s4-mcp-linux-arm64 \
+             dist/s4-filters.tar.gz \
             dist/s4-python-sdk.tar.gz \
             dist/s4-typescript-sdk.tar.gz \
             --repo "${{ github.repository }}" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,6 +1856,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,7 +1960,7 @@ name = "envelope-encrypt"
 version = "0.3.5"
 dependencies = [
  "aes-gcm",
- "base64",
+ "base64 0.22.1",
  "pii-shared",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -2124,6 +2136,7 @@ checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -2641,7 +2654,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2927,7 +2940,7 @@ version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -3456,12 +3469,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3760,6 +3779,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3997,6 +4026,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4061,7 +4110,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4153,6 +4202,42 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rmcp"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
+dependencies = [
+ "base64 0.23.1",
+ "chrono",
+ "futures",
+ "indexmap",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4400,7 +4485,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc",
@@ -4445,6 +4530,26 @@ dependencies = [
  "x509-parser",
  "xmlparser",
  "zeroize",
+]
+
+[[package]]
+name = "s4-mcp"
+version = "0.3.5"
+dependencies = [
+ "anyhow",
+ "axum",
+ "futures-util",
+ "http-body-util",
+ "quick-xml",
+ "reqwest",
+ "rmcp",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -4503,6 +4608,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4697,6 +4828,17 @@ name = "serde_derive"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4948,7 +5090,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "bytes",
  "chrono",
@@ -5028,7 +5170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "bitflags",
  "byteorder",
@@ -5075,7 +5217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "bitflags",
  "byteorder",
@@ -5151,7 +5293,7 @@ name = "stable-encrypt"
 version = "0.3.5"
 dependencies = [
  "aes-siv",
- "base64",
+ "base64 0.22.1",
  "serde_json",
  "wit-bindgen 0.60.0",
 ]
@@ -5831,7 +5973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
  "axum",
- "base64",
+ "base64 0.22.1",
  "mime_guess",
  "regex",
  "rust-embed",
@@ -6193,7 +6335,7 @@ version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65db2eb1bfc5371a3b4107dbf539d0b93d05016fc29625b1648146b47db02071"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "directories-next",
  "log",
  "postcard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "crates/policy",
   "crates/wasm-runtime",
   "crates/gateway",
+  "crates/s4-mcp",
   "crates/s4ctl",
   "filters/pii-default",
   "filters/pii-shared",

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Opt-in Avro OCF processing (`S4_ENABLE_AVRO=true`) and its supported subset are
 documented in [docs/avro.md](docs/avro.md). A runnable PUT/read example is in
 [examples/avro-demo.py](examples/avro-demo.py).
 
+The local stdio MCP server exposes put, get, list, and delete tools to agent
+clients while preserving the gateway's normal auth, pipeline, and metering path.
+See [docs/mcp.md](docs/mcp.md).
+
 ## Usage examples
 
 Everything below is copy-paste runnable.

--- a/crates/s4-mcp/Cargo.toml
+++ b/crates/s4-mcp/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "s4-mcp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Local stdio MCP server for the S4 object-processing gateway"
+publish = false
+
+[[bin]]
+name = "s4-mcp"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+futures-util = "0.3"
+quick-xml = { version = "0.38", features = ["serialize"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+rmcp = { version = "3.1", features = ["server", "macros", "schemars", "transport-io"] }
+schemars = "1"
+serde.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+url = "2"
+
+[dev-dependencies]
+axum.workspace = true
+http-body-util = "0.1"
+serde_json.workspace = true

--- a/crates/s4-mcp/src/main.rs
+++ b/crates/s4-mcp/src/main.rs
@@ -1,0 +1,685 @@
+//! Local stdio MCP server for S4.
+//!
+//! Each tool call uses the gateway's S3-compatible HTTP surface, preserving the
+//! same authentication, processing, storage, and metering path as native S3
+//! traffic.
+
+use std::{env, fmt};
+
+use futures_util::StreamExt;
+use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, ContentBlock};
+use rmcp::schemars::JsonSchema;
+use rmcp::tool;
+use rmcp::transport::stdio;
+use rmcp::{ErrorData as McpError, ServiceExt, tool_router};
+use serde::Deserialize;
+use url::Url;
+
+const DEFAULT_GATEWAY_URL: &str = "http://localhost:8080";
+const ENV_GATEWAY_URL: &str = "S4_GATEWAY_URL";
+const ENV_MCP_TOKEN: &str = "S4_MCP_TOKEN";
+const ENV_ACCESS_KEY: &str = "S4_ACCESS_KEY";
+const ENV_SECRET_KEY: &str = "S4_SECRET_KEY";
+const MAX_TEXT_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+const MAX_ERROR_RESPONSE_BYTES: usize = 64 * 1024;
+
+#[derive(Clone)]
+enum GatewayAuth {
+    McpToken(HeaderValue),
+    ApiKey {
+        access_key: HeaderValue,
+        secret_key: HeaderValue,
+    },
+}
+
+impl fmt::Debug for GatewayAuth {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::McpToken(_) => formatter.write_str("McpToken([REDACTED])"),
+            Self::ApiKey { .. } => formatter.write_str("ApiKey([REDACTED])"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Config {
+    gateway_url: Url,
+    auth: GatewayAuth,
+}
+
+impl Config {
+    fn from_env() -> anyhow::Result<Self> {
+        let gateway_url =
+            env::var(ENV_GATEWAY_URL).unwrap_or_else(|_| DEFAULT_GATEWAY_URL.to_string());
+        let mcp_token = env::var(ENV_MCP_TOKEN)
+            .ok()
+            .filter(|value| !value.is_empty());
+        let access_key = env::var(ENV_ACCESS_KEY)
+            .ok()
+            .filter(|value| !value.is_empty());
+        let secret_key = env::var(ENV_SECRET_KEY)
+            .ok()
+            .filter(|value| !value.is_empty());
+        Self::new(&gateway_url, mcp_token, access_key, secret_key)
+    }
+
+    fn new(
+        gateway_url: &str,
+        mcp_token: Option<String>,
+        access_key: Option<String>,
+        secret_key: Option<String>,
+    ) -> anyhow::Result<Self> {
+        let gateway_url = Url::parse(gateway_url)
+            .map_err(|error| anyhow::anyhow!("invalid {ENV_GATEWAY_URL}: {error}"))?;
+        if !matches!(gateway_url.scheme(), "http" | "https") || gateway_url.host().is_none() {
+            anyhow::bail!("{ENV_GATEWAY_URL} must be an absolute HTTP(S) URL");
+        }
+
+        let auth = if let Some(token) = mcp_token {
+            GatewayAuth::McpToken(parse_secret_header(ENV_MCP_TOKEN, &token)?)
+        } else {
+            let access_key = access_key.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "missing credentials: set {ENV_MCP_TOKEN}, or both {ENV_ACCESS_KEY} and {ENV_SECRET_KEY}"
+                )
+            })?;
+            let secret_key = secret_key.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "missing credentials: set {ENV_MCP_TOKEN}, or both {ENV_ACCESS_KEY} and {ENV_SECRET_KEY}"
+                )
+            })?;
+            GatewayAuth::ApiKey {
+                access_key: parse_secret_header(ENV_ACCESS_KEY, &access_key)?,
+                secret_key: parse_secret_header(ENV_SECRET_KEY, &secret_key)?,
+            }
+        };
+
+        Ok(Self { gateway_url, auth })
+    }
+
+    fn auth_headers(&self) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        match &self.auth {
+            GatewayAuth::McpToken(token) => {
+                headers.insert("x-s4-mcp-token", token.clone());
+            }
+            GatewayAuth::ApiKey {
+                access_key,
+                secret_key,
+            } => {
+                headers.insert("x-s4-access-key", access_key.clone());
+                headers.insert("x-s4-secret-key", secret_key.clone());
+            }
+        }
+        headers
+    }
+}
+
+fn parse_secret_header(name: &str, value: &str) -> anyhow::Result<HeaderValue> {
+    HeaderValue::from_str(value)
+        .map_err(|_| anyhow::anyhow!("{name} is not a valid HTTP header value"))
+}
+
+#[derive(Clone)]
+struct S4Server {
+    config: Config,
+    client: reqwest::Client,
+}
+
+impl S4Server {
+    fn new(config: Config) -> anyhow::Result<Self> {
+        let client = reqwest::Client::builder()
+            .user_agent(concat!("s4-mcp/", env!("CARGO_PKG_VERSION")))
+            .build()?;
+        Ok(Self { config, client })
+    }
+
+    fn object_url(&self, bucket: &str, key: &str) -> anyhow::Result<Url> {
+        if bucket.is_empty() {
+            anyhow::bail!("bucket must not be empty");
+        }
+        let mut url = self.config.gateway_url.clone();
+        url.set_query(None);
+        url.set_fragment(None);
+        let mut segments = url
+            .path_segments_mut()
+            .map_err(|_| anyhow::anyhow!("gateway URL cannot be used as a path base"))?;
+        segments.pop_if_empty();
+        segments.push(bucket);
+        for segment in key.split('/').filter(|segment| !segment.is_empty()) {
+            segments.push(segment);
+        }
+        drop(segments);
+        Ok(url)
+    }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct PutObjectParams {
+    /// Bucket to write into.
+    bucket: String,
+    /// Object key within the bucket.
+    key: String,
+    /// UTF-8 object body.
+    body: String,
+    /// Content-Type used by S4 to select the processing format.
+    #[serde(default = "default_content_type")]
+    content_type: String,
+}
+
+fn default_content_type() -> String {
+    "text/plain; charset=utf-8".to_string()
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct GetObjectParams {
+    bucket: String,
+    key: String,
+    /// Run the configured processing pipeline before returning the object.
+    #[serde(default)]
+    process: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ListObjectsParams {
+    bucket: String,
+    #[serde(default)]
+    prefix: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct DeleteObjectParams {
+    bucket: String,
+    key: String,
+}
+
+#[tool_router(server_handler)]
+impl S4Server {
+    #[tool(description = "Store a UTF-8 object through the configured S4 pipeline")]
+    async fn s4_put_object(
+        &self,
+        Parameters(params): Parameters<PutObjectParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let url = match object_url_for_tool(self, &params.bucket, &params.key, true) {
+            Ok(url) => url,
+            Err(result) => return Ok(result),
+        };
+        let content_type = match HeaderValue::from_str(&params.content_type) {
+            Ok(value) => value,
+            Err(_) => return Ok(tool_error("content_type is not a valid HTTP header value")),
+        };
+        let response = self
+            .client
+            .put(url)
+            .headers(self.config.auth_headers())
+            .header(CONTENT_TYPE, content_type)
+            .body(params.body)
+            .send()
+            .await;
+        Ok(status_only_result(response, "stored", &params.bucket, &params.key).await)
+    }
+
+    #[tool(description = "Read an object through the S4 gateway")]
+    async fn s4_get_object(
+        &self,
+        Parameters(params): Parameters<GetObjectParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let url = match object_url_for_tool(self, &params.bucket, &params.key, true) {
+            Ok(url) => url,
+            Err(result) => return Ok(result),
+        };
+        let mut request = self.client.get(url).headers(self.config.auth_headers());
+        if params.process {
+            request = request.header("x-s4-process", "read");
+        }
+        let response = match request.send().await {
+            Ok(response) => response,
+            Err(error) => return Ok(tool_error(format!("gateway request failed: {error}"))),
+        };
+        if !response.status().is_success() {
+            return Ok(gateway_error(response).await);
+        }
+        match read_text_bounded(response, MAX_TEXT_RESPONSE_BYTES).await {
+            Ok(body) => Ok(CallToolResult::success(vec![ContentBlock::text(body)])),
+            Err(error) => Ok(tool_error(error)),
+        }
+    }
+
+    #[tool(description = "List object keys in a bucket using ListObjectsV2")]
+    async fn s4_list_objects(
+        &self,
+        Parameters(params): Parameters<ListObjectsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut url = match self.object_url(&params.bucket, "") {
+            Ok(url) => url,
+            Err(error) => return Ok(tool_error(error.to_string())),
+        };
+        url.query_pairs_mut()
+            .append_pair("list-type", "2")
+            .append_pair("prefix", &params.prefix);
+        let response = match self
+            .client
+            .get(url)
+            .headers(self.config.auth_headers())
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => return Ok(tool_error(format!("gateway request failed: {error}"))),
+        };
+        if !response.status().is_success() {
+            return Ok(gateway_error(response).await);
+        }
+        let body = match read_text_bounded(response, MAX_TEXT_RESPONSE_BYTES).await {
+            Ok(body) => body,
+            Err(error) => return Ok(tool_error(error)),
+        };
+        let keys = match parse_s3_list_keys(&body) {
+            Ok(keys) => keys,
+            Err(error) => {
+                return Ok(tool_error(format!(
+                    "invalid ListObjectsV2 response: {error}"
+                )));
+            }
+        };
+        let message = if keys.is_empty() {
+            format!("no objects matching prefix '{}'", params.prefix)
+        } else {
+            keys.join("\n")
+        };
+        Ok(CallToolResult::success(vec![ContentBlock::text(message)]))
+    }
+
+    #[tool(description = "Delete an object through the S4 gateway")]
+    async fn s4_delete_object(
+        &self,
+        Parameters(params): Parameters<DeleteObjectParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let url = match object_url_for_tool(self, &params.bucket, &params.key, true) {
+            Ok(url) => url,
+            Err(result) => return Ok(result),
+        };
+        let response = self
+            .client
+            .delete(url)
+            .headers(self.config.auth_headers())
+            .send()
+            .await;
+        Ok(status_only_result(response, "deleted", &params.bucket, &params.key).await)
+    }
+}
+
+fn object_url_for_tool(
+    server: &S4Server,
+    bucket: &str,
+    key: &str,
+    require_key: bool,
+) -> Result<Url, CallToolResult> {
+    if require_key && key.is_empty() {
+        return Err(tool_error("key must not be empty"));
+    }
+    server
+        .object_url(bucket, key)
+        .map_err(|error| tool_error(error.to_string()))
+}
+
+async fn status_only_result(
+    response: Result<reqwest::Response, reqwest::Error>,
+    action: &str,
+    bucket: &str,
+    key: &str,
+) -> CallToolResult {
+    match response {
+        Ok(response) if response.status().is_success() => {
+            CallToolResult::success(vec![ContentBlock::text(format!(
+                "{action} {bucket}/{key} (status {})",
+                response.status().as_u16()
+            ))])
+        }
+        Ok(response) => gateway_error(response).await,
+        Err(error) => tool_error(format!("gateway request failed: {error}")),
+    }
+}
+
+async fn gateway_error(response: reqwest::Response) -> CallToolResult {
+    let status = response.status().as_u16();
+    let body = read_text_bounded(response, MAX_ERROR_RESPONSE_BYTES)
+        .await
+        .unwrap_or_else(|error| error);
+    tool_error(format!("gateway returned {status}: {body}"))
+}
+
+async fn read_text_bounded(response: reqwest::Response, limit: usize) -> Result<String, String> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > limit as u64)
+    {
+        return Err(format!("gateway response exceeds {limit} bytes"));
+    }
+    let mut bytes = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| format!("failed to read gateway response: {error}"))?;
+        if bytes.len().saturating_add(chunk.len()) > limit {
+            return Err(format!("gateway response exceeds {limit} bytes"));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    String::from_utf8(bytes).map_err(|_| "gateway response is not valid UTF-8".to_string())
+}
+
+fn tool_error(message: impl Into<String>) -> CallToolResult {
+    CallToolResult::error(vec![ContentBlock::text(message.into())])
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename = "ListBucketResult")]
+struct ListBucketResult {
+    #[serde(rename = "Contents", default)]
+    contents: Vec<ListObject>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListObject {
+    #[serde(rename = "Key")]
+    key: String,
+}
+
+fn parse_s3_list_keys(xml: &str) -> Result<Vec<String>, quick_xml::DeError> {
+    let result: ListBucketResult = quick_xml::de::from_str(xml)?;
+    Ok(result
+        .contents
+        .into_iter()
+        .map(|object| object.key)
+        .collect())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_writer(std::io::stderr)
+        .init();
+    let server = S4Server::new(Config::from_env()?)?;
+    tracing::info!("s4-mcp stdio server ready");
+    let service = server.serve(stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use axum::{
+        Router,
+        body::Body,
+        extract::{Request, State},
+        http::{HeaderMap as AxumHeaderMap, Method, Response},
+        routing::any,
+    };
+    use http_body_util::BodyExt;
+
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    struct RecordedRequest {
+        method: Method,
+        path: String,
+        query: Option<String>,
+        headers: AxumHeaderMap,
+        body: Vec<u8>,
+    }
+
+    #[derive(Clone, Default)]
+    struct MockState {
+        requests: Arc<Mutex<Vec<RecordedRequest>>>,
+    }
+
+    fn test_server() -> S4Server {
+        S4Server::new(
+            Config::new(
+                "http://localhost:8080",
+                Some("s4m_test".to_string()),
+                None,
+                None,
+            )
+            .unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn object_url_encodes_bucket_and_key_segments() {
+        let url = test_server()
+            .object_url("sandbox", "logs/agent run/1.json")
+            .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "http://localhost:8080/sandbox/logs/agent%20run/1.json"
+        );
+    }
+
+    #[test]
+    fn config_rejects_invalid_secret_headers_without_exposing_values() {
+        let error = Config::new(
+            "http://localhost:8080",
+            Some("secret\nvalue".to_string()),
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains(ENV_MCP_TOKEN));
+        assert!(!error.contains("secret"));
+    }
+
+    #[test]
+    fn config_debug_redacts_credentials() {
+        let config = Config::new(
+            "http://localhost:8080",
+            None,
+            Some("access-test".to_string()),
+            Some("secret-test".to_string()),
+        )
+        .unwrap();
+        let debug = format!("{config:?}");
+        assert!(!debug.contains("access-test"));
+        assert!(!debug.contains("secret-test"));
+    }
+
+    #[test]
+    fn parses_and_decodes_s3_list_keys() {
+        let xml = r#"<?xml version="1.0"?>
+<ListBucketResult>
+  <Contents><Key>a.txt</Key></Contents>
+  <Contents><Key>dir/a&amp;b.txt</Key></Contents>
+</ListBucketResult>"#;
+        assert_eq!(
+            parse_s3_list_keys(xml).unwrap(),
+            vec!["a.txt", "dir/a&b.txt"]
+        );
+    }
+
+    #[test]
+    fn empty_s3_list_has_no_keys() {
+        assert!(
+            parse_s3_list_keys("<ListBucketResult/>")
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    async fn mock_gateway(State(state): State<MockState>, request: Request) -> Response<Body> {
+        let method = request.method().clone();
+        let path = request.uri().path().to_string();
+        let query = request.uri().query().map(str::to_string);
+        let headers = request.headers().clone();
+        let body = request
+            .into_body()
+            .collect()
+            .await
+            .expect("mock request body")
+            .to_bytes()
+            .to_vec();
+        state.requests.lock().unwrap().push(RecordedRequest {
+            method: method.clone(),
+            path: path.clone(),
+            query: query.clone(),
+            headers,
+            body,
+        });
+
+        if path.ends_with("/too-large") {
+            return Response::new(Body::from(vec![b'x'; MAX_TEXT_RESPONSE_BYTES + 1]));
+        }
+        if method == Method::GET
+            && query
+                .as_deref()
+                .is_some_and(|value| value.contains("list-type=2"))
+        {
+            return Response::new(Body::from(
+                "<ListBucketResult><Contents><Key>logs/a&amp;b.txt</Key></Contents></ListBucketResult>",
+            ));
+        }
+        if method == Method::GET {
+            return Response::new(Body::from("processed object"));
+        }
+        Response::new(Body::empty())
+    }
+
+    async fn mock_server() -> (String, MockState) {
+        let state = MockState::default();
+        let app = Router::new()
+            .route("/{*path}", any(mock_gateway))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{address}"), state)
+    }
+
+    fn result_text(result: &CallToolResult) -> String {
+        serde_json::to_value(&result.content[0])
+            .unwrap()
+            .get("text")
+            .and_then(serde_json::Value::as_str)
+            .expect("text tool result")
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn tools_preserve_mcp_auth_and_processing_semantics() {
+        let (gateway_url, state) = mock_server().await;
+        let server = S4Server::new(
+            Config::new(&gateway_url, Some("s4m_test-token".to_string()), None, None).unwrap(),
+        )
+        .unwrap();
+
+        let put = server
+            .s4_put_object(Parameters(PutObjectParams {
+                bucket: "records".to_string(),
+                key: "daily report.json".to_string(),
+                body: r#"{"email":"alice@example.com"}"#.to_string(),
+                content_type: "application/json".to_string(),
+            }))
+            .await
+            .unwrap();
+        assert_eq!(put.is_error, Some(false));
+
+        let get = server
+            .s4_get_object(Parameters(GetObjectParams {
+                bucket: "records".to_string(),
+                key: "daily report.json".to_string(),
+                process: true,
+            }))
+            .await
+            .unwrap();
+        assert_eq!(get.is_error, Some(false));
+        assert_eq!(result_text(&get), "processed object");
+
+        let list = server
+            .s4_list_objects(Parameters(ListObjectsParams {
+                bucket: "records".to_string(),
+                prefix: "logs/".to_string(),
+            }))
+            .await
+            .unwrap();
+        assert_eq!(list.is_error, Some(false));
+        assert_eq!(result_text(&list), "logs/a&b.txt");
+
+        let delete = server
+            .s4_delete_object(Parameters(DeleteObjectParams {
+                bucket: "records".to_string(),
+                key: "daily report.json".to_string(),
+            }))
+            .await
+            .unwrap();
+        assert_eq!(delete.is_error, Some(false));
+
+        let requests = state.requests.lock().unwrap();
+        assert_eq!(requests.len(), 4);
+        assert_eq!(requests[0].method, Method::PUT);
+        assert_eq!(requests[0].path, "/records/daily%20report.json");
+        assert_eq!(requests[0].headers["x-s4-mcp-token"], "s4m_test-token");
+        assert_eq!(requests[0].headers[CONTENT_TYPE], "application/json");
+        assert_eq!(requests[0].body, br#"{"email":"alice@example.com"}"#);
+        assert_eq!(requests[1].headers["x-s4-process"], "read");
+        assert_eq!(requests[2].method, Method::GET);
+        assert_eq!(
+            requests[2].query.as_deref(),
+            Some("list-type=2&prefix=logs%2F")
+        );
+        assert_eq!(requests[3].method, Method::DELETE);
+    }
+
+    #[tokio::test]
+    async fn api_key_auth_uses_both_gateway_headers() {
+        let (gateway_url, state) = mock_server().await;
+        let server = S4Server::new(
+            Config::new(
+                &gateway_url,
+                None,
+                Some("s4_access".to_string()),
+                Some("s4s_secret".to_string()),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        server
+            .s4_delete_object(Parameters(DeleteObjectParams {
+                bucket: "records".to_string(),
+                key: "old.txt".to_string(),
+            }))
+            .await
+            .unwrap();
+
+        let requests = state.requests.lock().unwrap();
+        assert_eq!(requests[0].headers["x-s4-access-key"], "s4_access");
+        assert_eq!(requests[0].headers["x-s4-secret-key"], "s4s_secret");
+        assert!(!requests[0].headers.contains_key("x-s4-mcp-token"));
+    }
+
+    #[tokio::test]
+    async fn get_rejects_responses_above_the_text_limit() {
+        let (gateway_url, _) = mock_server().await;
+        let server = S4Server::new(
+            Config::new(&gateway_url, Some("s4m_test-token".to_string()), None, None).unwrap(),
+        )
+        .unwrap();
+        let result = server
+            .s4_get_object(Parameters(GetObjectParams {
+                bucket: "records".to_string(),
+                key: "too-large".to_string(),
+                process: false,
+            }))
+            .await
+            .unwrap();
+        assert_eq!(result.is_error, Some(true));
+        assert!(result_text(&result).contains("exceeds"));
+    }
+}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,76 @@
+# MCP server
+
+`s4-mcp` is a local stdio Model Context Protocol server. It exposes four text
+object tools to Claude, Codex, Cursor, and other MCP clients:
+
+- `s4_put_object`
+- `s4_get_object`
+- `s4_list_objects`
+- `s4_delete_object`
+
+The server does not implement a second storage or processing path. Every tool
+calls the S4 gateway's S3-compatible HTTP surface, so gateway authentication,
+the configured plugin pipeline, backend selection, limits, and metering still
+apply.
+
+## Install
+
+Build and install from the public source:
+
+```bash
+cargo install --git https://github.com/231self/S4 s4-mcp
+```
+
+Linux x86_64 and arm64 binaries are also attached to each
+[GitHub release](https://github.com/231self/S4/releases) as
+`s4-mcp-linux-amd64` and `s4-mcp-linux-arm64`.
+
+There is currently no npm package or hosted MCP transport.
+
+## Configure
+
+Create an MCP token in the S4 dashboard, then configure the local server:
+
+```json
+{
+  "mcpServers": {
+    "s4": {
+      "command": "s4-mcp",
+      "env": {
+        "S4_GATEWAY_URL": "https://api.s4.231self.com",
+        "S4_MCP_TOKEN": "s4m_your_token"
+      }
+    }
+  }
+}
+```
+
+An S4 API key pair can be used instead:
+
+```json
+{
+  "S4_GATEWAY_URL": "https://api.s4.231self.com",
+  "S4_ACCESS_KEY": "s4_your_access_key",
+  "S4_SECRET_KEY": "s4s_your_secret_key"
+}
+```
+
+`S4_MCP_TOKEN` takes precedence when both credential forms are present. Secret
+values are validated at startup and are omitted from debug output.
+
+## Tool behavior
+
+`s4_put_object` accepts a UTF-8 body and a `content_type` (default
+`text/plain; charset=utf-8`). S4 uses that Content-Type to select the processing
+format before writing to the configured backend.
+
+`s4_get_object` returns the stored representation by default. Set `process` to
+`true` to send `x-s4-process: read` and run the configured read pipeline before
+the MCP client receives the object.
+
+`s4_list_objects` performs S3 ListObjectsV2 with an optional prefix and returns
+decoded object keys. `s4_delete_object` deletes one bucket/key pair.
+
+MCP text responses are limited to 8 MiB. Binary request/response bodies,
+presigning, hosted Streamable HTTP transport, and agent payment protocols are
+not part of this stdio release.


### PR DESCRIPTION
Publish the existing P1 stdio MCP server in the public workspace so website install instructions resolve to auditable source.\n\n- exposes put/get/list/delete over the existing gateway HTTP path\n- supports MCP tokens or S4 API key pairs\n- sets explicit PUT Content-Type and supports processed reads\n- validates credentials, bounds text/error responses, and decodes ListObjectsV2 XML\n- adds mock-gateway integration coverage for all tools and auth modes\n- packages Linux amd64/arm64 binaries in GitHub releases\n- documents Cargo/GitHub installation; no npm, hosted MCP, AP2, or managed-storage claim\n\nValidation: full `cargo test --workspace`, full workspace clippy with `-D warnings`, actionlint, and source installation passed locally.