### PR TITLE
ci: reuse compiled pipelines in gateway tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,6 +23,7 @@ env:
 jobs:
   fmt:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -26,6 +35,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -34,10 +44,11 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - name: Lint
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -50,10 +61,11 @@ jobs:
       - name: Build Wasm filters
         run: bash scripts/build-filters.sh
       - name: Test
-        run: cargo test --workspace
+        run: cargo test --locked --workspace
 
   sdk:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -67,10 +79,16 @@ jobs:
         if: ${{ !env.ACT }}
         run: |
           bash scripts/generate-sdks.sh
-          git diff --exit-code -- sdks/
+          changes="$(git status --porcelain --untracked-files=all -- sdks/)"
+          if [ -n "$changes" ]; then
+            git diff -- sdks/
+            git status --short --untracked-files=all -- sdks/
+            exit 1
+          fi
 
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -86,6 +104,7 @@ jobs:
 
   postgres:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     services:
       postgres:
         image: postgres:17-trixie@sha256:e38411452a464af89e5adadb8d223bf53b898d47d6ef918b2d58c08707350449
@@ -114,10 +133,11 @@ jobs:
       - name: Build Wasm filters
         run: bash scripts/build-filters.sh
       - name: Test Postgres migrations and secret envelopes
-        run: cargo test -p s4-gateway --test db_keys_test
+        run: cargo test --locked -p s4-gateway --test db_keys_test
 
   interop:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -134,7 +154,9 @@ jobs:
           python3 -m pip install --user awscli boto3
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Unmodified-client interop (AWS CLI + boto3)
-        run: cargo test -p s4-gateway --test s3_frontdoor_test available_aws_cli_and_boto3_interoperate
+        env:
+          S4_RUN_EXTERNAL_CLIENT_INTEROP: "1"
+        run: cargo test --locked -p s4-gateway --test s3_frontdoor_test available_aws_cli_and_boto3_interoperate
 
   # Aggregate status so branch protection's required `check` keeps working
   # and never ends up "skipped" when a constituent job fails.
