### PR TITLE
Avoid shared migration version collision

### DIFF
--- a/crates/gateway/tests/db_keys_test.rs
+++ b/crates/gateway/tests/db_keys_test.rs
@@ -305,7 +305,7 @@ fn managed_store_migration_fails_closed_with_existing_authority_rows() {
     with_pool(|pool| async move {
         let schema = format!("managed_upgrade_{}", uuid::Uuid::new_v4().simple());
         let migration =
-            include_str!("../../../migrations/20260831000001_managed_store_operations.sql");
+            include_str!("../../../migrations/20260901000003_managed_store_operations.sql");
         let upgrade = format!(
             "CREATE SCHEMA \"{schema}\"; SET search_path TO \"{schema}\"; \
              CREATE TABLE managed_object_authorities (\

--- a/migrations/20260901000003_managed_store_operations.sql
+++ b/migrations/20260901000003_managed_store_operations.sql
@@ -1,3 +1,5 @@
+-- Version 20260901000003 is globally unique across the shared public/private
+-- `_sqlx_migrations` table.
 -- Customer-level managed mutations, capacity accounting, and opaque list
 -- cursors. Physical provider journals remain independent child operations.
 -- The pre-operation schema did not persist enough information to reconstruct


### PR DESCRIPTION
## Summary
- move the newly introduced managed-store migration from `20260831000001` to globally unused `20260901000003`
- update the migration upgrade fixture to use the corrected path
- leave the already-deployed private filter migration at `20260831000001` untouched

Both public and private migrators share `_sqlx_migrations`; the prior duplicate version caused `VersionMismatch(20260831000001)` as soon as private tests used the public PR #65 revision.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --locked -p s4-gateway --test db_keys_test -- -D warnings`
- migration/database suite: 20 migration and persistence tests passed
- the remaining staged-multipart case requires its pre-existing component-path fixture and is unrelated to this rename