### PR TITLE
Fix hosted pipeline security, durability, and compatibility gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4573,6 +4573,7 @@ dependencies = [
  "hex",
  "rand 0.8.7",
  "s4-error",
+ "serde",
  "sha2 0.10.9",
  "wasmtime",
  "wasmtime-wasi",

--- a/crates/gateway/src/multipart_staging.rs
+++ b/crates/gateway/src/multipart_staging.rs
@@ -2807,6 +2807,20 @@ mod tests {
     use super::*;
     use crate::key_cipher::LocalKeyWrapping;
 
+    #[test]
+    fn legacy_completion_result_json_defaults_new_accounting_fields() {
+        let result: MultipartCompletionResult = serde_json::from_value(serde_json::json!({
+            "etag": "\"legacy\"",
+            "checksum_sha256": "legacy-sha",
+            "version_id": null
+        }))
+        .unwrap();
+
+        assert_eq!(result.source_bytes, 0);
+        assert_eq!(result.size_bytes, 0);
+        assert!(result.pipeline_evidence.is_none());
+    }
+
     fn identity() -> MultipartIdentity {
         MultipartIdentity {
             tenant_id: "tenant-a".to_string(),

--- a/crates/gateway/src/pipeline.rs
+++ b/crates/gateway/src/pipeline.rs
@@ -37,16 +37,29 @@ pub struct PipelineLocator {
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PipelineStep {
     pub component_hash: String,
+    /// Disabled steps remain part of the immutable revision fingerprint but
+    /// are not loaded or executed. Older persisted resolutions predate this
+    /// field and contained only enabled steps.
+    #[serde(default = "enabled_by_default")]
+    pub enabled: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
     /// Bounded canonical JSON configuration (v0.2 steps only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config_json: Option<String>,
     pub capabilities: PluginCapabilities,
+    /// Sensitive request context is denied unless the resolver explicitly
+    /// grants individual fields to this exact step.
+    #[serde(default)]
+    pub sensitive_grant: s4_wasm_runtime::SensitiveGrant,
+}
+
+const fn enabled_by_default() -> bool {
+    true
 }
 
 /// Fully-resolved, immutable pipeline for one workspace/bucket/direction.
-#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
 pub struct PipelineResolution {
     pub locator: PipelineLocator,
     pub steps: Vec<PipelineStep>,
@@ -54,6 +67,60 @@ pub struct PipelineResolution {
     #[serde(default)]
     pub explicit_passthrough: bool,
     pub limits: PipelineLimits,
+}
+
+#[derive(serde::Deserialize)]
+struct PersistedPipelineResolution {
+    locator: PipelineLocator,
+    steps: Vec<PersistedPipelineStep>,
+    #[serde(default)]
+    explicit_passthrough: bool,
+    limits: PipelineLimits,
+}
+
+#[derive(serde::Deserialize)]
+struct PersistedPipelineStep {
+    component_hash: String,
+    #[serde(default = "enabled_by_default")]
+    enabled: bool,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    config_json: Option<String>,
+    capabilities: PluginCapabilities,
+    #[serde(default)]
+    sensitive_grant: Option<s4_wasm_runtime::SensitiveGrant>,
+}
+
+impl<'de> serde::Deserialize<'de> for PipelineResolution {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let persisted = PersistedPipelineResolution::deserialize(deserializer)?;
+        let static_revision = persisted.locator.revision == "static";
+        Ok(Self {
+            locator: persisted.locator,
+            steps: persisted
+                .steps
+                .into_iter()
+                .map(|step| PipelineStep {
+                    component_hash: step.component_hash,
+                    enabled: step.enabled,
+                    version: step.version,
+                    config_json: step.config_json,
+                    capabilities: step.capabilities,
+                    sensitive_grant: step.sensitive_grant.unwrap_or(if static_revision {
+                        s4_wasm_runtime::SensitiveGrant::ALL
+                    } else {
+                        s4_wasm_runtime::SensitiveGrant::NONE
+                    }),
+                })
+                .collect(),
+            explicit_passthrough: persisted.explicit_passthrough,
+            limits: persisted.limits,
+        })
+    }
 }
 
 /// Resolves the effective pipeline for a workspace + exact bucket + direction.
@@ -94,9 +161,13 @@ impl StaticPipelineResolver {
             .into_iter()
             .map(|(info, component_hash, capabilities)| PipelineStep {
                 component_hash,
+                enabled: true,
                 version: Some(info.version),
                 config_json: None,
                 capabilities,
+                // Preserve the historical self-hosted contract explicitly;
+                // hosted resolutions default to no sensitive grants.
+                sensitive_grant: s4_wasm_runtime::SensitiveGrant::ALL,
             })
             .collect();
         let explicit_passthrough = steps.is_empty();
@@ -154,13 +225,13 @@ pub(crate) fn plugin_step_info(step: &PipelineStep) -> PluginInfo {
             .clone()
             .unwrap_or_else(|| step.component_hash.chars().take(8).collect()),
         version: step.version.clone().unwrap_or_else(|| "0.1.0".to_string()),
-        enabled: true,
+        enabled: step.enabled,
         description: String::new(),
     }
 }
 
 pub(crate) fn pipeline_requires_passthrough(resolution: &PipelineResolution) -> bool {
-    resolution.steps.is_empty() && !resolution.explicit_passthrough
+    !resolution.steps.iter().any(|step| step.enabled) && !resolution.explicit_passthrough
 }
 
 pub(crate) fn missing_component_error(component_hash: &str) -> S4Error {
@@ -168,4 +239,59 @@ pub(crate) fn missing_component_error(component_hash: &str) -> S4Error {
         codes::WASM_INIT,
         format!("component {component_hash} is not available from its component source"),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn persisted_pre_grant_steps_default_enabled_and_deny_sensitive_context() {
+        let step: PipelineStep = serde_json::from_value(serde_json::json!({
+            "component_hash": "a".repeat(64),
+            "version": "0.2.0",
+            "config_json": "{\"mode\":\"redact\"}",
+            "capabilities": { "prefix_safe_for_read": false }
+        }))
+        .unwrap();
+
+        assert!(step.enabled);
+        assert_eq!(step.sensitive_grant, s4_wasm_runtime::SensitiveGrant::NONE);
+        assert_eq!(step.config_json.as_deref(), Some("{\"mode\":\"redact\"}"));
+    }
+
+    fn persisted_resolution_without_grant(revision: &str) -> serde_json::Value {
+        serde_json::json!({
+            "locator": {
+                "revision": revision,
+                "fingerprint": "legacy-fingerprint"
+            },
+            "steps": [{
+                "component_hash": "b".repeat(64),
+                "version": "0.1.0",
+                "config_json": null,
+                "capabilities": { "prefix_safe_for_read": false }
+            }],
+            "explicit_passthrough": false,
+            "limits": serde_json::to_value(PipelineLimits::default()).unwrap()
+        })
+    }
+
+    #[test]
+    fn old_static_multipart_resolution_restores_legacy_grants_only_for_static_revision() {
+        let static_resolution: PipelineResolution =
+            serde_json::from_value(persisted_resolution_without_grant("static")).unwrap();
+        assert_eq!(
+            static_resolution.steps[0].sensitive_grant,
+            s4_wasm_runtime::SensitiveGrant::ALL
+        );
+
+        let hosted_resolution: PipelineResolution =
+            serde_json::from_value(persisted_resolution_without_grant("relational-revision-id"))
+                .unwrap();
+        assert_eq!(
+            hosted_resolution.steps[0].sensitive_grant,
+            s4_wasm_runtime::SensitiveGrant::NONE
+        );
+    }
 }

--- a/crates/gateway/src/plugin_registry.rs
+++ b/crates/gateway/src/plugin_registry.rs
@@ -7,7 +7,8 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use s4_error::{S4Error, codes};
 use s4_wasm_runtime::{
-    CancellationToken, ExecutorConfig, FilterEngine, FilterSession, TransformOutcome, WasmExecutor,
+    CancellationToken, ExecutorConfig, FilterEngine, FilterSession, SensitiveGrant,
+    TransformOutcome, WasmExecutor,
 };
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -18,7 +19,7 @@ use crate::pipeline::{
     ComponentSource, PipelineResolution, PipelineStep, pipeline_requires_passthrough,
     plugin_step_info,
 };
-use crate::record::Record;
+use crate::record::{OutputValidator, Record};
 
 /// Default per-session fuel budget for the plugin pipeline. Set high enough
 /// for crypto filters (one RSA-2048 OAEP wrap costs ~25M wasm instructions).
@@ -71,6 +72,42 @@ struct RegistryState {
     cache_max_weight: usize,
 }
 
+fn touch_cache_entry(state: &mut RegistryState, component_hash: &str) {
+    if let Some(pos) = state
+        .cache_order
+        .iter()
+        .position(|hash| hash == component_hash)
+    {
+        state.cache_order.remove(pos);
+    }
+    state.cache_order.push_back(component_hash.to_string());
+}
+
+fn evict_unreferenced_engines(state: &mut RegistryState) {
+    // Catalog engines are pinned. Hosted request-only entries remain bounded
+    // by weighted LRU eviction.
+    while state.cache_weight > state.cache_max_weight {
+        let referenced: HashSet<&str> = state
+            .plugins
+            .values()
+            .map(|plugin| plugin.component_hash.as_str())
+            .collect();
+        let victim = state
+            .cache_order
+            .iter()
+            .find(|hash| !referenced.contains(hash.as_str()) && state.engines.contains_key(*hash));
+        let Some(victim) = victim.cloned() else {
+            break;
+        };
+        if let Some(pos) = state.cache_order.iter().position(|hash| hash == &victim) {
+            state.cache_order.remove(pos);
+        }
+        if let Some(entry) = state.engines.remove(&victim) {
+            state.cache_weight = state.cache_weight.saturating_sub(entry.weight);
+        }
+    }
+}
+
 pub struct PluginRegistry {
     state: RwLock<RegistryState>,
     fuel: u64,
@@ -82,8 +119,11 @@ pub struct PluginRegistry {
 struct SnapshotPlugin {
     info: PluginInfo,
     component_hash: String,
+    enabled: bool,
+    config_json: Option<String>,
     capabilities: PluginCapabilities,
-    engine: Arc<FilterEngine>,
+    sensitive_grant: SensitiveGrant,
+    engine: Option<Arc<FilterEngine>>,
 }
 
 #[derive(Clone)]
@@ -199,8 +239,7 @@ struct PluginSession {
 pub struct PipelineSession {
     plugins: Vec<Option<PluginSession>>,
     limits: PipelineLimits,
-    output_format: crate::Format,
-    decoder_limits: crate::record::DecoderLimits,
+    output_validator: OutputValidator,
     input_bytes: u64,
     output_bytes: u64,
     stage_output_bytes: Vec<u64>,
@@ -306,7 +345,7 @@ impl PluginRegistry {
         capabilities: PluginCapabilities,
     ) -> anyhow::Result<PluginInfo> {
         let component_hash = hex::encode(Sha256::digest(component_bytes));
-        let engine = match self.cached_engine(&component_hash) {
+        let candidate = match self.cached_engine(&component_hash) {
             Some((engine, registered)) => {
                 if registered != capabilities {
                     anyhow::bail!(
@@ -318,15 +357,7 @@ impl PluginRegistry {
             None => {
                 // Compile outside the registry lock so a slow first compile
                 // never stalls catalog reads or other request paths.
-                let engine = Arc::new(FilterEngine::with_fuel(component_bytes, self.fuel)?);
-                self.insert_engine(
-                    component_hash.clone(),
-                    Arc::clone(&engine),
-                    capabilities,
-                    Arc::from(component_bytes),
-                    engine.guest_memory_limit(),
-                );
-                engine
+                Arc::new(FilterEngine::with_fuel(component_bytes, self.fuel)?)
             }
         };
         let id = Uuid::new_v4().to_string();
@@ -338,6 +369,30 @@ impl PluginRegistry {
             description: String::new(),
         };
         let mut state = self.state.write().unwrap();
+        // Cache insertion and catalog pinning are one transaction. No
+        // concurrent insertion can evict this component in between them.
+        let engine = if let Some(existing) = state.engines.get(&component_hash) {
+            if existing.capabilities != capabilities {
+                anyhow::bail!(
+                    "component {component_hash} is already registered with different capabilities"
+                );
+            }
+            Arc::clone(&existing.engine)
+        } else {
+            let weight = candidate.guest_memory_limit();
+            state.cache_weight = state.cache_weight.saturating_add(weight);
+            state.engines.insert(
+                component_hash.clone(),
+                CacheEntry {
+                    engine: Arc::clone(&candidate),
+                    capabilities,
+                    bytes: Arc::from(component_bytes),
+                    weight,
+                },
+            );
+            candidate
+        };
+        touch_cache_entry(&mut state, &component_hash);
         state.plugins.insert(
             id.clone(),
             Plugin {
@@ -348,6 +403,7 @@ impl PluginRegistry {
             },
         );
         state.order.push(id);
+        evict_unreferenced_engines(&mut state);
         Ok(info)
     }
 
@@ -388,7 +444,11 @@ impl PluginRegistry {
     pub fn remove(&self, id: &str) -> bool {
         let mut state = self.state.write().unwrap();
         state.order.retain(|ordered_id| ordered_id != id);
-        state.plugins.remove(id).is_some()
+        let removed = state.plugins.remove(id).is_some();
+        if removed {
+            evict_unreferenced_engines(&mut state);
+        }
+        removed
     }
 
     /// Plugins omitted from `ids` retain their relative order at the end.
@@ -457,54 +517,34 @@ impl PluginRegistry {
         capabilities: PluginCapabilities,
         bytes: Arc<[u8]>,
         weight: usize,
-    ) {
+    ) -> Result<Arc<FilterEngine>, S4Error> {
         let mut state = self.state.write().unwrap();
         if let Some(existing) = state.engines.get(&component_hash) {
             if existing.capabilities != capabilities {
-                return;
+                return Err(S4Error::new(
+                    codes::CONFIG_INVALID,
+                    format!(
+                        "component {component_hash} is already registered with different capabilities"
+                    ),
+                ));
             }
-            if let Some(pos) = state
-                .cache_order
-                .iter()
-                .position(|hash| hash == &component_hash)
-            {
-                state.cache_order.remove(pos);
-            }
-            state.cache_order.push_back(component_hash);
-            return;
+            let authoritative = Arc::clone(&existing.engine);
+            touch_cache_entry(&mut state, &component_hash);
+            return Ok(authoritative);
         }
         state.cache_weight = state.cache_weight.saturating_add(weight);
         state.engines.insert(
             component_hash.clone(),
             CacheEntry {
-                engine,
+                engine: Arc::clone(&engine),
                 capabilities,
                 bytes,
                 weight,
             },
         );
-        state.cache_order.push_back(component_hash);
-        // Weighted LRU eviction. Only evict entries no longer referenced by the
-        // catalog, so the self-hosted static chain is never dropped.
-        while state.cache_weight > state.cache_max_weight {
-            let referenced: HashSet<&str> = state
-                .plugins
-                .values()
-                .map(|plugin| plugin.component_hash.as_str())
-                .collect();
-            let victim = state.cache_order.iter().find(|hash| {
-                !referenced.contains(hash.as_str()) && state.engines.contains_key(*hash)
-            });
-            let Some(victim) = victim.cloned() else {
-                break;
-            };
-            if let Some(pos) = state.cache_order.iter().position(|hash| hash == &victim) {
-                state.cache_order.remove(pos);
-            }
-            if let Some(entry) = state.engines.remove(&victim) {
-                state.cache_weight = state.cache_weight.saturating_sub(entry.weight);
-            }
-        }
+        touch_cache_entry(&mut state, &component_hash);
+        evict_unreferenced_engines(&mut state);
+        Ok(engine)
     }
 
     /// Snapshot builder over an immutable [`PipelineResolution`]. Missing
@@ -524,21 +564,29 @@ impl PluginRegistry {
         let limits = resolution.limits.validate()?;
         let mut plugins = Vec::with_capacity(resolution.steps.len());
         for step in &resolution.steps {
-            let engine = self.engine_for(step, source).await?;
+            let engine = if step.enabled {
+                Some(self.engine_for(step, source).await?)
+            } else {
+                None
+            };
             plugins.push(SnapshotPlugin {
                 info: plugin_step_info(step),
                 component_hash: step.component_hash.clone(),
+                enabled: step.enabled,
+                config_json: step.config_json.clone(),
                 capabilities: step.capabilities,
+                sensitive_grant: step.sensitive_grant,
                 engine,
             });
         }
-        Ok(PipelineSnapshot {
+        PipelineSnapshot {
             plugins,
             limits,
             executor: Arc::clone(&self.executor),
             fingerprint: Some(resolution.locator.fingerprint.clone()),
             revision: Some(resolution.locator.revision.clone()),
-        })
+        }
+        .constrained(self.pipeline_limits)
     }
 
     async fn engine_for(
@@ -585,8 +633,7 @@ impl PluginRegistry {
             step.capabilities,
             Arc::from(bytes.as_ref()),
             engine.guest_memory_limit(),
-        );
-        Ok(engine)
+        )
     }
 
     /// Ordered enabled catalog entries for the static/self-hosted resolver.
@@ -621,8 +668,11 @@ impl PluginRegistry {
             .map(|plugin| SnapshotPlugin {
                 info: plugin.info.clone(),
                 component_hash: plugin.component_hash.clone(),
+                enabled: true,
+                config_json: None,
                 capabilities: plugin.capabilities,
-                engine: Arc::clone(&plugin.engine),
+                sensitive_grant: SensitiveGrant::ALL,
+                engine: Some(Arc::clone(&plugin.engine)),
             })
             .collect();
         PipelineSnapshot {
@@ -635,16 +685,16 @@ impl PluginRegistry {
     }
 
     pub fn load_from_dir(&self, dir: &Path) -> anyhow::Result<Vec<PluginInfo>> {
-        self.load_from_dir_with_capabilities(dir, &HashSet::new())
+        self.load_from_dir_with_capabilities_excluding(dir, &HashSet::new(), None)
     }
 
-    /// Capability declarations are supplied by startup administration, never
-    /// by component bytes or the dashboard import request. A hash's first
-    /// registration remains immutable for the process lifetime.
-    pub(crate) fn load_from_dir_with_capabilities(
+    /// Capability declarations and exclusions are supplied by startup
+    /// administration, never by component bytes or dashboard requests.
+    pub(crate) fn load_from_dir_with_capabilities_excluding(
         &self,
         dir: &Path,
         prefix_safe_hashes: &HashSet<String>,
+        excluded_component: Option<&Path>,
     ) -> anyhow::Result<Vec<PluginInfo>> {
         let mut added = Vec::new();
         if !dir.exists() || !dir.is_dir() {
@@ -655,24 +705,22 @@ impl PluginRegistry {
             .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "wasm"))
             .collect();
         entries.sort_by_key(std::fs::DirEntry::file_name);
+        let excluded_component = excluded_component
+            .map(std::fs::canonicalize)
+            .transpose()?
+            .or_else(|| excluded_component.map(Path::to_path_buf));
         for entry in entries {
             let path = entry.path();
+            let canonical_path = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+            if excluded_component.as_ref() == Some(&canonical_path) {
+                continue;
+            }
             let bytes = std::fs::read(&path)?;
             let name = path
                 .file_stem()
                 .and_then(|name| name.to_str())
                 .unwrap_or("unknown");
             let hash = hex::encode(Sha256::digest(&bytes));
-            // The directory is a catalog, not a pipeline: skip artifacts whose
-            // digest was already registered (for example `pii-default`, which
-            // the hosted image also loads explicitly). This stops duplicate
-            // default loading and preserves the first registration's caps.
-            if self.state.read().unwrap().engines.contains_key(&hash) {
-                tracing::debug!(
-                    "skipping duplicate component {name} ({hash}) already in the catalog"
-                );
-                continue;
-            }
             let capabilities = PluginCapabilities {
                 prefix_safe_for_read: prefix_safe_hashes.contains(&hash),
             };
@@ -731,6 +779,7 @@ impl PipelineSnapshot {
     pub fn plugin_infos(&self) -> Vec<PluginInfo> {
         self.plugins
             .iter()
+            .filter(|plugin| plugin.enabled)
             .map(|plugin| plugin.info.clone())
             .collect()
     }
@@ -738,6 +787,7 @@ impl PipelineSnapshot {
     pub fn component_hashes(&self) -> Vec<&str> {
         self.plugins
             .iter()
+            .filter(|plugin| plugin.enabled)
             .map(|plugin| plugin.component_hash.as_str())
             .collect()
     }
@@ -745,21 +795,31 @@ impl PipelineSnapshot {
     pub fn capabilities(&self) -> Vec<PluginCapabilities> {
         self.plugins
             .iter()
+            .filter(|plugin| plugin.enabled)
             .map(|plugin| plugin.capabilities)
             .collect()
     }
 
     pub fn guest_memory_reservation(&self) -> Result<usize, S4Error> {
-        self.plugins.iter().try_fold(0usize, |total, plugin| {
-            total
-                .checked_add(plugin.engine.guest_memory_limit())
-                .ok_or_else(|| {
-                    S4Error::new(
-                        codes::WASM_ADMISSION,
-                        "Wasm guest-memory reservation overflow",
+        self.plugins
+            .iter()
+            .filter(|plugin| plugin.enabled)
+            .try_fold(0usize, |total, plugin| {
+                total
+                    .checked_add(
+                        plugin
+                            .engine
+                            .as_ref()
+                            .expect("enabled snapshot plugins have compiled engines")
+                            .guest_memory_limit(),
                     )
-                })
-        })
+                    .ok_or_else(|| {
+                        S4Error::new(
+                            codes::WASM_ADMISSION,
+                            "Wasm guest-memory reservation overflow",
+                        )
+                    })
+            })
     }
 
     pub fn start_session(
@@ -780,26 +840,32 @@ impl PipelineSnapshot {
         cancellation: CancellationToken,
         requested_deadline: Instant,
     ) -> Result<PipelineSession, S4Error> {
-        if self.plugins.len() > self.limits.max_plugins {
+        let enabled_plugins = self.plugins.iter().filter(|plugin| plugin.enabled).count();
+        if enabled_plugins > self.limits.max_plugins {
             return Err(limit_error(
                 codes::LIMIT_PLUGIN_COUNT,
                 "plugin count",
-                self.plugins.len() as u64,
+                enabled_plugins as u64,
                 self.limits.max_plugins as u64,
             ));
         }
-        let mut plugins = Vec::with_capacity(self.plugins.len());
+        let mut plugins = Vec::with_capacity(enabled_plugins);
         let mut fuel_consumed = 0u64;
         let object_deadline = requested_deadline.min(Instant::now() + self.limits.max_wall_time);
-        for plugin in &self.plugins {
+        for plugin in self.plugins.iter().filter(|plugin| plugin.enabled) {
             let remaining_fuel = self.limits.max_cumulative_fuel - fuel_consumed;
+            let mut plugin_session = session.clone();
+            plugin_session.config_json = plugin.config_json.clone();
             let filter = plugin
                 .engine
-                .start_session_with_control(
-                    session,
+                .as_ref()
+                .expect("enabled snapshot plugins have compiled engines")
+                .start_session_with_control_and_grant(
+                    &plugin_session,
                     cancellation.clone(),
                     remaining_fuel,
                     object_deadline,
+                    plugin.sensitive_grant,
                 )
                 .map_err(|error| plugin_error(&plugin.info.name, error))?;
             fuel_consumed = fuel_consumed
@@ -814,12 +880,15 @@ impl PipelineSnapshot {
                 filter: Box::new(filter),
             }));
         }
+        let output_format = crate::Format::parse(&session.format).unwrap_or(crate::Format::Text);
         Ok(PipelineSession {
             stage_output_bytes: vec![0; plugins.len()],
             plugins,
             limits: self.limits,
-            output_format: crate::Format::parse(&session.format).unwrap_or(crate::Format::Text),
-            decoder_limits: crate::record::DecoderLimits::default(),
+            output_validator: OutputValidator::new(
+                output_format,
+                crate::record::DecoderLimits::default(),
+            )?,
             input_bytes: 0,
             output_bytes: 0,
             fuel_consumed,
@@ -886,9 +955,7 @@ impl PipelineSnapshot {
                                 }
                             }
                             PipelineCommand::Finish(response) => {
-                                let fuel = pipeline.fuel_consumed();
-                                let _ =
-                                    response.send(pipeline.finish().map(|records| (records, fuel)));
+                                let _ = response.send(pipeline.finish_with_fuel());
                                 break;
                             }
                             PipelineCommand::Cancel => break,
@@ -1094,7 +1161,11 @@ impl PipelineSession {
         self.route_from(0, record)
     }
 
-    pub fn finish(mut self) -> Result<Vec<Record>, S4Error> {
+    pub fn finish(self) -> Result<Vec<Record>, S4Error> {
+        self.finish_with_fuel().map(|(records, _)| records)
+    }
+
+    fn finish_with_fuel(mut self) -> Result<(Vec<Record>, u64), S4Error> {
         let mut output = Vec::new();
         for index in 0..self.plugins.len() {
             self.check_deadline()?;
@@ -1126,13 +1197,10 @@ impl PipelineSession {
                 output.push(record);
             }
         }
-        // A custom filter's output must still form a well-formed record
-        // stream in the target format before it is committed downstream.
-        crate::record::validate_output_records(self.output_format, &output, self.decoder_limits)
-            .map_err(|error| {
-                S4Error::new(codes::DECODE_INVALID_OUTPUT, error.message().to_string())
-            })?;
-        Ok(output)
+        self.output_validator
+            .finish()
+            .map_err(output_validation_error)?;
+        Ok((output, self.fuel_consumed))
     }
 
     pub fn input_bytes(&self) -> u64 {
@@ -1171,6 +1239,9 @@ impl PipelineSession {
                 TransformOutcome::Drop => return Ok(None),
             }
         }
+        self.output_validator
+            .push_record(&record)
+            .map_err(output_validation_error)?;
         self.account_output(record_len(&record))?;
         Ok(Some(record))
     }
@@ -1261,6 +1332,10 @@ impl PipelineSession {
     }
 }
 
+fn output_validation_error(error: S4Error) -> S4Error {
+    S4Error::new(codes::DECODE_INVALID_OUTPUT, error.message().to_string())
+}
+
 fn plugin_error(name: &str, error: S4Error) -> S4Error {
     S4Error::new(error.code(), format!("plugin {name}: {}", error.message()))
 }
@@ -1314,6 +1389,15 @@ mod tests {
         component_named("noop.component.wasm")
     }
 
+    fn component_v02() -> Vec<u8> {
+        std::fs::read(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../..")
+                .join("target/test-components/test-filter-v02.component.wasm"),
+        )
+        .expect("test-filter-v02.component.wasm; run just build-filters")
+    }
+
     fn session() -> s4_wasm_runtime::Session {
         s4_wasm_runtime::Session {
             format: "text".to_string(),
@@ -1332,6 +1416,8 @@ mod tests {
         calls: Arc<Mutex<Vec<String>>>,
         count: usize,
         finish: Vec<u8>,
+        finish_fuel: u64,
+        emit: Option<Vec<u8>>,
         drop: bool,
         reject: Option<&'static str>,
     }
@@ -1354,6 +1440,9 @@ mod tests {
             if self.drop {
                 return Ok(TransformOutcome::Drop);
             }
+            if let Some(output) = &self.emit {
+                return Ok(TransformOutcome::Emit(output.clone()));
+            }
             let mut output = payload.to_vec();
             output.extend_from_slice(format!("{}{}", self.name, self.count).as_bytes());
             Ok(TransformOutcome::Emit(output))
@@ -1364,7 +1453,7 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push(format!("{}:finish", self.name));
-            Ok((self.finish, 0))
+            Ok((self.finish, self.finish_fuel))
         }
 
         fn fuel_consumed(&self) -> u64 {
@@ -1387,8 +1476,11 @@ mod tests {
             stage_output_bytes: vec![0; plugins.len()],
             plugins,
             limits,
-            output_format: crate::Format::Text,
-            decoder_limits: crate::record::DecoderLimits::default(),
+            output_validator: OutputValidator::new(
+                crate::Format::Text,
+                crate::record::DecoderLimits::default(),
+            )
+            .unwrap(),
             input_bytes: 0,
             output_bytes: 0,
             fuel_consumed: 0,
@@ -1402,6 +1494,8 @@ mod tests {
             calls,
             count: 0,
             finish: Vec::new(),
+            finish_fuel: 0,
+            emit: None,
             drop: false,
             reject: None,
         }
@@ -1433,6 +1527,128 @@ mod tests {
             )
             .unwrap_err();
         assert!(error.to_string().contains("different capabilities"));
+    }
+
+    #[test]
+    fn cache_insertion_returns_the_authoritative_engine_and_rejects_conflicts() {
+        let registry = PluginRegistry::new();
+        let bytes = component();
+        let digest = hex::encode(Sha256::digest(&bytes));
+        let first = Arc::new(FilterEngine::with_fuel(&bytes, DEFAULT_PIPELINE_FUEL).unwrap());
+        let authoritative = registry
+            .insert_engine(
+                digest.clone(),
+                first.clone(),
+                PluginCapabilities::default(),
+                Arc::from(bytes.as_slice()),
+                first.guest_memory_limit(),
+            )
+            .unwrap();
+        assert!(Arc::ptr_eq(&authoritative, &first));
+
+        let duplicate = Arc::new(FilterEngine::with_fuel(&bytes, DEFAULT_PIPELINE_FUEL).unwrap());
+        let authoritative = registry
+            .insert_engine(
+                digest.clone(),
+                duplicate,
+                PluginCapabilities::default(),
+                Arc::from(bytes.as_slice()),
+                first.guest_memory_limit(),
+            )
+            .unwrap();
+        assert!(Arc::ptr_eq(&authoritative, &first));
+
+        let conflicting = Arc::new(FilterEngine::with_fuel(&bytes, DEFAULT_PIPELINE_FUEL).unwrap());
+        assert!(
+            registry
+                .insert_engine(
+                    digest,
+                    conflicting,
+                    PluginCapabilities {
+                        prefix_safe_for_read: true,
+                    },
+                    Arc::from(bytes.as_slice()),
+                    first.guest_memory_limit(),
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn directory_catalog_preserves_digest_identical_steps() {
+        let directory = std::env::temp_dir().join(format!("s4-plugin-dir-{}", Uuid::now_v7()));
+        std::fs::create_dir_all(&directory).unwrap();
+        let bytes = component();
+        std::fs::write(directory.join("a.wasm"), &bytes).unwrap();
+        std::fs::write(directory.join("b.wasm"), &bytes).unwrap();
+        let registry = PluginRegistry::new();
+        let loaded = registry.load_from_dir(&directory).unwrap();
+        std::fs::remove_dir_all(directory).unwrap();
+
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(registry.list().len(), 2);
+        assert_eq!(registry.state.read().unwrap().engines.len(), 1);
+    }
+
+    #[test]
+    fn standard_image_excludes_only_the_explicit_component_path() {
+        let directory = std::env::temp_dir().join(format!("s4-image-dir-{}", Uuid::now_v7()));
+        std::fs::create_dir_all(&directory).unwrap();
+        let bytes = component();
+        let explicit = directory.join("pii-default.component.wasm");
+        let intentional_duplicate = directory.join("intentional-copy.component.wasm");
+        std::fs::write(&explicit, &bytes).unwrap();
+        std::fs::write(&intentional_duplicate, &bytes).unwrap();
+        let registry = PluginRegistry::new();
+        registry.import("pii-default", &bytes).unwrap();
+        let loaded = registry
+            .load_from_dir_with_capabilities_excluding(&directory, &HashSet::new(), Some(&explicit))
+            .unwrap();
+        std::fs::remove_dir_all(directory).unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "intentional-copy.component");
+        assert_eq!(registry.list().len(), 2);
+        assert_eq!(registry.state.read().unwrap().engines.len(), 1);
+    }
+
+    #[test]
+    fn catalog_import_is_pinned_before_capacity_eviction() {
+        let registry = PluginRegistry::with_options_and_cache(
+            DEFAULT_PIPELINE_FUEL,
+            PipelineLimits::default(),
+            ExecutorConfig::default(),
+            Some(1),
+        )
+        .unwrap();
+        let bytes = component();
+        let digest = hex::encode(Sha256::digest(&bytes));
+        registry.import("pinned", &bytes).unwrap();
+
+        assert!(registry.cached_engine(&digest).is_some());
+        assert_eq!(registry.list().len(), 1);
+        assert!(registry.state.read().unwrap().cache_weight > 1);
+    }
+
+    #[test]
+    fn catalog_remove_evicts_engine_after_its_last_pin_disappears() {
+        let registry = PluginRegistry::with_options_and_cache(
+            DEFAULT_PIPELINE_FUEL,
+            PipelineLimits::default(),
+            ExecutorConfig::default(),
+            Some(1),
+        )
+        .unwrap();
+        let bytes = component();
+        let digest = hex::encode(Sha256::digest(&bytes));
+        let plugin = registry.import("temporary", &bytes).unwrap();
+        assert!(registry.cached_engine(&digest).is_some());
+
+        assert!(registry.remove(&plugin.id));
+        assert!(registry.cached_engine(&digest).is_none());
+        let state = registry.state.read().unwrap();
+        assert_eq!(state.cache_weight, 0);
+        assert!(state.cache_order.is_empty());
     }
 
     #[test]
@@ -1625,6 +1841,65 @@ mod tests {
         assert_eq!(output[0], Record::new("tailb1", ""));
         assert_eq!(output[1], Record::new("last", ""));
         assert_eq!(*calls.lock().unwrap(), ["a:finish", "b:tail", "b:finish"]);
+    }
+
+    #[test]
+    fn finish_fuel_is_included_in_the_reported_total() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut filter = fake("fuel", calls);
+        filter.finish_fuel = 17;
+        let (_, fuel) = fake_pipeline(vec![filter], PipelineLimits::default())
+            .finish_with_fuel()
+            .unwrap();
+        assert_eq!(fuel, 17);
+    }
+
+    #[test]
+    fn malformed_transform_output_is_rejected_before_it_reaches_a_sink() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut filter = fake("malformed", calls);
+        filter.emit = Some(br#"{"unterminated":"#.to_vec());
+        let mut pipeline = fake_pipeline(vec![filter], PipelineLimits::default());
+        pipeline.output_validator = OutputValidator::new(
+            crate::Format::Jsonl,
+            crate::record::DecoderLimits::default(),
+        )
+        .unwrap();
+
+        let error = pipeline
+            .process(Record::new(br#"{"source":true}"#.to_vec(), "\n"))
+            .unwrap_err();
+        assert_eq!(error.code(), codes::DECODE_INVALID_OUTPUT);
+    }
+
+    #[test]
+    fn aggregate_transform_and_finish_json_is_rejected_before_commit() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut filter = fake("aggregate", calls);
+        filter.emit = Some(br#"{"transform":true}"#.to_vec());
+        filter.finish = br#"{"finish":true}"#.to_vec();
+        let mut pipeline = fake_pipeline(vec![filter], PipelineLimits::default());
+        pipeline.output_validator =
+            OutputValidator::new(crate::Format::Json, crate::record::DecoderLimits::default())
+                .unwrap();
+
+        assert!(pipeline.process(Record::new("source", "")).is_ok());
+        assert_eq!(
+            pipeline.finish().unwrap_err().code(),
+            codes::DECODE_INVALID_OUTPUT
+        );
+    }
+
+    #[test]
+    fn complete_eight_mibibyte_record_bypasses_only_transport_frame_limit() {
+        let mut pipeline = fake_pipeline(Vec::new(), PipelineLimits::default());
+        let payload = vec![b'x'; crate::record::DEFAULT_MAX_RECORD_BYTES];
+        let output = pipeline
+            .process(Record::new(payload.clone(), "\n"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(output.payload.len(), payload.len());
+        assert!(pipeline.finish().unwrap().is_empty());
     }
 
     #[test]
@@ -2030,6 +2305,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn snapshot_for_rejects_all_disabled_chain_without_explicit_passthrough() {
+        let registry = PluginRegistry::new();
+        let resolution = PipelineResolution {
+            locator: crate::pipeline::PipelineLocator {
+                revision: "test".to_string(),
+                fingerprint: "deadbeef".to_string(),
+            },
+            steps: vec![PipelineStep {
+                component_hash: "unavailable-disabled-component".to_string(),
+                enabled: false,
+                version: None,
+                config_json: None,
+                capabilities: PluginCapabilities::default(),
+                sensitive_grant: SensitiveGrant::NONE,
+            }],
+            explicit_passthrough: false,
+            limits: PipelineLimits::default(),
+        };
+        let error = registry
+            .snapshot_for(&resolution, &registry)
+            .await
+            .err()
+            .expect("all-disabled pipeline without pass-through must fail");
+        assert_eq!(error.code(), codes::CONFIG_INVALID);
+    }
+
+    #[tokio::test]
     async fn snapshot_for_accepts_explicit_passthrough() {
         let registry = PluginRegistry::new();
         let resolution = PipelineResolution {
@@ -2049,13 +2351,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolved_limits_cannot_raise_registry_deployment_limits() {
+        let deployment_limits = PipelineLimits {
+            max_output_bytes: 128,
+            max_cumulative_fuel: 256,
+            ..PipelineLimits::default()
+        };
+        let registry = PluginRegistry::with_options(
+            DEFAULT_PIPELINE_FUEL,
+            deployment_limits,
+            ExecutorConfig::default(),
+        )
+        .unwrap();
+        let resolution = PipelineResolution {
+            locator: crate::pipeline::PipelineLocator {
+                revision: "test".to_string(),
+                fingerprint: "deadbeef".to_string(),
+            },
+            steps: Vec::new(),
+            explicit_passthrough: true,
+            limits: PipelineLimits::default(),
+        };
+
+        let snapshot = registry.snapshot_for(&resolution, &registry).await.unwrap();
+        assert_eq!(snapshot.limits.max_output_bytes, 128);
+        assert_eq!(snapshot.limits.max_cumulative_fuel, 256);
+    }
+
+    #[tokio::test]
     async fn snapshot_for_verifies_digest_after_component_source_fetch() {
         let registry = PluginRegistry::new();
         let step = PipelineStep {
             component_hash: "bogus-not-a-real-sha256".to_string(),
+            enabled: true,
             version: None,
             config_json: None,
             capabilities: PluginCapabilities::default(),
+            sensitive_grant: SensitiveGrant::NONE,
         };
         let resolution = PipelineResolution {
             locator: crate::pipeline::PipelineLocator {
@@ -2113,9 +2445,11 @@ mod tests {
         let digest = hex::encode(Sha256::digest(&bytes));
         let step = PipelineStep {
             component_hash: digest,
+            enabled: true,
             version: Some("1.0.0".to_string()),
             config_json: None,
             capabilities: PluginCapabilities::default(),
+            sensitive_grant: SensitiveGrant::NONE,
         };
         let resolution = PipelineResolution {
             locator: crate::pipeline::PipelineLocator {
@@ -2139,6 +2473,47 @@ mod tests {
         );
         let cached = registry.cached_engine(&resolution.steps[0].component_hash);
         assert!(cached.is_some(), "compiled engine must be cached");
+    }
+
+    #[tokio::test]
+    async fn resolved_step_applies_its_config_and_explicit_sensitive_grant() {
+        let registry = PluginRegistry::new();
+        let bytes = component_v02();
+        let digest = hex::encode(Sha256::digest(&bytes));
+        let resolution = PipelineResolution {
+            locator: crate::pipeline::PipelineLocator {
+                revision: "configured".to_string(),
+                fingerprint: "configured-fingerprint".to_string(),
+            },
+            steps: vec![PipelineStep {
+                component_hash: digest,
+                enabled: true,
+                version: Some("0.2.0".to_string()),
+                config_json: Some(r#"{"region":"eu"}"#.to_string()),
+                capabilities: PluginCapabilities::default(),
+                sensitive_grant: SensitiveGrant::NONE,
+            }],
+            explicit_passthrough: false,
+            limits: PipelineLimits::default(),
+        };
+        let source = StaticComponentSource {
+            bytes: Arc::new(bytes),
+        };
+        let snapshot = registry.snapshot_for(&resolution, &source).await.unwrap();
+        let mut request = session();
+        request.operation = s4_wasm_runtime::Operation::Read;
+        request.content_type = "test/require-step-context".to_string();
+        request.public_key_pem = Some("must-not-be-shared".to_string());
+        request.stable_key = Some(vec![7; 32]);
+        request.stable_fields = Some("email".to_string());
+
+        let mut pipeline = snapshot
+            .start_session(&request, CancellationToken::new())
+            .unwrap();
+        assert_eq!(
+            pipeline.process(Record::new("payload", "")).unwrap(),
+            Some(Record::new("payload", ""))
+        );
     }
 
     struct StaticComponentSource {

--- a/crates/gateway/src/record.rs
+++ b/crates/gateway/src/record.rs
@@ -460,47 +460,90 @@ fn validate_utf8(input: &[u8], code: &'static str) -> Result<(), S4Error> {
         .map_err(|error| S4Error::new(code, error.to_string()))
 }
 
-/// Validates a complete set of output records against the selected record
-/// format before they are committed downstream.
-///
-/// Custom filter components are untrusted: their `Emit` and `finish` output
-/// must still form a well-formed record stream in the target format. Re-decoding
-/// the output with a fresh [`RecordDecoder`] proves structure and encoding
-/// (UTF-8, JSON documents, CSV fields, line/TSV framing) without ever
-/// committing malformed data.
+/// Stateful validator for the aggregate byte stream emitted by an untrusted
+/// pipeline. One instance spans every transform and finish record so framing
+/// errors that cross record boundaries cannot be hidden by per-record parsing.
+#[derive(Debug)]
+pub struct OutputValidator {
+    format: Format,
+    decoder: RecordDecoder,
+    max_frame_bytes: usize,
+    input_seen: bool,
+    finished: bool,
+}
+
+impl OutputValidator {
+    pub fn new(format: Format, limits: DecoderLimits) -> Result<Self, S4Error> {
+        let decoder = RecordDecoder::new(format, limits)?;
+        Ok(Self {
+            format,
+            decoder,
+            max_frame_bytes: limits.max_source_frame_bytes,
+            input_seen: false,
+            finished: false,
+        })
+    }
+
+    pub fn push_record(&mut self, record: &Record) -> Result<(), S4Error> {
+        if self.finished {
+            return Err(S4Error::new(
+                codes::INTERNAL,
+                "cannot validate output after finish",
+            ));
+        }
+        self.push_bytes(&record.payload)?;
+        self.push_bytes(&record.separator)
+    }
+
+    pub fn finish(&mut self) -> Result<(), S4Error> {
+        if self.finished {
+            return Ok(());
+        }
+        self.finished = true;
+        // A pipeline may legitimately drop every record. In particular, an
+        // empty CSV output is valid even though an empty CSV source is not.
+        if !self.input_seen {
+            return Ok(());
+        }
+        self.decoder.finish()?;
+        self.drain_records()
+    }
+
+    fn push_bytes(&mut self, bytes: &[u8]) -> Result<(), S4Error> {
+        self.input_seen |= !bytes.is_empty();
+        // `max_source_frame_bytes` bounds transport chunks, not complete
+        // records. Feed large final records incrementally while retaining the
+        // independent record/document limits inside RecordDecoder.
+        for chunk in bytes.chunks(self.max_frame_bytes) {
+            self.decoder.push(chunk)?;
+            self.drain_records()?;
+        }
+        Ok(())
+    }
+
+    fn drain_records(&mut self) -> Result<(), S4Error> {
+        while let Some(record) = self.decoder.next_record()? {
+            if self.format == Format::Jsonl {
+                validate_utf8(&record.payload, codes::DECODE_ENCODING)?;
+                serde_json::from_slice::<serde_json::Value>(&record.payload)
+                    .map_err(|error| S4Error::new(codes::DECODE_JSONL, error.to_string()))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Validates a complete set of output records as one aggregate output stream.
 pub fn validate_output_records(
     format: Format,
     records: &[Record],
     limits: DecoderLimits,
 ) -> Result<(), S4Error> {
-    // A pipeline may legitimately drop every record (e.g. PII redaction on an
-    // empty or all-sensitive stream); empty output is always well-formed.
-    if records.is_empty() {
-        return Ok(());
-    }
-    let mut decoder = RecordDecoder::new(format, limits)?;
+    let mut validator = OutputValidator::new(format, limits)?;
     for record in records {
-        if !record.payload.is_empty() {
-            decoder.push(&record.payload)?;
-            while decoder.next_record()?.is_some() {}
-        }
-        if !record.separator.is_empty() {
-            decoder.push(&record.separator)?;
-            while decoder.next_record()?.is_some() {}
-        }
+        validator.push_record(record)?;
     }
-    decoder.finish()?;
-    while decoder.next_record()?.is_some() {}
-    // The line decoder validates framing and UTF-8 but not per-line JSON
-    // structure; prove JSONL/JSON documents parse before commit.
-    if format == Format::Jsonl {
-        for record in records {
-            validate_utf8(&record.payload, codes::DECODE_ENCODING)?;
-            serde_json::from_slice::<serde_json::Value>(&record.payload)
-                .map_err(|error| S4Error::new(codes::DECODE_JSONL, error.to_string()))?;
-        }
-    }
-    Ok(())
+    validator.finish()
 }
 
 fn limit_error(code: &'static str, kind: &str, actual: usize, limit: usize) -> S4Error {
@@ -593,6 +636,81 @@ mod tests {
                 .unwrap_err()
                 .code(),
             codes::DECODE_JSON
+        );
+    }
+
+    #[test]
+    fn output_validator_accepts_complete_records_larger_than_transport_frames() {
+        let limits = DecoderLimits::default();
+        let payload = vec![b'x'; DEFAULT_MAX_RECORD_BYTES];
+        validate_output_records(
+            Format::Text,
+            &[Record::new(payload, Bytes::from_static(b"\n"))],
+            limits,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn output_validator_enforces_aggregate_json_framing() {
+        let records = [
+            Record::new(br#"{"transform":true}"#.to_vec(), Bytes::new()),
+            Record::new(br#"{"finish":true}"#.to_vec(), Bytes::new()),
+        ];
+        assert_eq!(
+            validate_output_records(Format::Json, &records, DecoderLimits::default())
+                .unwrap_err()
+                .code(),
+            codes::DECODE_JSON
+        );
+    }
+
+    #[test]
+    fn output_validator_tracks_jsonl_and_csv_framing_across_records() {
+        validate_output_records(
+            Format::Jsonl,
+            &[
+                Record::new(br#"{"split":"#.to_vec(), Bytes::new()),
+                Record::new(br#"true}"#.to_vec(), Bytes::from_static(b"\n")),
+            ],
+            DecoderLimits::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            validate_output_records(
+                Format::Jsonl,
+                &[
+                    Record::new(br#"{"first":true}"#.to_vec(), Bytes::new()),
+                    Record::new(br#"{"second":true}"#.to_vec(), Bytes::from_static(b"\n"),),
+                ],
+                DecoderLimits::default(),
+            )
+            .unwrap_err()
+            .code(),
+            codes::DECODE_JSONL
+        );
+
+        validate_output_records(
+            Format::Csv,
+            &[
+                Record::new(b"\"quoted".to_vec(), Bytes::new()),
+                Record::new(b"\nfield\",tail".to_vec(), Bytes::from_static(b"\n")),
+            ],
+            DecoderLimits::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            validate_output_records(
+                Format::Csv,
+                &[
+                    Record::new(b"\"closed\"".to_vec(), Bytes::new()),
+                    Record::new(b"garbage".to_vec(), Bytes::from_static(b"\n")),
+                ],
+                DecoderLimits::default(),
+            )
+            .unwrap_err()
+            .code(),
+            codes::DECODE_CSV
         );
     }
 }

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -80,10 +80,10 @@ use crate::transaction::{
     AbortSignal, AwsS3TransactionBackend, BackendCapabilities, CompatibilitySpoolConfig,
     CompatibilitySpoolTransaction, CompletionReconciliation, ConditionalReadCapability,
     DirectOperationScope, DirectS3Sink, EvidenceRecord, ExpectedObject, IncompleteUploadDiscovery,
-    ListCapability, MemorySinkTransaction, MultipartResponseCapability, ObjectDestination,
-    ObjectSinkTransaction, OperationJournal, OperationReconciler, OperationRecord, OperationState,
-    ResponseChecksumCapability, SpoolQuota, StoredObjectMeta, TransactionError,
-    VersioningCapability,
+    JournalError, ListCapability, MemorySinkTransaction, MultipartResponseCapability,
+    ObjectDestination, ObjectSinkTransaction, OperationJournal, OperationReconciler,
+    OperationRecord, OperationState, ResponseChecksumCapability, SpoolQuota, StoredObjectMeta,
+    TransactionError, VersioningCapability,
 };
 use crate::workspace_storage::{
     BackendConfigRequest, BackendConfigResponse, BackendType, WorkspaceId, WorkspaceStorageError,
@@ -165,6 +165,13 @@ struct OperationUsage<'a> {
 #[derive(Clone, Copy)]
 struct AuthorizedOperation<'a> {
     auth: &'a Auth,
+    authorization: &'a UsageAuthorization,
+    receipt_id: Uuid,
+}
+
+#[derive(Clone, Copy)]
+struct AuthorizedUsage<'a> {
+    operation: OperationIdentity,
     authorization: &'a UsageAuthorization,
 }
 
@@ -322,6 +329,26 @@ async fn record_operation_with_event(
     record_usage(control, context, &event, key).await
 }
 
+async fn record_durable_operation_with_event(
+    journal: Option<&Arc<dyn OperationJournal>>,
+    control: Arc<dyn ControlPlane>,
+    context: &AuthenticatedRequestContext,
+    event: UsageEvent,
+    key: &str,
+) -> Result<(), axum::response::Response> {
+    persist_usage_evidence(journal, &event)
+        .await
+        .map_err(|error| {
+            warn!(
+                operation_id = %event.operation_id,
+                error = %error,
+                "failed to persist usage evidence"
+            );
+            s3_error::service_unavailable(key, "Usage evidence could not be persisted.")
+        })?;
+    record_operation_with_event(control, context, event, key).await
+}
+
 fn multipart_completion_event(
     authorization: &UsageAuthorization,
     result: &MultipartCompletionResult,
@@ -342,44 +369,118 @@ fn multipart_completion_event(
     }
 }
 
-/// Persist the canonical usage event as durable journal evidence before the
-/// control-plane receipt is recorded. If the receipt write fails after a
-/// storage commit (503) or the process dies in that window, the hosted control
-/// plane can later reconcile the committed operation from this evidence.
-async fn persist_usage_evidence(journal: Option<&Arc<dyn OperationJournal>>, event: &UsageEvent) {
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+struct DurableUsageEvidence {
+    receipt_id: Uuid,
+    source_bytes: u64,
+    output_bytes: u64,
+    processed_bytes: u64,
+    route: String,
+    kind: String,
+    bucket: String,
+    #[serde(default)]
+    pipeline_evidence: Option<crate::control::PipelineEvidence>,
+}
+
+impl From<&UsageEvent> for DurableUsageEvidence {
+    fn from(event: &UsageEvent) -> Self {
+        Self {
+            receipt_id: event.id,
+            source_bytes: event.source_bytes,
+            output_bytes: event.output_bytes,
+            processed_bytes: event.processed_bytes,
+            route: event.route.as_str().to_string(),
+            kind: event.kind.as_str().to_string(),
+            bucket: event.bucket.clone(),
+            pipeline_evidence: event.pipeline_evidence.clone(),
+        }
+    }
+}
+
+fn usage_evidence_id(receipt_id: Uuid) -> Uuid {
+    Uuid::new_v5(&Uuid::NAMESPACE_OID, receipt_id.as_bytes())
+}
+
+/// Persist the complete canonical usage event before entering a provider
+/// commit window. Exact retries use one deterministic evidence identity.
+async fn persist_usage_evidence(
+    journal: Option<&Arc<dyn OperationJournal>>,
+    event: &UsageEvent,
+) -> Result<(), JournalError> {
     let Some(journal) = journal else {
-        return;
+        return Ok(());
     };
-    let evidence = EvidenceRecord::new(
+    // A process may have a Postgres journal because DATABASE_URL is set while
+    // writing to the development memory sink. That sink has no operation row;
+    // skip evidence rather than violating the evidence foreign key.
+    if journal.get(event.operation_id).await?.is_none() {
+        return Ok(());
+    }
+    append_usage_evidence(journal, event).await
+}
+
+async fn persist_transaction_usage_evidence(
+    journal: Option<&Arc<dyn OperationJournal>>,
+    durable_operation_id: Option<Uuid>,
+    event: &UsageEvent,
+) -> Result<(), JournalError> {
+    let Some(durable_operation_id) = durable_operation_id else {
+        return Ok(());
+    };
+    if durable_operation_id != event.operation_id {
+        return Err(JournalError::Corrupt(
+            "sink operation does not match usage evidence operation".to_string(),
+        ));
+    }
+    let journal = journal.ok_or_else(|| {
+        JournalError::Persistence("durable sink has no operation journal".to_string())
+    })?;
+    if journal.get(durable_operation_id).await?.is_none() {
+        return Err(JournalError::Corrupt(format!(
+            "durable sink operation {durable_operation_id} has no journal intent"
+        )));
+    }
+    append_usage_evidence(journal, event).await
+}
+
+async fn append_usage_evidence(
+    journal: &Arc<dyn OperationJournal>,
+    event: &UsageEvent,
+) -> Result<(), JournalError> {
+    let mut evidence = EvidenceRecord::new(
         event.operation_id,
         "usage",
-        serde_json::json!({
-            "receipt_id": event.id,
-            "source_bytes": event.source_bytes,
-            "output_bytes": event.output_bytes,
-            "processed_bytes": event.processed_bytes,
-            "route": event.route.as_str(),
-            "kind": event.kind.as_str(),
-            "bucket": &event.bucket,
-            "pipeline_evidence": event.pipeline_evidence.as_ref().map(|evidence| {
-                serde_json::json!({
-                    "revision": evidence.revision,
-                    "fingerprint": evidence.fingerprint,
-                    "components": evidence.components,
-                    "fuel_consumed": evidence.fuel_consumed,
-                    "duration_ms": evidence.duration_ms,
-                    "spool_mode": evidence.spool_mode,
-                })
-            }),
-        }),
+        serde_json::to_value(DurableUsageEvidence::from(event))
+            .map_err(|error| JournalError::Persistence(error.to_string()))?,
     );
-    if let Err(error) = journal.append_evidence(evidence).await {
-        warn!(
-            operation_id = %event.operation_id,
-            error = %error,
-            "failed to persist usage evidence"
-        );
+    evidence.id = usage_evidence_id(event.id);
+    journal.append_evidence(evidence).await
+}
+
+async fn load_usage_evidence(
+    journal: &Arc<dyn OperationJournal>,
+    operation_id: Uuid,
+    receipt_id: Uuid,
+) -> Result<DurableUsageEvidence, JournalError> {
+    let expected_id = usage_evidence_id(receipt_id);
+    let record = journal
+        .evidence(operation_id)
+        .await?
+        .into_iter()
+        .find(|record| record.id == expected_id && record.kind == "usage")
+        .ok_or_else(|| {
+            JournalError::Corrupt(format!(
+                "operation {operation_id} is missing deterministic usage evidence"
+            ))
+        })?;
+    let evidence: DurableUsageEvidence = serde_json::from_value(record.detail)
+        .map_err(|error| JournalError::Corrupt(error.to_string()))?;
+    if evidence.receipt_id != receipt_id {
+        return Err(JournalError::Corrupt(format!(
+            "operation {operation_id} usage evidence has the wrong receipt"
+        )));
     }
+    Ok(evidence)
 }
 
 fn admitted_response_bytes(response: &axum::response::Response) -> Option<u64> {
@@ -2417,7 +2518,13 @@ async fn demo_process(
                 "Demo input exceeds 64 KiB",
             );
         }
-        canonical_records.push(crate::record::Record::new(canonical, bytes::Bytes::new()));
+        // Demo records are returned as independent values rather than one
+        // concatenated JSON document. Model that framing explicitly as JSONL
+        // while the pipeline runs, then strip the known separator below.
+        canonical_records.push(crate::record::Record::new(
+            canonical,
+            bytes::Bytes::from_static(b"\n"),
+        ));
     }
 
     let snapshot = match demo_pipeline(&state, mode) {
@@ -2435,8 +2542,8 @@ async fn demo_process(
         DemoMode::Join => Some(demo_request_stable_key()),
     };
     let session = s4_wasm_runtime::Session {
-        format: Format::Json.as_str().to_string(),
-        content_type: "application/json".to_string(),
+        format: Format::Jsonl.as_str().to_string(),
+        content_type: "application/x-ndjson".to_string(),
         policy_version: 0,
         operation: s4_wasm_runtime::Operation::Write,
         config_json: None,
@@ -2459,7 +2566,7 @@ async fn demo_process(
     let mut output_bytes = 0usize;
     let mut processed = Vec::with_capacity(output.len());
     for (index, record) in output.into_iter().enumerate() {
-        if !record.separator.is_empty() {
+        if record.separator.as_ref() != b"\n" {
             return demo_error(
                 StatusCode::UNPROCESSABLE_ENTITY,
                 "pipeline_failed",
@@ -2845,7 +2952,7 @@ async fn streaming_single_put(
     state: &AppState,
     mut authentication: HeaderAuthentication,
     backend: ResolvedBackend,
-    authorization: &UsageAuthorization,
+    usage: AuthorizedUsage<'_>,
     headers: &HeaderMap,
     mut body: axum::body::Body,
     key: &str,
@@ -2861,6 +2968,8 @@ async fn streaming_single_put(
 > {
     use http_body_util::BodyExt as _;
     use sha2::Digest as _;
+    let authorization = usage.authorization;
+    let receipt_id = usage.operation.receipt_id;
 
     if authentication.body_verifier.is_none() && headers.contains_key(header::CONTENT_ENCODING) {
         return Err(StreamingPutError::InvalidRequest(
@@ -2877,7 +2986,7 @@ async fn streaming_single_put(
             state,
             authentication,
             backend,
-            authorization,
+            usage,
             headers,
             body,
             key,
@@ -2891,6 +3000,7 @@ async fn streaming_single_put(
         AuthorizedOperation {
             auth: &authentication.auth,
             authorization,
+            receipt_id,
         },
         authorization.bucket(),
         key,
@@ -3023,6 +3133,25 @@ async fn streaming_single_put(
         let output_digest = hex::encode(output_hasher.finalize());
         let mut sink = sink.lock().await;
         sink.verify_output(output_bytes, &output_digest).await?;
+        let mut usage_event = UsageEvent::new(
+            receipt_id,
+            authorization.operation_id(),
+            authorization.bucket(),
+            authorization.kind(),
+            authorization.route(),
+            input_bytes,
+            output_bytes,
+        );
+        if let Some(evidence) = &pipeline_evidence {
+            usage_event = usage_event.with_pipeline_evidence(evidence.clone());
+        }
+        persist_transaction_usage_evidence(
+            state.operation_journal.as_ref(),
+            sink.durable_operation_id(),
+            &usage_event,
+        )
+        .await
+        .map_err(TransactionError::from)?;
         let stored = sink.complete().await?;
         Ok((stored, output_bytes, pipeline_evidence))
     }
@@ -3122,7 +3251,7 @@ async fn streaming_avro_single_put(
     state: &AppState,
     mut authentication: HeaderAuthentication,
     backend: ResolvedBackend,
-    authorization: &UsageAuthorization,
+    usage: AuthorizedUsage<'_>,
     headers: &HeaderMap,
     mut body: axum::body::Body,
     key: &str,
@@ -3138,6 +3267,8 @@ async fn streaming_avro_single_put(
 > {
     use http_body_util::BodyExt as _;
     use sha2::Digest as _;
+    let authorization = usage.authorization;
+    let receipt_id = usage.operation.receipt_id;
 
     let content_type = headers
         .get(header::CONTENT_TYPE)
@@ -3199,6 +3330,7 @@ async fn streaming_avro_single_put(
         AuthorizedOperation {
             auth: &authentication.auth,
             authorization,
+            receipt_id,
         },
         authorization.bucket(),
         key,
@@ -3211,6 +3343,22 @@ async fn streaming_avro_single_put(
         let mut sink = sink_guard.sink.lock().await;
         sink.write(bytes::Bytes::from(output)).await?;
         sink.verify_output(output_bytes, &digest).await?;
+        let usage_event = UsageEvent::new(
+            receipt_id,
+            authorization.operation_id(),
+            authorization.bucket(),
+            authorization.kind(),
+            authorization.route(),
+            input_bytes,
+            output_bytes,
+        );
+        persist_transaction_usage_evidence(
+            state.operation_journal.as_ref(),
+            sink.durable_operation_id(),
+            &usage_event,
+        )
+        .await
+        .map_err(TransactionError::from)?;
         sink.complete().await?
     };
     sink_guard.disarm();
@@ -3917,6 +4065,27 @@ async fn complete_staged_multipart(
         renew_and_fence_completion(staging, identity, lease).await?;
         sink.verify_output(output_bytes, &checksum_sha256).await?;
         renew_and_fence_completion(staging, identity, lease).await?;
+        let precommit_result = MultipartCompletionResult {
+            etag: None,
+            checksum_sha256: checksum_sha256.clone(),
+            version_id: None,
+            source_bytes: input_bytes,
+            size_bytes: output_bytes,
+            pipeline_evidence: pipeline_evidence.clone(),
+        };
+        persist_transaction_usage_evidence(
+            state.operation_journal.as_ref(),
+            sink.durable_operation_id(),
+            &multipart_completion_event(
+                operation.authorization,
+                &precommit_result,
+                operation.receipt_id,
+            ),
+        )
+        .await
+        .map_err(TransactionError::from)
+        .map_err(StreamingPutError::from)?;
+        renew_and_fence_completion(staging, identity, lease).await?;
         let stored = sink.complete().await?;
         let result = MultipartCompletionResult {
             etag: stored.etag,
@@ -4061,10 +4230,21 @@ async fn reconcile_existing_direct_completion(
     })
 }
 
-fn recovered_multipart_result(
+async fn recovered_multipart_result(
+    journal: Option<&Arc<dyn OperationJournal>>,
     operation: OperationRecord,
     lease: &CompletionLease,
+    receipt_id: Uuid,
 ) -> Result<MultipartCompletionResult, MultipartCompletionError> {
+    let journal = journal.ok_or_else(|| {
+        MultipartCompletionError::Invalid(
+            "committed direct operation has no durable journal".to_string(),
+        )
+    })?;
+    let durable = load_usage_evidence(journal, operation.id, receipt_id)
+        .await
+        .map_err(TransactionError::from)
+        .map_err(StreamingPutError::from)?;
     let stored = operation.committed.ok_or_else(|| {
         MultipartCompletionError::Invalid(
             "committed direct operation is missing destination metadata".to_string(),
@@ -4087,13 +4267,24 @@ fn recovered_multipart_result(
         .ok_or_else(|| {
             MultipartCompletionError::Invalid("multipart source size overflow".to_string())
         })?;
+    if durable.source_bytes != source_bytes
+        || durable.output_bytes != size_bytes
+        || durable.processed_bytes != source_bytes.max(size_bytes)
+        || durable.bucket != operation.destination.bucket
+        || durable.route != UsageRoute::CompleteMultipartUpload.as_str()
+        || durable.kind != RequestKind::Write.as_str()
+    {
+        return Err(MultipartCompletionError::Invalid(
+            "committed direct operation usage evidence does not match recovery state".to_string(),
+        ));
+    }
     Ok(MultipartCompletionResult {
         etag: stored.etag,
         checksum_sha256,
         version_id: stored.version_id,
         source_bytes,
         size_bytes,
-        pipeline_evidence: None,
+        pipeline_evidence: durable.pipeline_evidence,
     })
 }
 
@@ -4181,6 +4372,27 @@ async fn complete_staged_avro_multipart(
         renew_and_fence_completion(staging, identity, lease).await?;
         sink.write(bytes::Bytes::from(output)).await?;
         sink.verify_output(output_bytes, &output_digest).await?;
+        renew_and_fence_completion(staging, identity, lease).await?;
+        let precommit_result = MultipartCompletionResult {
+            etag: None,
+            checksum_sha256: output_digest.clone(),
+            version_id: None,
+            source_bytes: input_bytes,
+            size_bytes: output_bytes,
+            pipeline_evidence: None,
+        };
+        persist_transaction_usage_evidence(
+            state.operation_journal.as_ref(),
+            sink.durable_operation_id(),
+            &multipart_completion_event(
+                operation.authorization,
+                &precommit_result,
+                operation.receipt_id,
+            ),
+        )
+        .await
+        .map_err(TransactionError::from)
+        .map_err(StreamingPutError::from)?;
         renew_and_fence_completion(staging, identity, lease).await?;
         let stored = sink.complete().await?;
         let result = MultipartCompletionResult {
@@ -4618,7 +4830,10 @@ async fn s3_put(
         &state,
         header_auth,
         backend,
-        &authorization,
+        AuthorizedUsage {
+            operation,
+            authorization: &authorization,
+        },
         &parts.headers,
         request_body,
         &key,
@@ -4636,7 +4851,6 @@ async fn s3_put(
                 Some(evidence) => usage.event().with_pipeline_evidence(evidence),
                 None => usage.event(),
             };
-            persist_usage_evidence(state.operation_journal.as_ref(), &event).await;
             if let Err(response) =
                 record_operation_with_event(state.control.clone(), &auth.context, event, &key).await
             {
@@ -5071,7 +5285,7 @@ async fn process_transformed_source<F, Fut>(
     format: Format,
     max_source_frame_bytes: usize,
     mut emit: F,
-) -> Result<(), TransformedReadError>
+) -> Result<u64, TransformedReadError>
 where
     F: FnMut(bytes::Bytes) -> Fut,
     Fut: std::future::Future<Output = Result<(), TransformedReadError>>,
@@ -5119,7 +5333,8 @@ where
                 }
             }
         }
-        for record in pipeline.finish().await?.0 {
+        let (records, fuel_consumed) = pipeline.finish().await?;
+        for record in records {
             if !record.payload.is_empty() {
                 emit(record.payload).await?;
             }
@@ -5127,7 +5342,7 @@ where
                 emit(record.separator).await?;
             }
         }
-        Ok(())
+        Ok(fuel_consumed)
     }
     .await;
     if result.is_err() {
@@ -5141,7 +5356,23 @@ where
 enum DirectReadEvent {
     Data(bytes::Bytes),
     Failed(TransformedReadError),
-    Done,
+    Done {
+        fuel_consumed: u64,
+        duration_ms: u64,
+    },
+}
+
+fn direct_read_done_evidence(
+    snapshot: &PipelineSnapshot,
+    event: &DirectReadEvent,
+) -> Option<crate::control::PipelineEvidence> {
+    match event {
+        DirectReadEvent::Done {
+            fuel_consumed,
+            duration_ms,
+        } => snapshot.pipeline_evidence(*fuel_consumed, *duration_ms, "none"),
+        DirectReadEvent::Data(_) | DirectReadEvent::Failed(_) => None,
+    }
 }
 
 struct DirectReadBody {
@@ -5171,9 +5402,17 @@ impl http_body::Body for DirectReadBody {
                 self.done = true;
                 std::task::Poll::Ready(Some(Err(std::io::Error::other(error_to_log(&error)))))
             }
-            std::task::Poll::Ready(Some(DirectReadEvent::Done)) | std::task::Poll::Ready(None) => {
+            std::task::Poll::Ready(Some(DirectReadEvent::Done { .. })) => {
                 self.done = true;
                 std::task::Poll::Ready(None)
+            }
+            std::task::Poll::Ready(None) => {
+                self.done = true;
+                self.source_cancellation.cancel();
+                self.pipeline_cancellation.cancel();
+                std::task::Poll::Ready(Some(Err(std::io::Error::other(
+                    "transformed read worker terminated unexpectedly",
+                ))))
             }
             std::task::Poll::Pending => std::task::Poll::Pending,
         }
@@ -5199,6 +5438,22 @@ fn error_to_log(error: &TransformedReadError) -> String {
     }
 }
 
+fn direct_read_worker_terminated(
+    key: &str,
+    source_cancellation: &s4_wasm_runtime::CancellationToken,
+    pipeline_cancellation: &s4_wasm_runtime::CancellationToken,
+) -> axum::response::Response {
+    source_cancellation.cancel();
+    pipeline_cancellation.cancel();
+    transformed_read_error_response(
+        key,
+        TransformedReadError::Pipeline(s4_error::S4Error::new(
+            s4_error::codes::INTERNAL,
+            "transformed read worker terminated unexpectedly",
+        )),
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn transformed_read_response(
     state: &AppState,
@@ -5212,7 +5467,7 @@ async fn transformed_read_response(
     pipeline_evidence: &mut Option<crate::control::PipelineEvidence>,
 ) -> (axum::response::Response, Option<u64>) {
     let (format, content_type) = preflight;
-    let pipeline_started = std::time::Instant::now();
+    *pipeline_evidence = None;
     let snapshot = match state
         .gateway
         .resolve_pipeline(
@@ -5230,10 +5485,7 @@ async fn transformed_read_response(
             );
         }
     };
-    if let Some(mut evidence) = snapshot.pipeline_evidence(0, 0, "none") {
-        evidence.duration_ms = pipeline_started.elapsed().as_millis() as u64;
-        *pipeline_evidence = Some(evidence);
-    }
+    let pipeline_started = std::time::Instant::now();
     let source_cancellation = object.cancellation.clone();
     let source_counters = object.counters.clone();
     let pipeline_cancellation = s4_wasm_runtime::CancellationToken::new();
@@ -5253,6 +5505,9 @@ async fn transformed_read_response(
         .iter()
         .all(|capabilities| capabilities.prefix_safe_for_read);
     if direct {
+        // The response body continues executing after this function returns,
+        // so final fuel and duration are not yet knowable. Leave evidence
+        // absent rather than attaching fabricated zero-valued measurements.
         let max_source_frame_bytes = state.source_body_limits.max_frame_bytes;
         let (sender, mut receiver) = tokio::sync::mpsc::channel(2);
         tokio::spawn(async move {
@@ -5277,7 +5532,10 @@ async fn transformed_read_response(
             )
             .await;
             let event = match result {
-                Ok(()) => DirectReadEvent::Done,
+                Ok(fuel_consumed) => DirectReadEvent::Done {
+                    fuel_consumed,
+                    duration_ms: pipeline_started.elapsed().as_millis() as u64,
+                },
                 Err(error) => DirectReadEvent::Failed(error),
             };
             let _ = sender.send(event).await;
@@ -5302,7 +5560,8 @@ async fn transformed_read_response(
                     None,
                 )
             }
-            Some(DirectReadEvent::Done) | None => {
+            Some(event @ DirectReadEvent::Done { .. }) => {
+                *pipeline_evidence = direct_read_done_evidence(&snapshot, &event);
                 let mut response = axum::response::Response::builder().status(StatusCode::OK);
                 response
                     .headers_mut()
@@ -5312,6 +5571,14 @@ async fn transformed_read_response(
                     response.body(axum::body::Body::empty()).unwrap(),
                     Some(source_counters.bytes()),
                 )
+            }
+            None => {
+                let response = direct_read_worker_terminated(
+                    key,
+                    &source_cancellation,
+                    &pipeline_cancellation,
+                );
+                (response, None)
             }
             Some(DirectReadEvent::Failed(error)) => {
                 (transformed_read_error_response(key, error), None)
@@ -5371,10 +5638,13 @@ async fn transformed_read_response(
     )
     .await;
     drop(spool_sender);
-    if let Err(error) = result {
-        let _ = spool_writer.await;
-        return (transformed_read_error_response(key, error), None);
-    }
+    let pipeline_fuel = match result {
+        Ok(fuel) => fuel,
+        Err(error) => {
+            let _ = spool_writer.await;
+            return (transformed_read_error_response(key, error), None);
+        }
+    };
     let spool = match spool_writer.await {
         Ok(Ok(spool)) => spool,
         Ok(Err(error)) => return (transformed_read_error_response(key, error), None),
@@ -5390,6 +5660,11 @@ async fn transformed_read_response(
             );
         }
     };
+    *pipeline_evidence = snapshot.pipeline_evidence(
+        pipeline_fuel,
+        pipeline_started.elapsed().as_millis() as u64,
+        "encrypted",
+    );
     let (body, content_length) = match spool.into_body(source_cancellation).await {
         Ok(result) => result,
         Err(error) => return (transformed_read_error_response(key, error.into()), None),
@@ -5893,6 +6168,25 @@ mod tests {
         assert!(validate_storage_boundary_startup(true, false, false).is_ok());
     }
 
+    async fn insert_test_usage_intent(journal: &Arc<dyn OperationJournal>, operation_id: Uuid) {
+        journal
+            .insert_intent(OperationRecord::direct_intent(
+                DirectOperationScope {
+                    operation_id,
+                    tenant_id: "workspace-test".to_string(),
+                },
+                ObjectDestination {
+                    backend_id: "test".to_string(),
+                    bucket: "bucket".to_string(),
+                    logical_key: "key".to_string(),
+                    physical_key: "key".to_string(),
+                },
+                ExpectedObject::default(),
+            ))
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn persist_usage_evidence_writes_durable_journal_record() {
         let journal: Arc<dyn OperationJournal> =
@@ -5906,7 +6200,10 @@ mod tests {
             64,
             32,
         );
-        persist_usage_evidence(Some(&journal), &event).await;
+        insert_test_usage_intent(&journal, event.operation_id).await;
+        persist_usage_evidence(Some(&journal), &event)
+            .await
+            .unwrap();
 
         let evidence = journal.evidence(event.operation_id).await.unwrap();
         assert_eq!(evidence.len(), 1);
@@ -5921,6 +6218,156 @@ mod tests {
         assert_eq!(evidence[0].detail["route"].as_str(), Some("PutObject"));
         assert_eq!(evidence[0].detail["kind"].as_str(), Some("write"));
         assert_eq!(evidence[0].detail["bucket"].as_str(), Some("bucket"));
+    }
+
+    #[tokio::test]
+    async fn precommit_usage_evidence_failure_is_not_suppressed() {
+        let concrete = Arc::new(crate::transaction::InMemoryOperationJournal::new());
+        concrete.fail_next_evidence_appends(1);
+        let journal: Arc<dyn OperationJournal> = concrete;
+        let event = UsageEvent::new(
+            Uuid::now_v7(),
+            Uuid::now_v7(),
+            "bucket",
+            RequestKind::Write,
+            UsageRoute::PutObject,
+            8,
+            8,
+        );
+        insert_test_usage_intent(&journal, event.operation_id).await;
+
+        assert!(
+            persist_usage_evidence(Some(&journal), &event)
+                .await
+                .is_err()
+        );
+        assert!(
+            journal
+                .evidence(event.operation_id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn postgres_journal_does_not_receive_evidence_for_dev_memory_sink() {
+        let concrete = Arc::new(crate::transaction::InMemoryOperationJournal::new());
+        // This models Postgres' evidence FK: any accidental append is a hard
+        // failure because a memory sink has no object_operations row.
+        concrete.fail_next_evidence_appends(1);
+        let journal: Arc<dyn OperationJournal> = concrete;
+        let sink = MemorySinkTransaction::new(
+            Arc::new(MemoryStore::new()),
+            "bucket",
+            "key",
+            "text/plain",
+            1024,
+        )
+        .unwrap();
+        let event = UsageEvent::new(
+            Uuid::now_v7(),
+            Uuid::now_v7(),
+            "bucket",
+            RequestKind::Write,
+            UsageRoute::PutObject,
+            8,
+            8,
+        );
+
+        persist_transaction_usage_evidence(Some(&journal), sink.durable_operation_id(), &event)
+            .await
+            .unwrap();
+        assert!(
+            journal
+                .evidence(event.operation_id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn multipart_crash_recovery_restores_exact_precommit_pipeline_evidence() {
+        let journal: Arc<dyn OperationJournal> =
+            Arc::new(crate::transaction::InMemoryOperationJournal::new());
+        let identity = multipart_completion_operation_identity("upload-a", "fingerprint-a");
+        let authorization = identity.authorization(
+            "bucket-a",
+            UsageRoute::CompleteMultipartUpload,
+            RequestKind::Write,
+            128,
+        );
+        let pipeline_evidence = crate::control::PipelineEvidence {
+            revision: "revision-a".to_string(),
+            fingerprint: "fingerprint-a".to_string(),
+            components: "component-a".to_string(),
+            fuel_consumed: 77,
+            duration_ms: 9,
+            spool_mode: "none".to_string(),
+        };
+        let precommit_result = MultipartCompletionResult {
+            etag: None,
+            checksum_sha256: "output-sha".to_string(),
+            version_id: None,
+            source_bytes: 32,
+            size_bytes: 24,
+            pipeline_evidence: Some(pipeline_evidence.clone()),
+        };
+        insert_test_usage_intent(&journal, identity.operation_id).await;
+        persist_usage_evidence(
+            Some(&journal),
+            &multipart_completion_event(&authorization, &precommit_result, identity.receipt_id),
+        )
+        .await
+        .unwrap();
+
+        let mut operation = OperationRecord::direct_intent(
+            DirectOperationScope {
+                operation_id: identity.operation_id,
+                tenant_id: "workspace-a".to_string(),
+            },
+            ObjectDestination {
+                backend_id: "S3".to_string(),
+                bucket: "bucket-a".to_string(),
+                logical_key: "key-a".to_string(),
+                physical_key: "key-a".to_string(),
+            },
+            ExpectedObject {
+                digest: Some("output-sha".to_string()),
+                size: Some(24),
+                metadata: Default::default(),
+            },
+        );
+        operation.state = OperationState::Committed;
+        operation.committed = Some(StoredObjectMeta {
+            etag: Some("\"etag-a\"".to_string()),
+            version_id: Some("version-a".to_string()),
+            ..StoredObjectMeta::default()
+        });
+        let lease = CompletionLease {
+            fencing_token: 1,
+            selected_parts: vec![MultipartPart {
+                upload_id: "upload-a".to_string(),
+                part_number: 1,
+                attempt: 1,
+                artifact_key: "artifact-a".to_string(),
+                etag: "\"part-a\"".to_string(),
+                checksum_sha256: "part-sha".to_string(),
+                size_bytes: 32,
+                created_at_ms: now_ms(),
+            }],
+            cleanup_parts: Vec::new(),
+        };
+
+        let recovered =
+            recovered_multipart_result(Some(&journal), operation, &lease, identity.receipt_id)
+                .await
+                .unwrap();
+        assert_eq!(recovered.pipeline_evidence, Some(pipeline_evidence));
+        assert_eq!(recovered.source_bytes, 32);
+        assert_eq!(recovered.size_bytes, 24);
+        assert_eq!(recovered.checksum_sha256, "output-sha");
     }
 
     #[tokio::test]
@@ -6116,6 +6563,7 @@ mod tests {
         let scope = direct_operation_scope(AuthorizedOperation {
             auth: &auth,
             authorization: &authorization,
+            receipt_id: operation.receipt_id,
         });
 
         assert_eq!(scope.operation_id, authorization.operation_id());
@@ -6125,6 +6573,8 @@ mod tests {
     #[tokio::test]
     async fn multipart_success_and_exact_replay_meter_with_one_stable_identity() {
         let control = Arc::new(RecordingControlPlane::default());
+        let journal: Arc<dyn OperationJournal> =
+            Arc::new(crate::transaction::InMemoryOperationJournal::new());
         let context = AuthenticatedRequestContext {
             user_id: "user-a".to_string(),
             workspace_id: crate::workspace_storage::WorkspaceId::new("workspace-a").unwrap(),
@@ -6136,29 +6586,45 @@ mod tests {
             RequestKind::Write,
             64,
         );
+        insert_test_usage_intent(&journal, operation.operation_id).await;
 
+        let result = MultipartCompletionResult {
+            etag: Some("\"etag\"".to_string()),
+            checksum_sha256: "sha".to_string(),
+            version_id: None,
+            source_bytes: 32,
+            size_bytes: 24,
+            pipeline_evidence: None,
+        };
         for _ in 0..2 {
-            record_operation(
+            record_durable_operation_with_event(
+                Some(&journal),
                 control.clone(),
                 &context,
-                OperationUsage {
-                    operation,
-                    authorization: &authorization,
-                    source_bytes: 32,
-                    output_bytes: 24,
-                },
+                multipart_completion_event(&authorization, &result, operation.receipt_id),
                 "key-a",
             )
             .await
             .unwrap();
         }
 
-        let calls = control.calls.lock().unwrap();
-        assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0], calls[1]);
-        assert_eq!(calls[0].event.operation_id, authorization.operation_id());
-        assert_eq!(calls[0].event.route, UsageRoute::CompleteMultipartUpload);
-        assert_eq!(calls[0].event.processed_bytes, 32);
+        {
+            let calls = control.calls.lock().unwrap();
+            assert_eq!(calls.len(), 2);
+            assert_eq!(calls[0], calls[1]);
+            assert_eq!(calls[0].event.operation_id, authorization.operation_id());
+            assert_eq!(calls[0].event.route, UsageRoute::CompleteMultipartUpload);
+            assert_eq!(calls[0].event.processed_bytes, 32);
+        }
+        let evidence = journal.evidence(operation.operation_id).await.unwrap();
+        assert_eq!(evidence.len(), 1);
+        assert!(evidence.iter().all(|record| record.kind == "usage"));
+        let receipt_id = operation.receipt_id.to_string();
+        assert!(
+            evidence
+                .iter()
+                .all(|record| record.detail["receipt_id"].as_str() == Some(receipt_id.as_str()))
+        );
     }
 
     #[tokio::test]
@@ -6374,18 +6840,146 @@ mod tests {
         assert!(!source_cancellation.is_cancelled());
         assert!(!pipeline_cancellation.is_cancelled());
 
+        let source_cancellation = s4_wasm_runtime::CancellationToken::new();
+        let pipeline_cancellation = s4_wasm_runtime::CancellationToken::new();
         let (sender, receiver) = tokio::sync::mpsc::channel(1);
         drop(sender);
-        let body = DirectReadBody {
+        let mut body = DirectReadBody {
             first: None,
             receiver,
             source_cancellation: source_cancellation.clone(),
             pipeline_cancellation: pipeline_cancellation.clone(),
             done: false,
         };
-        drop(body);
+        let error = body.frame().await.unwrap().unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "transformed read worker terminated unexpectedly"
+        );
         assert!(source_cancellation.is_cancelled());
         assert!(pipeline_cancellation.is_cancelled());
+
+        let source_cancellation = s4_wasm_runtime::CancellationToken::new();
+        let pipeline_cancellation = s4_wasm_runtime::CancellationToken::new();
+        let response = direct_read_worker_terminated(
+            "private-key",
+            &source_cancellation,
+            &pipeline_cancellation,
+        );
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(response.headers().get(header::ETAG).is_none());
+        assert!(source_cancellation.is_cancelled());
+        assert!(pipeline_cancellation.is_cancelled());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn transformed_source_returns_post_finish_fuel_for_spooled_evidence() {
+        let component = std::fs::read(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../target/components/noop.component.wasm"),
+        )
+        .expect("noop.component.wasm; run just build-filters");
+        let registry = PluginRegistry::new();
+        registry.import("noop", &component).unwrap();
+        let pipeline = registry
+            .snapshot()
+            .start_streaming_session(
+                s4_wasm_runtime::Session {
+                    format: "text".to_string(),
+                    content_type: "text/plain".to_string(),
+                    policy_version: 0,
+                    operation: s4_wasm_runtime::Operation::Read,
+                    config_json: None,
+                    public_key_pem: None,
+                    stable_key: None,
+                    stable_fields: None,
+                },
+                s4_wasm_runtime::CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        let object = OpenedObject::new(
+            StatusCode::OK,
+            metadata(None, Some("\"source-a\""), "text/plain"),
+            Body::from("line\n"),
+            BodyLimits::default(),
+        );
+
+        let fuel =
+            process_transformed_source(object, pipeline, Format::Text, 1024, |_| async { Ok(()) })
+                .await
+                .unwrap();
+        assert!(
+            fuel > 0,
+            "completed pipeline evidence must use measured fuel"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn successful_drop_all_direct_read_keeps_measured_finish_evidence() {
+        let component = std::fs::read(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../target/test-components/test-filter.component.wasm"),
+        )
+        .expect("test-filter.component.wasm; run just build-filters");
+        let registry = Arc::new(PluginRegistry::new());
+        registry
+            .import_with_capabilities(
+                "dropper",
+                &component,
+                PluginCapabilities {
+                    prefix_safe_for_read: true,
+                },
+            )
+            .unwrap();
+        let resolver = crate::pipeline::StaticPipelineResolver::new(registry.clone());
+        let resolution = crate::pipeline::PipelineResolver::resolve(
+            &resolver,
+            "workspace-a",
+            "bucket-a",
+            crate::pipeline::PipelineDirection::Read,
+        )
+        .await
+        .unwrap();
+        let snapshot = registry
+            .snapshot_for(&resolution, registry.as_ref())
+            .await
+            .unwrap();
+        let mut pipeline = snapshot
+            .clone()
+            .start_streaming_session(
+                s4_wasm_runtime::Session {
+                    format: "text".to_string(),
+                    content_type: "text/plain".to_string(),
+                    policy_version: 0,
+                    operation: s4_wasm_runtime::Operation::Read,
+                    config_json: None,
+                    public_key_pem: None,
+                    stable_key: None,
+                    stable_fields: None,
+                },
+                s4_wasm_runtime::CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            pipeline
+                .process(crate::record::Record::new("drop", "\n"))
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let (_, fuel_consumed) = pipeline.finish().await.unwrap();
+        let event = DirectReadEvent::Done {
+            fuel_consumed,
+            duration_ms: 5,
+        };
+        let evidence = direct_read_done_evidence(&snapshot, &event).unwrap();
+        assert_eq!(evidence.fuel_consumed, fuel_consumed);
+        assert!(evidence.fuel_consumed > 0);
+        assert_eq!(evidence.duration_ms, 5);
+        assert_eq!(evidence.spool_mode, "none");
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -7071,7 +7665,8 @@ async fn s3_post(
             .await
         {
             Ok(CompletionAcquire::Replayed(result)) => {
-                if let Err(response) = record_operation_with_event(
+                if let Err(response) = record_durable_operation_with_event(
+                    state.operation_journal.as_ref(),
                     state.control.clone(),
                     &auth.context,
                     multipart_completion_event(&authorization, &result, operation.receipt_id),
@@ -7173,8 +7768,15 @@ async fn s3_post(
                 );
             }
         };
-        let result = if let Some(operation) = recovered {
-            let result = match recovered_multipart_result(operation, &lease) {
+        let result = if let Some(recovered_operation) = recovered {
+            let result = match recovered_multipart_result(
+                state.operation_journal.as_ref(),
+                recovered_operation,
+                &lease,
+                operation.receipt_id,
+            )
+            .await
+            {
                 Ok(result) => result,
                 Err(error) => return multipart_completion_error_response(&key, error),
             };
@@ -7201,6 +7803,7 @@ async fn s3_post(
                     AuthorizedOperation {
                         auth: &auth,
                         authorization: &authorization,
+                        receipt_id: operation.receipt_id,
                     },
                     backend,
                 ),
@@ -7227,7 +7830,8 @@ async fn s3_post(
             }
         };
         cleanup_staged_parts(&staging, upload_id, lease.cleanup_parts, "complete").await;
-        if let Err(response) = record_operation_with_event(
+        if let Err(response) = record_durable_operation_with_event(
+            state.operation_journal.as_ref(),
             state.control.clone(),
             &auth.context,
             multipart_completion_event(&authorization, &result, operation.receipt_id),
@@ -7292,6 +7896,24 @@ async fn s3_post(
         {
             return s3_error::multipart_not_supported(&key);
         }
+        // Freeze and serialize policy before creating managed multipart state.
+        // Resolver or serialization failures therefore cannot orphan a managed
+        // registration without a corresponding staging upload.
+        let plugin_snapshot = match state
+            .gateway
+            .resolve(
+                auth.workspace_id().as_str(),
+                &bucket,
+                crate::pipeline::PipelineDirection::Write,
+            )
+            .await
+        {
+            Ok(resolution) => match serde_json::to_value(&resolution) {
+                Ok(snapshot) => snapshot,
+                Err(error) => return s3_error::internal_error(&key, &error.to_string()),
+            },
+            Err(error) => return s3_error::invalid_request(&key, error.message()),
+        };
         let upload_id = Uuid::now_v7().to_string();
         let managed_registration = if let ResolvedBackend::Managed(storage) = &backend {
             match storage
@@ -7303,18 +7925,6 @@ async fn s3_post(
             }
         } else {
             None
-        };
-        let plugin_snapshot = match state
-            .gateway
-            .resolve(
-                auth.workspace_id().as_str(),
-                &bucket,
-                crate::pipeline::PipelineDirection::Write,
-            )
-            .await
-        {
-            Ok(resolution) => serde_json::to_value(&resolution).unwrap_or(serde_json::json!(null)),
-            Err(error) => return s3_error::invalid_request(&key, error.message()),
         };
         let now = now_ms();
         let upload = MultipartUpload {
@@ -8667,7 +9277,8 @@ pub async fn build_state(
             .min(crate::object::DEFAULT_MAX_SOURCE_BYTES),
     };
 
-    let component_bytes = std::fs::read(component_path())?;
+    let explicit_component_path = component_path();
+    let component_bytes = std::fs::read(&explicit_component_path)?;
     let pipeline_fuel = std::env::var("S4_WASM_FUEL")
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
@@ -8711,7 +9322,11 @@ pub async fn build_state(
     if let Ok(plugin_dir) = std::env::var("S4_PLUGINS_DIR") {
         let dir = std::path::Path::new(&plugin_dir);
         if dir.exists() {
-            plugins.load_from_dir_with_capabilities(dir, &prefix_safe_hashes)?;
+            plugins.load_from_dir_with_capabilities_excluding(
+                dir,
+                &prefix_safe_hashes,
+                Some(&explicit_component_path),
+            )?;
         }
     }
 

--- a/crates/gateway/src/transaction/journal.rs
+++ b/crates/gateway/src/transaction/journal.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
-use sea_orm::sea_query::Expr;
+use sea_orm::sea_query::{Expr, OnConflict};
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter,
     QueryOrder, QuerySelect, Set, SqlxPostgresConnector,
@@ -369,16 +369,35 @@ impl OperationJournal for PostgresOperationJournal {
     }
 
     async fn append_evidence(&self, evidence: EvidenceRecord) -> Result<(), JournalError> {
-        object_operation_evidence::ActiveModel {
+        let expected = evidence.clone();
+        object_operation_evidence::Entity::insert(object_operation_evidence::ActiveModel {
             id: Set(evidence.id),
             operation_id: Set(evidence.operation_id),
             kind: Set(evidence.kind),
             detail: Set(evidence.detail),
             created_at_ms: Set(evidence.created_at_ms),
-        }
-        .insert(&self.db)
+        })
+        .on_conflict(
+            OnConflict::column(object_operation_evidence::Column::Id)
+                .do_nothing()
+                .to_owned(),
+        )
+        .exec_without_returning(&self.db)
         .await
         .map_err(persistence)?;
+        let stored = object_operation_evidence::Entity::find_by_id(expected.id)
+            .one(&self.db)
+            .await
+            .map_err(persistence)?
+            .ok_or_else(|| JournalError::Persistence("evidence insert disappeared".to_string()))?;
+        if stored.operation_id != expected.operation_id
+            || stored.kind != expected.kind
+            || stored.detail != expected.detail
+        {
+            return Err(JournalError::Conflict(
+                "evidence id conflicts with an existing record".to_string(),
+            ));
+        }
         Ok(())
     }
 
@@ -513,6 +532,7 @@ struct MemoryState {
 pub struct InMemoryOperationJournal {
     state: Arc<Mutex<MemoryState>>,
     fail_committed_transitions: Arc<AtomicUsize>,
+    fail_evidence_appends: Arc<AtomicUsize>,
 }
 
 #[cfg(any(test, debug_assertions))]
@@ -524,6 +544,10 @@ impl InMemoryOperationJournal {
     pub fn fail_next_committed_transitions(&self, count: usize) {
         self.fail_committed_transitions
             .store(count, Ordering::Release);
+    }
+
+    pub fn fail_next_evidence_appends(&self, count: usize) {
+        self.fail_evidence_appends.store(count, Ordering::Release);
     }
 }
 
@@ -685,7 +709,35 @@ impl OperationJournal for InMemoryOperationJournal {
     }
 
     async fn append_evidence(&self, evidence: EvidenceRecord) -> Result<(), JournalError> {
-        self.state.lock().await.evidence.push(evidence);
+        if self
+            .fail_evidence_appends
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(JournalError::Persistence(
+                "injected evidence append failure".to_string(),
+            ));
+        }
+        let mut state = self.state.lock().await;
+        if let Some(existing) = state
+            .evidence
+            .iter()
+            .find(|record| record.id == evidence.id)
+        {
+            return if existing.operation_id == evidence.operation_id
+                && existing.kind == evidence.kind
+                && existing.detail == evidence.detail
+            {
+                Ok(())
+            } else {
+                Err(JournalError::Conflict(
+                    "evidence id conflicts with an existing record".to_string(),
+                ))
+            };
+        }
+        state.evidence.push(evidence);
         Ok(())
     }
 

--- a/crates/gateway/src/transaction/mod.rs
+++ b/crates/gateway/src/transaction/mod.rs
@@ -503,6 +503,11 @@ impl SinkCommitState {
 #[async_trait]
 pub trait ObjectSinkTransaction: Send {
     fn commit_state(&self) -> SinkCommitState;
+    /// Durable journal operation backing this sink, if any. Development
+    /// memory and compatibility sinks deliberately return `None`.
+    fn durable_operation_id(&self) -> Option<Uuid> {
+        None
+    }
     async fn write(&mut self, chunk: Bytes) -> Result<(), TransactionError>;
     async fn verify_output(
         &mut self,

--- a/crates/gateway/src/transaction/s3.rs
+++ b/crates/gateway/src/transaction/s3.rs
@@ -857,6 +857,10 @@ impl ObjectSinkTransaction for DirectS3Sink {
         }
     }
 
+    fn durable_operation_id(&self) -> Option<uuid::Uuid> {
+        Some(self.operation.id)
+    }
+
     async fn write(&mut self, mut chunk: Bytes) -> Result<(), TransactionError> {
         if self.finished {
             return Err(TransactionError::Finished);

--- a/crates/gateway/tests/db_keys_test.rs
+++ b/crates/gateway/tests/db_keys_test.rs
@@ -635,6 +635,23 @@ fn postgres_operation_journal_persists_canonical_ambiguous_completion() {
 }
 
 #[test]
+fn postgres_evidence_foreign_key_requires_a_matching_operation_intent() {
+    with_pool(|pool| async move {
+        let journal = PostgresOperationJournal::new(pool);
+        let missing_operation_id = uuid::Uuid::now_v7();
+        let error = journal
+            .append_evidence(EvidenceRecord::new(
+                missing_operation_id,
+                "usage",
+                serde_json::json!({"source": "memory-sink-regression"}),
+            ))
+            .await
+            .expect_err("evidence without an operation intent must violate the FK");
+        assert!(error.to_string().contains("journal persistence failed"));
+    });
+}
+
+#[test]
 fn postgres_multipart_completion_cas_replay_and_fencing_are_durable() {
     with_pool(|pool| async move {
         let db = sea_db(pool.clone());

--- a/crates/gateway/tests/s3_frontdoor_test.rs
+++ b/crates/gateway/tests/s3_frontdoor_test.rs
@@ -5393,6 +5393,15 @@ async fn empty_prefix_safe_snapshot_streams_without_length_or_staging() {
             .collect::<Vec<_>>(),
         vec![(RequestKind::Read, UsageRoute::GetObject, 0, 0)]
     );
+    let events = control.events.lock().unwrap();
+    let evidence = events[0]
+        .event
+        .pipeline_evidence
+        .as_ref()
+        .expect("completed empty direct read must retain measured evidence");
+    assert_eq!(evidence.revision, "static");
+    assert_eq!(evidence.fuel_consumed, 0);
+    assert_eq!(evidence.spool_mode, "none");
     task.abort();
 }
 

--- a/crates/gateway/tests/stable_encrypt_test.rs
+++ b/crates/gateway/tests/stable_encrypt_test.rs
@@ -152,12 +152,21 @@ fn no_key_no_encryption() {
 }
 
 #[test]
-fn non_json_records_pass_through() {
+fn non_json_records_are_rejected_for_jsonl_output() {
     let registry = registry();
     let key = stable_key("s4s_testsecret");
     let input = b"plain text line\nanother line\n";
-    let out = run(&registry, input, Some(&key), Some("email"));
-    assert_eq!(out, input);
+    let error = common::stream_process(
+        &registry,
+        input,
+        Format::Jsonl,
+        "application/x-ndjson",
+        None,
+        Some(&key),
+        Some("email"),
+    )
+    .unwrap_err();
+    assert_eq!(error.code(), s4_error::codes::DECODE_INVALID_OUTPUT);
 }
 
 #[test]

--- a/crates/s4ctl/src/main.rs
+++ b/crates/s4ctl/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, bail};
 use clap::{Parser, Subcommand};
+use reqwest::Url;
 use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -598,27 +599,46 @@ impl Client {
 /// Hosted (SaaS control plane) client. Authenticates exclusively with a
 /// Supabase access token; a data-plane API key is never accepted here.
 struct HostedApi {
-    gateway: String,
+    gateway: Url,
     workspace: String,
     token: String,
     http: reqwest::Client,
 }
 
 impl HostedApi {
-    fn new(gateway: &str, workspace: &str, token: &str) -> Self {
-        Self {
-            gateway: gateway.trim_end_matches('/').to_string(),
+    fn new(gateway: &str, workspace: &str, token: &str) -> anyhow::Result<Self> {
+        let gateway = Url::parse(gateway).context("invalid hosted gateway URL")?;
+        if gateway.cannot_be_a_base() {
+            bail!("hosted gateway URL cannot be used as a base URL");
+        }
+        Ok(Self {
+            gateway,
             workspace: workspace.to_string(),
             token: token.to_string(),
             http: reqwest::Client::new(),
-        }
+        })
     }
 
-    fn path(&self, suffix: &str) -> String {
-        format!(
-            "{}/dashboard/api/workspaces/{}/{}",
-            self.gateway, self.workspace, suffix
-        )
+    fn path(&self, segments: &[&str]) -> anyhow::Result<Url> {
+        let mut url = self.gateway.clone();
+        url.set_query(None);
+        url.set_fragment(None);
+        let mut path = url
+            .path_segments_mut()
+            .map_err(|_| anyhow::anyhow!("hosted gateway URL cannot contain path segments"))?;
+        path.pop_if_empty();
+        path.extend(["dashboard", "api", "workspaces"]);
+        path.push(&self.workspace);
+        path.extend(segments.iter().copied());
+        drop(path);
+        Ok(url)
+    }
+
+    fn path_with_query(&self, segments: &[&str], query: &[(&str, String)]) -> anyhow::Result<Url> {
+        let mut url = self.path(segments)?;
+        url.query_pairs_mut()
+            .extend_pairs(query.iter().map(|(key, value)| (*key, value.as_str())));
+        Ok(url)
     }
 
     fn auth_headers(&self) -> anyhow::Result<HeaderMap> {
@@ -636,29 +656,39 @@ impl HostedApi {
         Ok(h)
     }
 
-    async fn get<T: for<'de> Deserialize<'de>>(&self, suffix: &str) -> anyhow::Result<T> {
+    async fn get<T: for<'de> Deserialize<'de>>(&self, segments: &[&str]) -> anyhow::Result<T> {
+        self.get_with_query(segments, &[]).await
+    }
+
+    async fn get_with_query<T: for<'de> Deserialize<'de>>(
+        &self,
+        segments: &[&str],
+        query: &[(&str, String)],
+    ) -> anyhow::Result<T> {
+        let url = self.path_with_query(segments, query)?;
         let resp = self
             .http
-            .get(self.path(suffix))
+            .get(url.clone())
             .headers(self.auth_headers()?)
             .send()
             .await?;
         let status = resp.status();
         let body = resp.text().await?;
         if !status.is_success() {
-            bail!("GET {}: {} — {}", suffix, status, body);
+            bail!("GET {}: {} — {}", url, status, body);
         }
-        serde_json::from_str(&body).with_context(|| format!("parse GET {}: {}", suffix, body))
+        serde_json::from_str(&body).with_context(|| format!("parse GET {}: {}", url, body))
     }
 
     async fn post<T: Serialize, R: for<'de> Deserialize<'de>>(
         &self,
-        suffix: &str,
+        segments: &[&str],
         body: &T,
     ) -> anyhow::Result<R> {
+        let url = self.path(segments)?;
         let resp = self
             .http
-            .post(self.path(suffix))
+            .post(url.clone())
             .headers(self.json_headers()?)
             .json(body)
             .send()
@@ -666,19 +696,20 @@ impl HostedApi {
         let status = resp.status();
         let text = resp.text().await?;
         if !status.is_success() {
-            bail!("POST {}: {} — {}", suffix, status, text);
+            bail!("POST {}: {} — {}", url, status, text);
         }
-        serde_json::from_str(&text).with_context(|| format!("parse POST {}: {}", suffix, text))
+        serde_json::from_str(&text).with_context(|| format!("parse POST {}: {}", url, text))
     }
 
     async fn put<T: Serialize, R: for<'de> Deserialize<'de>>(
         &self,
-        suffix: &str,
+        segments: &[&str],
         body: &T,
     ) -> anyhow::Result<R> {
+        let url = self.path(segments)?;
         let resp = self
             .http
-            .put(self.path(suffix))
+            .put(url.clone())
             .headers(self.json_headers()?)
             .json(body)
             .send()
@@ -686,19 +717,16 @@ impl HostedApi {
         let status = resp.status();
         let text = resp.text().await?;
         if !status.is_success() {
-            bail!("PUT {}: {} — {}", suffix, status, text);
+            bail!("PUT {}: {} — {}", url, status, text);
         }
-        serde_json::from_str(&text).with_context(|| format!("parse PUT {}: {}", suffix, text))
+        serde_json::from_str(&text).with_context(|| format!("parse PUT {}: {}", url, text))
     }
 
-    async fn delete<T: Serialize, R: for<'de> Deserialize<'de>>(
-        &self,
-        suffix: &str,
-        body: &T,
-    ) -> anyhow::Result<R> {
+    async fn put_unit<T: Serialize>(&self, segments: &[&str], body: &T) -> anyhow::Result<()> {
+        let url = self.path(segments)?;
         let resp = self
             .http
-            .delete(self.path(suffix))
+            .put(url.clone())
             .headers(self.json_headers()?)
             .json(body)
             .send()
@@ -706,9 +734,26 @@ impl HostedApi {
         let status = resp.status();
         let text = resp.text().await?;
         if !status.is_success() {
-            bail!("DELETE {}: {} — {}", suffix, status, text);
+            bail!("PUT {}: {} — {}", url, status, text);
         }
-        serde_json::from_str(&text).with_context(|| format!("parse DELETE {}: {}", suffix, text))
+        Ok(())
+    }
+
+    async fn delete_unit<T: Serialize>(&self, segments: &[&str], body: &T) -> anyhow::Result<()> {
+        let url = self.path(segments)?;
+        let resp = self
+            .http
+            .delete(url.clone())
+            .headers(self.json_headers()?)
+            .json(body)
+            .send()
+            .await?;
+        let status = resp.status();
+        let text = resp.text().await?;
+        if !status.is_success() {
+            bail!("DELETE {}: {} — {}", url, status, text);
+        }
+        Ok(())
     }
 
     /// Stage raw Wasm bytes into the private quarantine artifact store.
@@ -717,7 +762,7 @@ impl HostedApi {
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/wasm"));
         let resp = self
             .http
-            .post(self.path("filter-artifacts"))
+            .post(self.path(&["filter-artifacts"])?)
             .headers(headers)
             .body(bytes.to_vec())
             .send()
@@ -1054,10 +1099,10 @@ async fn main() -> anyhow::Result<()> {
             if token.is_empty() {
                 bail!("S4_ACCESS_TOKEN must not be empty");
             }
-            let api = HostedApi::new(&cli.gateway, workspace, &token);
+            let api = HostedApi::new(&cli.gateway, workspace, &token)?;
             match cmd {
                 HostedCmd::Catalog => {
-                    let value: serde_json::Value = api.get("filter-catalog").await?;
+                    let value: serde_json::Value = api.get(&["filter-catalog"]).await?;
                     let plugins = value["plugins"].as_array().cloned().unwrap_or_default();
                     if plugins.is_empty() {
                         println!("No plugins in the workspace catalog.");
@@ -1151,7 +1196,7 @@ async fn main() -> anyhow::Result<()> {
                         "capability_requests": capability,
                         "config_schema": config_schema,
                     });
-                    let created: serde_json::Value = api.post("filter-plugins", &body).await?;
+                    let created: serde_json::Value = api.post(&["filter-plugins"], &body).await?;
                     println!(
                         "Uploaded {}: plugin={} version={} validation_run={}",
                         slug,
@@ -1167,7 +1212,7 @@ async fn main() -> anyhow::Result<()> {
                 }
                 HostedCmd::Validation { version_id } => {
                     let value: serde_json::Value = api
-                        .get(&format!("filter-plugin-versions/{version_id}/validation"))
+                        .get(&["filter-plugin-versions", version_id, "validation"])
                         .await?;
                     let version = &value["version"];
                     println!(
@@ -1208,14 +1253,16 @@ async fn main() -> anyhow::Result<()> {
                     version_id,
                 } => {
                     let body = serde_json::json!({ "version_id": version_id });
-                    let _: serde_json::Value = api
-                        .put(
-                            &format!(
-                                "filter-installations/{installation_id}/capabilities/{capability}"
-                            ),
-                            &body,
-                        )
-                        .await?;
+                    api.put_unit(
+                        &[
+                            "filter-installations",
+                            installation_id,
+                            "capabilities",
+                            capability,
+                        ],
+                        &body,
+                    )
+                    .await?;
                     println!("Capability {capability} granted on installation {installation_id}.");
                 }
                 HostedCmd::Revoke {
@@ -1224,19 +1271,21 @@ async fn main() -> anyhow::Result<()> {
                     version_id,
                 } => {
                     let body = serde_json::json!({ "version_id": version_id });
-                    let _: serde_json::Value = api
-                        .delete(
-                            &format!(
-                                "filter-installations/{installation_id}/capabilities/{capability}"
-                            ),
-                            &body,
-                        )
-                        .await?;
+                    api.delete_unit(
+                        &[
+                            "filter-installations",
+                            installation_id,
+                            "capabilities",
+                            capability,
+                        ],
+                        &body,
+                    )
+                    .await?;
                     println!("Capability {capability} revoked on installation {installation_id}.");
                 }
                 HostedCmd::Pipelines { cmd } => match cmd {
                     HostedPipelineCmd::List => {
-                        let value: serde_json::Value = api.get("filter-pipelines").await?;
+                        let value: serde_json::Value = api.get(&["filter-pipelines"]).await?;
                         let pipelines = value["pipelines"].as_array().cloned().unwrap_or_default();
                         if pipelines.is_empty() {
                             println!("No pipelines.");
@@ -1269,7 +1318,7 @@ async fn main() -> anyhow::Result<()> {
                     HostedPipelineCmd::Create { direction, name } => {
                         let body = serde_json::json!({ "direction": direction, "name": name });
                         let created: serde_json::Value =
-                            api.post("filter-pipelines", &body).await?;
+                            api.post(&["filter-pipelines"], &body).await?;
                         println!(
                             "Created pipeline {} (draft revision {})",
                             created["pipeline"]["id"].as_str().unwrap_or("?"),
@@ -1290,7 +1339,7 @@ async fn main() -> anyhow::Result<()> {
                             "steps": parsed,
                         });
                         let updated: serde_json::Value = api
-                            .put(&format!("filter-pipelines/{pipeline_id}/draft"), &body)
+                            .put(&["filter-pipelines", pipeline_id, "draft"], &body)
                             .await?;
                         println!(
                             "Draft updated: revision {} fingerprint={} steps={}",
@@ -1302,7 +1351,7 @@ async fn main() -> anyhow::Result<()> {
                     HostedPipelineCmd::Publish { pipeline_id } => {
                         let body = serde_json::json!({});
                         let published: serde_json::Value = api
-                            .post(&format!("filter-pipelines/{pipeline_id}/publish"), &body)
+                            .post(&["filter-pipelines", pipeline_id, "publish"], &body)
                             .await?;
                         println!(
                             "Published revision {} (revision_no {}) fingerprint={}",
@@ -1318,7 +1367,7 @@ async fn main() -> anyhow::Result<()> {
                         let body = serde_json::json!({});
                         let rolled_back: serde_json::Value = api
                             .post(
-                                &format!("filter-pipelines/{pipeline_id}/rollback/{revision_id}"),
+                                &["filter-pipelines", pipeline_id, "rollback", revision_id],
                                 &body,
                             )
                             .await?;
@@ -1331,7 +1380,7 @@ async fn main() -> anyhow::Result<()> {
                     }
                 },
                 HostedCmd::Assignments => {
-                    let value: serde_json::Value = api.get("filter-assignments").await?;
+                    let value: serde_json::Value = api.get(&["filter-assignments"]).await?;
                     let assignments = value["assignments"].as_array().cloned().unwrap_or_default();
                     let scopes = value["bucket_scopes"]
                         .as_array()
@@ -1364,7 +1413,7 @@ async fn main() -> anyhow::Result<()> {
                 } => {
                     let body = serde_json::json!({ "pipeline_id": pipeline_id });
                     let _: serde_json::Value = api
-                        .put(&format!("filter-assignments/{direction}/default"), &body)
+                        .put(&["filter-assignments", direction, "default"], &body)
                         .await?;
                     println!("Default {direction} pipeline set to {pipeline_id}.");
                 }
@@ -1375,29 +1424,22 @@ async fn main() -> anyhow::Result<()> {
                 } => {
                     let body = serde_json::json!({ "pipeline_id": pipeline_id });
                     let _: serde_json::Value = api
-                        .put(
-                            &format!("filter-assignments/{direction}/buckets/{bucket}"),
-                            &body,
-                        )
+                        .put(&["filter-assignments", direction, "buckets", bucket], &body)
                         .await?;
                     println!("{direction} pipeline {pipeline_id} assigned to bucket {bucket}.");
                 }
                 HostedCmd::UnassignBucket { direction, bucket } => {
                     let body = serde_json::json!({});
-                    let _: serde_json::Value = api
-                        .delete(
-                            &format!("filter-assignments/{direction}/buckets/{bucket}"),
-                            &body,
-                        )
+                    api.delete_unit(&["filter-assignments", direction, "buckets", bucket], &body)
                         .await?;
                     println!("Removed {direction} assignment for bucket {bucket}.");
                 }
                 HostedCmd::Audit { limit } => {
-                    let suffix = match limit {
-                        Some(limit) => format!("filter-audit?limit={limit}"),
-                        None => "filter-audit".to_string(),
-                    };
-                    let value: serde_json::Value = api.get(&suffix).await?;
+                    let query = limit
+                        .map(|limit| vec![("limit", limit.to_string())])
+                        .unwrap_or_default();
+                    let value: serde_json::Value =
+                        api.get_with_query(&["filter-audit"], &query).await?;
                     let events = value["events"].as_array().cloned().unwrap_or_default();
                     if events.is_empty() {
                         println!("No audit events.");
@@ -1699,6 +1741,26 @@ async fn main() -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn success_server(body: &'static str) -> (String, tokio::task::JoinHandle<String>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 16 * 1024];
+            let read = socket.read(&mut request).await.unwrap();
+            request.truncate(read);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+            String::from_utf8(request).unwrap()
+        });
+        (format!("http://{address}"), task)
+    }
 
     #[test]
     fn parse_draft_step_accepts_installation_and_version() {
@@ -1736,21 +1798,63 @@ mod tests {
 
     #[test]
     fn hosted_api_path_scopes_to_the_workspace() {
-        let api = HostedApi::new("http://localhost:9000/", "ws-abc", "token");
+        let api = HostedApi::new("http://localhost:9000/", "ws-abc", "token").unwrap();
         assert_eq!(
-            api.path("filter-catalog"),
+            api.path(&["filter-catalog"]).unwrap().as_str(),
             "http://localhost:9000/dashboard/api/workspaces/ws-abc/filter-catalog"
         );
     }
 
     #[test]
+    fn hosted_api_percent_encodes_every_dynamic_path_segment() {
+        let api = HostedApi::new("https://api.example/base", "ws/abc", "token").unwrap();
+        assert_eq!(
+            api.path(&["filter-assignments", "read/write", "buckets", "bucket name"])
+                .unwrap()
+                .as_str(),
+            "https://api.example/base/dashboard/api/workspaces/ws%2Fabc/filter-assignments/read%2Fwrite/buckets/bucket%20name"
+        );
+    }
+
+    #[test]
     fn hosted_token_is_never_fallback_to_data_plane_keys() {
-        let api = HostedApi::new("http://localhost:9000", "ws-abc", "secret-token");
+        let api = HostedApi::new("http://localhost:9000", "ws-abc", "secret-token").unwrap();
         let headers = api.auth_headers().unwrap();
         assert_eq!(
             headers.get("Authorization").unwrap().to_str().unwrap(),
             "Bearer secret-token"
         );
         assert!(headers.get("x-s4-access-key").is_none());
+    }
+
+    #[tokio::test]
+    async fn hosted_unit_mutations_accept_text_and_empty_success_bodies() {
+        let (gateway, put_request) = success_server("capability granted").await;
+        let api = HostedApi::new(&gateway, "ws-abc", "secret-token").unwrap();
+        api.put_unit(
+            &[
+                "filter-installations",
+                "install-1",
+                "capabilities",
+                "stable_fields",
+            ],
+            &serde_json::json!({"version_id": "version-1"}),
+        )
+        .await
+        .unwrap();
+        let request = put_request.await.unwrap();
+        assert!(request.starts_with("PUT /dashboard/api/workspaces/ws-abc/"));
+        assert!(request.contains("authorization: Bearer secret-token\r\n"));
+
+        let (gateway, delete_request) = success_server("").await;
+        let api = HostedApi::new(&gateway, "ws-abc", "secret-token").unwrap();
+        api.delete_unit(
+            &["filter-assignments", "write", "buckets", "bucket-a"],
+            &serde_json::json!({}),
+        )
+        .await
+        .unwrap();
+        let request = delete_request.await.unwrap();
+        assert!(request.starts_with("DELETE /dashboard/api/workspaces/ws-abc/"));
     }
 }

--- a/crates/wasm-runtime/Cargo.toml
+++ b/crates/wasm-runtime/Cargo.toml
@@ -13,3 +13,4 @@ rand.workspace = true
 hex.workspace = true
 sha2 = "0.10"
 zeroize.workspace = true
+serde = { workspace = true, features = ["derive"] }

--- a/crates/wasm-runtime/src/lib.rs
+++ b/crates/wasm-runtime/src/lib.rs
@@ -157,7 +157,7 @@ pub enum FilterWorldVersion {
 /// Which optional sensitive fields a specific component invocation may
 /// receive. Sensitive material is delivered per-grant, never to every plugin
 /// in a pipeline unconditionally.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SensitiveGrant {
     pub public_key_pem: bool,
     pub entropy_seed: bool,

--- a/filters/test-filter-v02/src/lib.rs
+++ b/filters/test-filter-v02/src/lib.rs
@@ -15,6 +15,15 @@ mod guest {
             if context.content_type == "test/begin-reject" {
                 return Err("begin rejected".to_string());
             }
+            if context.content_type == "test/require-step-context"
+                && (!matches!(context.operation, Operation::Read)
+                    || context.config_json.as_deref() != Some(r#"{"region":"eu"}"#)
+                    || context.public_key_pem.is_some()
+                    || context.stable_key.is_some()
+                    || context.stable_fields.is_some())
+            {
+                return Err("per-step context mismatch".to_string());
+            }
             Ok(())
         }
 

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -10,7 +10,8 @@ GW_LOG="/tmp/s4-e2e-gateway-${RUN_ID}.log"
 # Isolate the local-mode key store from the user's real config directory so a
 # stale `~/Library/Application Support/s4/keys.json` (DEK wrapped by an earlier
 # ephemeral/secret key) can never abort gateway startup.
-KEYS_FILE="/tmp/s4-e2e-keys-${RUN_ID}.json"
+KEYS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/s4-e2e-keys-${RUN_ID}.XXXXXX")"
+KEYS_FILE="$KEYS_DIR/keys.json"
 MC_CONF="${COMPOSE_PROJECT}-mc"
 MC_IMAGE="minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"
 GW_PORT="${S4_E2E_GW_PORT:-9010}"
@@ -21,7 +22,8 @@ cleanup() {
     [ -n "$GW_PID" ] && kill "$GW_PID" 2>/dev/null || true
     [ -n "$GW_PID" ] && wait "$GW_PID" 2>/dev/null || true
     "${COMPOSE[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
-    rm -f "$READBACK" "$GW_LOG" "$KEYS_FILE"
+    rm -f "$READBACK" "$GW_LOG"
+    rm -rf "$KEYS_DIR"
     docker volume rm "$MC_CONF" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT

--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -10,14 +10,15 @@ GATEWAY_PID=""
 # Isolate the local-mode key store from the user's real config directory so a
 # stale `~/Library/Application Support/s4/keys.json` (DEK wrapped by an earlier
 # ephemeral/secret key) can never abort gateway startup.
-KEYS_FILE="/tmp/s4-sdkgen-keys-$$.json"
+KEYS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/s4-sdkgen-keys.XXXXXX")"
+KEYS_FILE="$KEYS_DIR/keys.json"
 
 cleanup() {
     if [ -n "$GATEWAY_PID" ]; then
         kill "$GATEWAY_PID" 2>/dev/null || true
         wait "$GATEWAY_PID" 2>/dev/null || true
     fi
-    rm -f "$KEYS_FILE"
+    rm -rf "$KEYS_DIR"
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## Context

PR #62 was merged before its full remediation review completed. This follow-up applies the independently reviewed final tree on top of that merge.

## Fixes
- Enforce per-step enabled state, config, and explicit sensitive grants; hosted defaults deny sensitive context.
- Constrain resolved limits and make compile-cache capabilities/catalog pinning authoritative under races and eviction.
- Validate aggregate transform + finish output before commit, including records up to supported limits.
- Persist deterministic pipeline evidence across direct/multipart commit and recovery; report measured read/finalization evidence.
- Fail closed on transformed-read worker termination.
- Preserve static multipart compatibility and self-hosted duplicate behavior without double-loading the image default.
- Fix multipart cleanup/journal durability and hosted s4ctl URL/response contracts.
- Isolate local script key stores with private mktemp directories.

## Verification
- Final independent review: no findings, merge-ready.
- fmt + strict workspace clippy pass.
- Full workspace tests pass: gateway lib 315, front-door 87 + 1 ignored soak, Postgres 15, runtime 46, s4ctl 7, property/streaming/RSS/integration suites green.
- Final corrective tree exactly matches the reviewed/tested tree (zero tree delta).