@@ -142,10 +164,11 @@ jobs:
     needs: [fmt, lint, test, sdk, e2e, postgres, interop]
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Fail if any check failed
-        if: ${{ contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled') }}
+        if: ${{ contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled') || contains(join(needs.*.result, ','), 'skipped') }}
         run: exit 1
       - name: All checks passed
-        if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
+        if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') && !contains(join(needs.*.result, ','), 'skipped') }}
         run: echo "all checks passed"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,13 @@ on:
     - cron: "17 3 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
@@ -16,6 +23,7 @@ env:
 jobs:
   property:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -28,20 +36,22 @@ jobs:
       - name: Build Wasm filters
         run: bash scripts/build-filters.sh
       - name: High-case property tests (10k cases)
-        run: PROPTEST_CASES=10000 cargo test -p s4-gateway --test property --test record_decoder
+        run: PROPTEST_CASES=10000 cargo test --locked -p s4-gateway --test property --test record_decoder
 
   rss:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.97.0
       - uses: Swatinem/rust-cache@v2
       - name: Fixed-RSS 1 GiB streaming
-        run: cargo test -p s4-gateway --test streaming_rss -- --nocapture
+        run: cargo test --locked -p s4-gateway --test streaming_rss -- --nocapture
 
   interop:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -58,10 +68,13 @@ jobs:
           python3 -m pip install --user awscli boto3
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Unmodified-client interop (AWS CLI + boto3)
-        run: cargo test -p s4-gateway --test s3_frontdoor_test available_aws_cli_and_boto3_interoperate
+        env:
+          S4_RUN_EXTERNAL_CLIENT_INTEROP: "1"
+        run: cargo test --locked -p s4-gateway --test s3_frontdoor_test available_aws_cli_and_boto3_interoperate
 
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,12 +1,18 @@
 name: Weekly
 
-# Deep soak: repeated streaming round-trips, high-case property tests, and the
-# fixed-RSS memory bound. Runs less frequently than Nightly because the soak
-# path is intentionally long.
+# Deep soak and high-case property tests. Nightly already covers fixed-RSS and
+# MinIO E2E six minutes before this workflow starts each Monday.
 on:
   schedule:
     - cron: "23 3 * * 1"
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,6 +22,7 @@ env:
 jobs:
   soak:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -28,10 +35,11 @@ jobs:
       - name: Build Wasm filters
         run: bash scripts/build-filters.sh
       - name: Soak streaming round-trips (500 iterations)
-        run: S4_SOAK_ITERATIONS=500 cargo test -p s4-gateway --test s3_frontdoor_test soak_streaming_roundtrip_holds_under_repetition -- --ignored --nocapture
+        run: S4_SOAK_ITERATIONS=500 cargo test --locked -p s4-gateway --test s3_frontdoor_test soak_streaming_roundtrip_holds_under_repetition -- --ignored --nocapture
 
   property:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -44,28 +52,4 @@ jobs:
       - name: Build Wasm filters
         run: bash scripts/build-filters.sh
       - name: High-case property tests (50k cases)
-        run: PROPTEST_CASES=50000 cargo test -p s4-gateway --test property --test record_decoder
-
-  rss:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.97.0
-      - uses: Swatinem/rust-cache@v2
-      - name: Fixed-RSS 1 GiB streaming
-        run: cargo test -p s4-gateway --test streaming_rss -- --nocapture
-
-  e2e:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.97.0
-        with:
-          targets: wasm32-wasip1,wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
-      - name: Install wasm-tools
-        run: cargo install --locked wasm-tools --version 1.255.0
-      - name: End-to-end (MinIO direct S3 streaming)
-        run: bash scripts/e2e-local.sh
+        run: PROPTEST_CASES=50000 cargo test --locked -p s4-gateway --test property --test record_decoder

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -62,8 +62,13 @@ impl Gateway {
     }
 
     pub fn with_registry(engine: FilterEngine, plugins: Arc<PluginRegistry>) -> Self {
+        Self::with_shared_registry(Arc::new(engine), plugins)
+    }
+
+    /// Build a gateway around an already compiled immutable engine.
+    pub fn with_shared_registry(engine: Arc<FilterEngine>, plugins: Arc<PluginRegistry>) -> Self {
         Self {
-            engine: Arc::new(engine),
+            engine,
             plugins: Some(plugins.clone()),
             resolver: Some(Arc::new(StaticPipelineResolver::new(plugins.clone()))),
             component_source: Some(plugins),

--- a/crates/gateway/src/plugin_registry.rs
+++ b/crates/gateway/src/plugin_registry.rs
@@ -46,6 +46,7 @@ pub struct PluginCapabilities {
     pub prefix_safe_for_read: bool,
 }
 
+#[derive(Clone)]
 struct Plugin {
     info: PluginInfo,
     component_hash: String,
@@ -55,6 +56,7 @@ struct Plugin {
 
 /// One entry in the bounded digest-keyed compile cache. Weight is the guest
 /// memory reservation of the compiled engine; eviction is weighted LRU.
+#[derive(Clone)]
 struct CacheEntry {
     engine: Arc<FilterEngine>,
     capabilities: PluginCapabilities,
@@ -62,7 +64,7 @@ struct CacheEntry {
     weight: usize,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct RegistryState {
     plugins: HashMap<String, Plugin>,
     order: Vec<String>,
@@ -113,6 +115,7 @@ pub struct PluginRegistry {
     fuel: u64,
     pipeline_limits: PipelineLimits,
     executor: Arc<WasmExecutor>,
+    executor_config: ExecutorConfig,
 }
 
 #[derive(Clone)]
@@ -331,6 +334,20 @@ impl PluginRegistry {
             fuel,
             pipeline_limits: pipeline_limits.validate()?,
             executor: Arc::new(WasmExecutor::new(executor_config)?),
+            executor_config,
+        })
+    }
+
+    /// Create an isolated registry that reuses only immutable compiled Wasm
+    /// engines and component bytes. Catalog mutations and executor admission
+    /// state remain local to the returned registry.
+    pub fn isolated_clone(&self) -> Result<Self, S4Error> {
+        Ok(Self {
+            state: RwLock::new(self.state.read().unwrap().clone()),
+            fuel: self.fuel,
+            pipeline_limits: self.pipeline_limits,
+            executor: Arc::new(WasmExecutor::new(self.executor_config)?),
+            executor_config: self.executor_config,
         })
     }
 
@@ -1588,6 +1605,40 @@ mod tests {
         assert_eq!(loaded.len(), 2);
         assert_eq!(registry.list().len(), 2);
         assert_eq!(registry.state.read().unwrap().engines.len(), 1);
+    }
+
+    #[test]
+    fn isolated_clone_shares_compiled_engines_but_not_mutable_state() {
+        let registry = PluginRegistry::new();
+        let bytes = component();
+        let digest = hex::encode(Sha256::digest(&bytes));
+        let plugin = registry.import("shared", &bytes).unwrap();
+        let isolated = registry.isolated_clone().unwrap();
+
+        let original_engine = registry
+            .state
+            .read()
+            .unwrap()
+            .engines
+            .get(&digest)
+            .unwrap()
+            .engine
+            .clone();
+        let isolated_engine = isolated
+            .state
+            .read()
+            .unwrap()
+            .engines
+            .get(&digest)
+            .unwrap()
+            .engine
+            .clone();
+        assert!(Arc::ptr_eq(&original_engine, &isolated_engine));
+        assert!(!Arc::ptr_eq(&registry.executor, &isolated.executor));
+
+        isolated.set_enabled(&plugin.id, false).unwrap();
+        assert!(registry.get_info(&plugin.id).unwrap().enabled);
+        assert!(!isolated.get_info(&plugin.id).unwrap().enabled);
     }
 
     #[test]

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -572,6 +572,117 @@ struct DemoPipelines {
     join: Option<PipelineSnapshot>,
 }
 
+struct DemoPipelineTemplate {
+    registry: PluginRegistry,
+    pii_id: String,
+    stable_id: Option<String>,
+}
+
+impl DemoPipelineTemplate {
+    fn instantiate(&self) -> anyhow::Result<DemoPipelines> {
+        let registry = self.registry.isolated_clone()?;
+        if let Some(stable_id) = &self.stable_id {
+            registry.set_enabled(stable_id, false);
+        }
+        let safe = registry.snapshot().constrained(demo_pipeline_limits())?;
+        let join = if let Some(stable_id) = &self.stable_id {
+            registry.set_enabled(stable_id, true);
+            registry.reorder(vec![stable_id.clone(), self.pii_id.clone()]);
+            Some(registry.snapshot().constrained(demo_pipeline_limits())?)
+        } else {
+            None
+        };
+        Ok(DemoPipelines { safe, join })
+    }
+}
+
+/// Immutable startup pipeline artifacts that can produce isolated gateway
+/// state without recompiling the same Wasm components.
+#[doc(hidden)]
+pub struct StatePipelineTemplate {
+    engine: Arc<s4_wasm_runtime::FilterEngine>,
+    plugins: PluginRegistry,
+    demo: DemoPipelineTemplate,
+    max_pipeline_output_bytes: u64,
+}
+
+impl StatePipelineTemplate {
+    #[doc(hidden)]
+    pub fn from_env() -> anyhow::Result<Self> {
+        let source_body_limits = source_body_limits_from_env();
+        let explicit_component_path = component_path();
+        let component_bytes = std::fs::read(&explicit_component_path)?;
+        let pipeline_fuel = std::env::var("S4_WASM_FUEL")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(crate::plugin_registry::DEFAULT_PIPELINE_FUEL);
+        let engine = Arc::new(s4_wasm_runtime::FilterEngine::with_fuel(
+            &component_bytes,
+            pipeline_fuel,
+        )?);
+        let default_pipeline_limits = PipelineLimits::default();
+        let max_pipeline_output_bytes = std::env::var("S4_MAX_PIPELINE_OUTPUT_BYTES")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(default_pipeline_limits.max_output_bytes)
+            .min(default_pipeline_limits.max_output_bytes);
+        let pipeline_limits = PipelineLimits {
+            max_input_bytes: default_pipeline_limits
+                .max_input_bytes
+                .min(source_body_limits.max_bytes),
+            max_output_bytes: max_pipeline_output_bytes,
+            max_cumulative_fuel: pipeline_fuel,
+            ..default_pipeline_limits
+        };
+        let plugins = PluginRegistry::with_options(
+            pipeline_fuel,
+            pipeline_limits,
+            s4_wasm_runtime::ExecutorConfig::default(),
+        )?;
+        let prefix_safe_hashes = prefix_safe_component_hashes();
+
+        use sha2::Digest as _;
+        let default_hash = hex::encode(sha2::Sha256::digest(&component_bytes));
+        plugins.import_with_capabilities(
+            "pii-default",
+            &component_bytes,
+            PluginCapabilities {
+                prefix_safe_for_read: prefix_safe_hashes.contains(&default_hash),
+            },
+        )?;
+
+        if let Ok(plugin_dir) = std::env::var("S4_PLUGINS_DIR") {
+            let dir = std::path::Path::new(&plugin_dir);
+            if dir.exists() {
+                plugins.load_from_dir_with_capabilities_excluding(
+                    dir,
+                    &prefix_safe_hashes,
+                    Some(&explicit_component_path),
+                )?;
+            }
+        }
+
+        let demo = build_demo_pipeline_template(
+            &component_bytes,
+            bundled_stable_component().as_deref(),
+            pipeline_fuel,
+        )?;
+        Ok(Self {
+            engine,
+            plugins,
+            demo,
+            max_pipeline_output_bytes,
+        })
+    }
+
+    fn instantiate(&self) -> anyhow::Result<(Gateway, Arc<PluginRegistry>, DemoPipelines)> {
+        let plugins = Arc::new(self.plugins.isolated_clone()?);
+        let gateway = Gateway::with_shared_registry(Arc::clone(&self.engine), plugins.clone());
+        Ok((gateway, plugins, self.demo.instantiate()?))
+    }
+}
+
 /// The process's single `AppState` shares this anonymous admission policy across
 /// all router clones and both processing routes. A noisy anonymous client can
 /// exhaust the shared allowance; edge or identity-aware limiting is the
@@ -638,32 +749,44 @@ fn demo_pipeline_limits() -> PipelineLimits {
     }
 }
 
+fn build_demo_pipeline_template(
+    pii_component: &[u8],
+    stable_component: Option<&[u8]>,
+    engine_fuel: u64,
+) -> anyhow::Result<DemoPipelineTemplate> {
+    let registry = PluginRegistry::with_fuel(engine_fuel);
+    let pii = registry.import("pii-default", pii_component)?;
+    let stable_id = if let Some(component) = stable_component {
+        let stable = match registry.import("stable-encrypt", component) {
+            Ok(stable) => stable,
+            Err(error) => {
+                warn!("stable-encrypt unavailable for the stateless demo: {error}");
+                return Ok(DemoPipelineTemplate {
+                    registry,
+                    pii_id: pii.id,
+                    stable_id: None,
+                });
+            }
+        };
+        registry.reorder(vec![stable.id.clone(), pii.id.clone()]);
+        Some(stable.id)
+    } else {
+        None
+    };
+    Ok(DemoPipelineTemplate {
+        registry,
+        pii_id: pii.id,
+        stable_id,
+    })
+}
+
+#[cfg(test)]
 fn build_demo_pipelines(
     pii_component: &[u8],
     stable_component: Option<&[u8]>,
     engine_fuel: u64,
 ) -> anyhow::Result<DemoPipelines> {
-    let registry = PluginRegistry::with_fuel(engine_fuel);
-    let pii = registry.import("pii-default", pii_component)?;
-    let safe = registry.snapshot().constrained(demo_pipeline_limits())?;
-    let join = stable_component.and_then(|component| {
-        let stable = match registry.import("stable-encrypt", component) {
-            Ok(stable) => stable,
-            Err(error) => {
-                warn!("stable-encrypt unavailable for the stateless demo: {error}");
-                return None;
-            }
-        };
-        registry.reorder(vec![stable.id, pii.id.clone()]);
-        match registry.snapshot().constrained(demo_pipeline_limits()) {
-            Ok(snapshot) => Some(snapshot),
-            Err(error) => {
-                warn!("join demo pipeline constraints are invalid: {error}");
-                None
-            }
-        }
-    });
-    Ok(DemoPipelines { safe, join })
+    build_demo_pipeline_template(pii_component, stable_component, engine_fuel)?.instantiate()
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -9204,6 +9327,22 @@ fn validate_storage_boundary_startup(
     Ok(())
 }
 
+fn source_body_limits_from_env() -> BodyLimits {
+    BodyLimits {
+        max_frame_bytes: std::env::var("S4_SOURCE_MAX_FRAME_BYTES")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(crate::object::DEFAULT_MAX_SOURCE_FRAME_BYTES),
+        max_bytes: std::env::var("S4_MAX_OBJECT_BYTES")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(crate::object::DEFAULT_MAX_SOURCE_BYTES)
+            .min(crate::object::DEFAULT_MAX_SOURCE_BYTES),
+    }
+}
+
 /// Build the engine state from environment variables, injecting the given
 /// control plane and key-wrapping backend. This is the shared construction
 /// path for both the OSS self-host binary (`NoopControlPlane` +
@@ -9213,6 +9352,20 @@ pub async fn build_state(
     control: Arc<dyn ControlPlane>,
     wrapping: Arc<dyn KeyWrapping>,
     workspace_storage: Arc<dyn WorkspaceStorageRepository>,
+) -> anyhow::Result<Arc<AppState>> {
+    let pipeline_template = StatePipelineTemplate::from_env()?;
+    build_state_with_pipeline_template(control, wrapping, workspace_storage, &pipeline_template)
+        .await
+}
+
+/// Build isolated state from startup artifacts that have already compiled the
+/// configured Wasm components.
+#[doc(hidden)]
+pub async fn build_state_with_pipeline_template(
+    control: Arc<dyn ControlPlane>,
+    wrapping: Arc<dyn KeyWrapping>,
+    workspace_storage: Arc<dyn WorkspaceStorageRepository>,
+    pipeline_template: &StatePipelineTemplate,
 ) -> anyhow::Result<Arc<AppState>> {
     let s3_endpoint = std::env::var("S3_ENDPOINT").ok();
     let auth_disabled = enabled_env_flag("AUTH_DISABLED");
@@ -9232,81 +9385,9 @@ pub async fn build_state(
     let workspace_endpoint_policy =
         WorkspaceEndpointPolicy::from_env(explicit_single_tenant).map_err(anyhow::Error::msg)?;
 
-    let source_body_limits = BodyLimits {
-        max_frame_bytes: std::env::var("S4_SOURCE_MAX_FRAME_BYTES")
-            .ok()
-            .and_then(|value| value.parse().ok())
-            .filter(|value| *value > 0)
-            .unwrap_or(crate::object::DEFAULT_MAX_SOURCE_FRAME_BYTES),
-        max_bytes: std::env::var("S4_MAX_OBJECT_BYTES")
-            .ok()
-            .and_then(|value| value.parse().ok())
-            .filter(|value| *value > 0)
-            .unwrap_or(crate::object::DEFAULT_MAX_SOURCE_BYTES)
-            .min(crate::object::DEFAULT_MAX_SOURCE_BYTES),
-    };
-
-    let explicit_component_path = component_path();
-    let component_bytes = std::fs::read(&explicit_component_path)?;
-    let pipeline_fuel = std::env::var("S4_WASM_FUEL")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(crate::plugin_registry::DEFAULT_PIPELINE_FUEL);
-    use sha2::Digest as _;
-
-    let engine = s4_wasm_runtime::FilterEngine::with_fuel(&component_bytes, pipeline_fuel)?;
-    let default_pipeline_limits = PipelineLimits::default();
-    let max_pipeline_output_bytes = std::env::var("S4_MAX_PIPELINE_OUTPUT_BYTES")
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(default_pipeline_limits.max_output_bytes)
-        .min(default_pipeline_limits.max_output_bytes);
-    let pipeline_limits = PipelineLimits {
-        max_input_bytes: default_pipeline_limits
-            .max_input_bytes
-            .min(source_body_limits.max_bytes),
-        max_output_bytes: max_pipeline_output_bytes,
-        max_cumulative_fuel: pipeline_fuel,
-        ..default_pipeline_limits
-    };
-    let plugins = Arc::new(PluginRegistry::with_options(
-        pipeline_fuel,
-        pipeline_limits,
-        s4_wasm_runtime::ExecutorConfig::default(),
-    )?);
-    let prefix_safe_hashes = prefix_safe_component_hashes();
-
-    // Only a startup-controlled component digest can grant direct-read safety.
-    let default_hash = hex::encode(sha2::Sha256::digest(&component_bytes));
-    plugins.import_with_capabilities(
-        "pii-default",
-        &component_bytes,
-        PluginCapabilities {
-            prefix_safe_for_read: prefix_safe_hashes.contains(&default_hash),
-        },
-    )?;
-
-    // Auto-load plugins from S4_PLUGINS_DIR if set
-    if let Ok(plugin_dir) = std::env::var("S4_PLUGINS_DIR") {
-        let dir = std::path::Path::new(&plugin_dir);
-        if dir.exists() {
-            plugins.load_from_dir_with_capabilities_excluding(
-                dir,
-                &prefix_safe_hashes,
-                Some(&explicit_component_path),
-            )?;
-        }
-    }
-
-    let stable_demo_component = bundled_stable_component();
-    let demo_pipelines = build_demo_pipelines(
-        &component_bytes,
-        stable_demo_component.as_deref(),
-        pipeline_fuel,
-    )?;
-
-    let gateway = Gateway::with_registry(engine, plugins.clone());
+    let source_body_limits = source_body_limits_from_env();
+    let max_pipeline_output_bytes = pipeline_template.max_pipeline_output_bytes;
+    let (gateway, plugins, demo_pipelines) = pipeline_template.instantiate()?;
 
     // Envelope encryption for API key secrets (needed to verify SigV4).
     // The wrapping backend is injected by the caller so the engine stays

--- a/crates/gateway/tests/s3_frontdoor_test.rs
+++ b/crates/gateway/tests/s3_frontdoor_test.rs
@@ -20,7 +20,10 @@ use s4_gateway::control::{
 use s4_gateway::key_cipher::{KeyWrapping, LocalKeyWrapping, SecretCipher, default_wrapping};
 use s4_gateway::object::BodyLimits;
 use s4_gateway::plugin_registry::{PipelineLimits, PluginRegistry};
-use s4_gateway::server::{AppState, StreamingReadMode, build_router, build_state};
+use s4_gateway::server::{
+    AppState, StatePipelineTemplate, StreamingReadMode, build_router,
+    build_state_with_pipeline_template,
+};
 use s4_gateway::sigv4::SigV4Policy;
 use s4_gateway::store::{
     FileKeyStore, KeyRepository, KeyStore, MAX_CREDENTIAL_LABEL_BYTES, MAX_CREDENTIAL_TTL_SECONDS,
@@ -33,7 +36,7 @@ use std::convert::Infallible;
 use std::pin::Pin;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::io::AsyncWriteExt as _;
@@ -240,50 +243,58 @@ impl http_body::Body for PollTrackingBody {
     }
 }
 
+fn test_pipeline_template() -> &'static StatePipelineTemplate {
+    static PIPELINES: OnceLock<StatePipelineTemplate> = OnceLock::new();
+    PIPELINES.get_or_init(|| {
+        // SAFETY: the process-wide fixture initializes the environment once,
+        // before any test state reads it.
+        unsafe {
+            std::env::set_var("AUTH_DISABLED", "0");
+            std::env::set_var("S4_SINGLE_TENANT", "1");
+            std::env::set_var("S4_WORKSPACE_ENDPOINT_PRIVATE_ALLOWLIST", "127.0.0.1");
+            std::env::remove_var("S4_WORKSPACE_ENDPOINT_ALLOWLIST");
+            std::env::remove_var("DATABASE_URL");
+            std::env::remove_var("S4_KEYS_FILE");
+            std::env::remove_var("S3_ENDPOINT");
+            std::env::remove_var("S4_SECRET_KEK");
+            std::env::remove_var("S4_SERVICE_BUCKETS");
+            std::env::remove_var("S4_LEGACY_MAX_OBJECT_BYTES");
+            std::env::remove_var("S4_MAX_OBJECT_BYTES");
+            std::env::remove_var("S4_MAX_PIPELINE_OUTPUT_BYTES");
+            std::env::remove_var("S4_STREAMING_READ_MODE");
+            std::env::remove_var("S4_STREAMING_WRITE_MODE");
+            std::env::remove_var("S4_TRANSFORMED_READ_SPOOL");
+            std::env::remove_var("S4_PREFIX_SAFE_COMPONENT_HASHES");
+            std::env::remove_var("S4_SPOOL_DIR");
+            std::env::remove_var("S4_SPOOL_MAX_OBJECT_BYTES");
+            std::env::remove_var("S4_SPOOL_QUOTA_BYTES");
+            std::env::remove_var("S4_STREAMING_S3_PROVIDER");
+            std::env::remove_var("S4_MANAGED_STREAMING_MODE");
+            std::env::remove_var("S4_MANAGED_STREAMING_TRANSACTIONAL");
+            std::env::remove_var("S4_MANAGED_PLACEMENT_VERSION");
+            std::env::remove_var("S4_DEV_MEMORY_STREAMING");
+            std::env::remove_var("S4_MULTIPART_MODE");
+            // Phase 12 removed the legacy buffered PUT/GET path entirely; the
+            // streaming in-memory dev backend is the only write/read path left.
+            std::env::set_var("S4_STREAMING_WRITE_MODE", "single");
+            std::env::set_var("S4_STREAMING_READ_MODE", "passthrough");
+            std::env::set_var("S4_DEV_MEMORY_STREAMING", "1");
+            // Load the built filter components so the full pipeline (including
+            // stable-encrypt) is available for joinable-read tests.
+            let components =
+                std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/components");
+            std::env::set_var("S4_PLUGINS_DIR", components);
+        }
+        StatePipelineTemplate::from_env().expect("compile test pipeline components")
+    })
+}
+
 async fn test_state() -> Arc<AppState> {
-    // SAFETY: test-only env mutation; every test in this file sets the same
-    // values so concurrent runs stay deterministic.
-    unsafe {
-        std::env::set_var("AUTH_DISABLED", "0");
-        std::env::set_var("S4_SINGLE_TENANT", "1");
-        std::env::set_var("S4_WORKSPACE_ENDPOINT_PRIVATE_ALLOWLIST", "127.0.0.1");
-        std::env::remove_var("S4_WORKSPACE_ENDPOINT_ALLOWLIST");
-        std::env::remove_var("DATABASE_URL");
-        std::env::remove_var("S4_KEYS_FILE");
-        std::env::remove_var("S3_ENDPOINT");
-        std::env::remove_var("S4_SECRET_KEK");
-        std::env::remove_var("S4_SERVICE_BUCKETS");
-        std::env::remove_var("S4_LEGACY_MAX_OBJECT_BYTES");
-        std::env::remove_var("S4_MAX_OBJECT_BYTES");
-        std::env::remove_var("S4_MAX_PIPELINE_OUTPUT_BYTES");
-        std::env::remove_var("S4_STREAMING_READ_MODE");
-        std::env::remove_var("S4_STREAMING_WRITE_MODE");
-        std::env::remove_var("S4_TRANSFORMED_READ_SPOOL");
-        std::env::remove_var("S4_PREFIX_SAFE_COMPONENT_HASHES");
-        std::env::remove_var("S4_SPOOL_DIR");
-        std::env::remove_var("S4_SPOOL_MAX_OBJECT_BYTES");
-        std::env::remove_var("S4_SPOOL_QUOTA_BYTES");
-        std::env::remove_var("S4_STREAMING_S3_PROVIDER");
-        std::env::remove_var("S4_MANAGED_STREAMING_MODE");
-        std::env::remove_var("S4_MANAGED_STREAMING_TRANSACTIONAL");
-        std::env::remove_var("S4_MANAGED_PLACEMENT_VERSION");
-        std::env::remove_var("S4_DEV_MEMORY_STREAMING");
-        std::env::remove_var("S4_MULTIPART_MODE");
-        // Phase 12 removed the legacy buffered PUT/GET path entirely; the
-        // streaming in-memory dev backend is the only write/read path left.
-        std::env::set_var("S4_STREAMING_WRITE_MODE", "single");
-        std::env::set_var("S4_STREAMING_READ_MODE", "passthrough");
-        std::env::set_var("S4_DEV_MEMORY_STREAMING", "1");
-        // Load the built filter components so the full pipeline (including
-        // stable-encrypt) is available for joinable-read tests.
-        let components =
-            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/components");
-        std::env::set_var("S4_PLUGINS_DIR", components);
-    }
-    build_state(
+    build_state_with_pipeline_template(
         Arc::new(NoopControlPlane),
         default_wrapping().expect("wrapping"),
         Arc::new(InMemoryWorkspaceStorageRepository::new()),
+        test_pipeline_template(),
     )
     .await
     .expect("build_state")
@@ -4454,6 +4465,9 @@ async fn unmodified_rust_sdk_default_put_is_accepted() {
 
 #[tokio::test]
 async fn available_aws_cli_and_boto3_interoperate() {
+    if std::env::var("S4_RUN_EXTERNAL_CLIENT_INTEROP").as_deref() != Ok("1") {
+        return;
+    }
     let aws_available = tokio::time::timeout(
         Duration::from_secs(5),
         Command::new("aws")
@@ -4472,9 +4486,14 @@ async fn available_aws_cli_and_boto3_interoperate() {
     )
     .await
     .is_ok_and(|result| result.is_ok_and(|output| output.status.success()));
-    if !aws_available && !boto3_available {
-        return;
-    }
+    assert!(
+        aws_available,
+        "S4_RUN_EXTERNAL_CLIENT_INTEROP requires AWS CLI"
+    );
+    assert!(
+        boto3_available,
+        "S4_RUN_EXTERNAL_CLIENT_INTEROP requires boto3"
+    );
 
     let mut state = test_state().await;
     Arc::get_mut(&mut state)

--- a/scripts/build-filters.sh
+++ b/scripts/build-filters.sh
@@ -70,7 +70,7 @@ for entry in "${FILTERS[@]}"; do
   # Rust crate names use underscores; package names use dashes.
   lib_name="${crate//-/_}"
   echo "=== Building ${crate} (WASI) ==="
-  cargo build --release -p "${crate}" --target "${TARGET}"
+  cargo build --locked --release -p "${crate}" --target "${TARGET}"
   wasm-tools component new \
     "${BIN_DIR}/${lib_name}.wasm" \
     --adapt "wasi_snapshot_preview1=${ADAPTER}" \
@@ -82,14 +82,14 @@ done
 # auto-load directory.
 TEST_OUT_DIR="$ROOT/target/test-components"
 mkdir -p "$TEST_OUT_DIR"
-cargo build --release -p test-filter --target "$TARGET"
+cargo build --locked --release -p test-filter --target "$TARGET"
 wasm-tools component new \
   "${BIN_DIR}/test_filter.wasm" \
   --adapt "wasi_snapshot_preview1=${ADAPTER}" \
   -o "${TEST_OUT_DIR}/test-filter.component.wasm"
 
 # v0.2 world fixture: exercises `operation` and `config-json` context delivery.
-cargo build --release -p test-filter-v02 --target "$TARGET"
+cargo build --locked --release -p test-filter-v02 --target "$TARGET"
 wasm-tools component new \
   "${BIN_DIR}/test_filter_v02.wasm" \
   --adapt "wasi_snapshot_preview1=${ADAPTER}" \
@@ -97,7 +97,7 @@ wasm-tools component new \
 
 # Binary reductors receive no host imports. Build this fixture for the bare Wasm
 # target and componentize it without a WASI adapter.
-cargo build --release -p test-binary-reductor --target "$NO_WASI_TARGET"
+cargo build --locked --release -p test-binary-reductor --target "$NO_WASI_TARGET"
 wasm-tools component new \
   "${NO_WASI_BIN_DIR}/test_binary_reductor.wasm" \
   -o "${TEST_OUT_DIR}/test-binary-reductor.component.wasm"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -5,12 +5,12 @@ echo "=== cargo fmt --check ==="
 cargo fmt --check
 
 echo "=== cargo clippy ==="
-cargo clippy --all-targets -- -D warnings
+cargo clippy --locked --all-targets -- -D warnings
 
 echo "=== building filters ==="
 bash scripts/build-filters.sh
 
 echo "=== cargo test ==="
-cargo test --workspace
+cargo test --locked --workspace
 
 echo "=== All Phase 0 checks passed ==="

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -50,7 +50,7 @@ docker run "${MC_OPTS[@]}" mb local/s4-local --ignore-existing
 # 3. Build filters and binaries
 echo "--- Building filters and binaries ---"
 (cd "$ROOT" && bash scripts/build-filters.sh)
-(cd "$ROOT" && cargo build -p s4-gateway -p s4ctl)
+(cd "$ROOT" && cargo build --locked -p s4-gateway -p s4ctl)
 
 # 4. Start the gateway against MinIO (auth disabled)
 echo "--- Starting S4 gateway on $GW_URL ---"

--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -29,10 +29,10 @@ if [ ! -f "$PROJECT_DIR/target/components/pii-default.component.wasm" ]; then
 fi
 
 echo "→ Building gateway..."
-(cd "$PROJECT_DIR" && cargo build -p s4-gateway)
+(cd "$PROJECT_DIR" && cargo build --locked -p s4-gateway)
 
 echo "→ Starting gateway on port $GATEWAY_PORT..."
-(cd "$PROJECT_DIR" && AUTH_DISABLED=true S4_KEYS_FILE="$KEYS_FILE" LISTEN_ADDR="127.0.0.1:$GATEWAY_PORT" cargo run -p s4-gateway) &
+(cd "$PROJECT_DIR" && AUTH_DISABLED=true S4_KEYS_FILE="$KEYS_FILE" LISTEN_ADDR="127.0.0.1:$GATEWAY_PORT" cargo run --locked -p s4-gateway) &
 GATEWAY_PID=$!
 
 # Wait for gateway to be ready


### PR DESCRIPTION
## Summary

- compile gateway startup pipeline artifacts once per front-door test process, then fork isolated registries and executors that share only immutable Wasm engines
- reduce the local `s3_frontdoor_test` runtime from 343.47s to 5.63s without sharding or additional CI runners
- harden PR and scheduled CI with stale-run cancellation, merge-queue support, strict aggregate status, timeouts, locked Cargo commands, complete SDK drift detection, and explicit external-client interop
- remove duplicate Monday RSS and MinIO jobs while retaining their Nightly coverage

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked --workspace`
- [x] parallel and serial `s3_frontdoor_test` runs
- [x] explicit AWS CLI and boto3 interop run
- [x] 10,000-case Nightly property command (41.47s locally)
- [x] workflow parsing with `act -l`
- [x] `bash -n` for modified CI scripts