### PR TITLE
feat(gateway): close hosted Wasm runtime gaps

### DIFF
--- a/crates/gateway/src/control.rs
+++ b/crates/gateway/src/control.rs
@@ -71,6 +71,8 @@ pub struct UsageAuthorization {
     route: UsageRoute,
     kind: RequestKind,
     max_processed_bytes: u64,
+    pipeline_revision: Option<String>,
+    pipeline_fingerprint: Option<String>,
 }
 
 impl UsageAuthorization {
@@ -89,7 +91,15 @@ impl UsageAuthorization {
             route,
             kind,
             max_processed_bytes,
+            pipeline_revision: None,
+            pipeline_fingerprint: None,
         }
+    }
+
+    pub(crate) fn with_pipeline(mut self, locator: &crate::pipeline::PipelineLocator) -> Self {
+        self.pipeline_revision = Some(locator.revision.clone());
+        self.pipeline_fingerprint = Some(locator.fingerprint.clone());
+        self
     }
 
     pub fn operation_id(&self) -> Uuid {
@@ -115,6 +125,14 @@ impl UsageAuthorization {
     pub fn max_processed_bytes(&self) -> u64 {
         self.max_processed_bytes
     }
+
+    pub fn pipeline_revision(&self) -> Option<&str> {
+        self.pipeline_revision.as_deref()
+    }
+
+    pub fn pipeline_fingerprint(&self) -> Option<&str> {
+        self.pipeline_fingerprint.as_deref()
+    }
 }
 
 /// Immutable authorization facts selected before an operation can begin.
@@ -131,6 +149,8 @@ pub struct AuthorizationGrant {
     route: UsageRoute,
     kind: RequestKind,
     max_processed_bytes: u64,
+    pipeline_revision: Option<String>,
+    pipeline_fingerprint: Option<String>,
 }
 
 impl AuthorizationGrant {
@@ -149,6 +169,8 @@ impl AuthorizationGrant {
             route: authorization.route,
             kind: authorization.kind,
             max_processed_bytes: authorization.max_processed_bytes,
+            pipeline_revision: authorization.pipeline_revision.clone(),
+            pipeline_fingerprint: authorization.pipeline_fingerprint.clone(),
         }
     }
 
@@ -184,6 +206,14 @@ impl AuthorizationGrant {
         self.max_processed_bytes
     }
 
+    pub fn pipeline_revision(&self) -> Option<&str> {
+        self.pipeline_revision.as_deref()
+    }
+
+    pub fn pipeline_fingerprint(&self) -> Option<&str> {
+        self.pipeline_fingerprint.as_deref()
+    }
+
     pub(crate) fn matches(&self, authorization: &UsageAuthorization) -> bool {
         self.operation_id == authorization.operation_id
             && self.receipt_id == authorization.receipt_id
@@ -191,6 +221,8 @@ impl AuthorizationGrant {
             && self.route == authorization.route
             && self.kind == authorization.kind
             && self.max_processed_bytes == authorization.max_processed_bytes
+            && self.pipeline_revision == authorization.pipeline_revision
+            && self.pipeline_fingerprint == authorization.pipeline_fingerprint
     }
 }
 
@@ -237,6 +269,84 @@ pub struct PipelineEvidence {
     pub duration_ms: u64,
     /// Spool mode (`none` or `encrypted`) for unsafe-read evidence.
     pub spool_mode: String,
+}
+
+/// Internal execution-attempt evidence. This is deliberately separate from
+/// [`UsageEvent`]: failed work contributes to platform COGS but never creates a
+/// customer usage receipt or charge.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PipelineAttempt {
+    operation_id: Uuid,
+    bucket: String,
+    direction: crate::pipeline::PipelineDirection,
+    revision: Option<String>,
+    fingerprint: Option<String>,
+    components: Option<String>,
+    error_code: &'static str,
+    fuel_consumed: u64,
+    duration_ms: u64,
+}
+
+impl PipelineAttempt {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn failed(
+        operation_id: Uuid,
+        bucket: impl Into<String>,
+        direction: crate::pipeline::PipelineDirection,
+        resolution: Option<&crate::pipeline::PipelineResolution>,
+        components: Option<String>,
+        error_code: &'static str,
+        fuel_consumed: u64,
+        duration_ms: u64,
+    ) -> Self {
+        Self {
+            operation_id,
+            bucket: bucket.into(),
+            direction,
+            revision: resolution.map(|value| value.locator.revision.clone()),
+            fingerprint: resolution.map(|value| value.locator.fingerprint.clone()),
+            components,
+            error_code,
+            fuel_consumed,
+            duration_ms,
+        }
+    }
+
+    pub fn operation_id(&self) -> Uuid {
+        self.operation_id
+    }
+
+    pub fn bucket(&self) -> &str {
+        &self.bucket
+    }
+
+    pub fn direction(&self) -> crate::pipeline::PipelineDirection {
+        self.direction
+    }
+
+    pub fn revision(&self) -> Option<&str> {
+        self.revision.as_deref()
+    }
+
+    pub fn fingerprint(&self) -> Option<&str> {
+        self.fingerprint.as_deref()
+    }
+
+    pub fn components(&self) -> Option<&str> {
+        self.components.as_deref()
+    }
+
+    pub fn error_code(&self) -> &'static str {
+        self.error_code
+    }
+
+    pub fn fuel_consumed(&self) -> u64 {
+        self.fuel_consumed
+    }
+
+    pub fn duration_ms(&self) -> u64 {
+        self.duration_ms
+    }
 }
 
 impl UsageEvent {
@@ -379,6 +489,17 @@ pub trait ControlPlane: Send + Sync + 'static {
         context: &AuthenticatedRequestContext,
         event: &UsageEvent,
     ) -> Result<(), MeteringError>;
+
+    /// Record internal failed-attempt COGS. The default preserves compatibility
+    /// for existing control planes; hosted implementations may persist it in a
+    /// ledger that is not connected to customer settlement.
+    async fn record_pipeline_attempt(
+        &self,
+        _context: &AuthenticatedRequestContext,
+        _attempt: &PipelineAttempt,
+    ) -> Result<(), MeteringError> {
+        Ok(())
+    }
 
     /// Optional tenant ceiling. `None` inherits the deployment ceiling; a
     /// tenant can only lower, never raise, the configured mode.
@@ -591,6 +712,42 @@ mod tests {
         ] {
             assert!(!grant.matches(&mismatch));
         }
+    }
+
+    #[test]
+    fn grant_validation_binds_pipeline_revision_and_fingerprint() {
+        let authorization = UsageAuthorization::new(
+            Uuid::now_v7(),
+            Uuid::now_v7(),
+            "bucket",
+            UsageRoute::PutObject,
+            RequestKind::Write,
+            64,
+        )
+        .with_pipeline(&crate::pipeline::PipelineLocator {
+            revision: "revision-a".to_string(),
+            fingerprint: "a".repeat(64),
+        });
+        let grant = AuthorizationGrant::new(&authorization, Utc::now(), 1);
+        assert_eq!(grant.pipeline_revision(), Some("revision-a"));
+        assert_eq!(
+            grant.pipeline_fingerprint(),
+            authorization.pipeline_fingerprint()
+        );
+
+        let changed = UsageAuthorization::new(
+            authorization.operation_id(),
+            authorization.receipt_id(),
+            "bucket",
+            UsageRoute::PutObject,
+            RequestKind::Write,
+            64,
+        )
+        .with_pipeline(&crate::pipeline::PipelineLocator {
+            revision: "revision-b".to_string(),
+            fingerprint: "b".repeat(64),
+        });
+        assert!(!grant.matches(&changed));
     }
 
     #[test]

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -107,7 +107,9 @@ impl Gateway {
                 "no pipeline resolver is configured",
             )
         })?;
-        resolver.resolve(workspace_id, bucket, direction).await
+        let resolution = resolver.resolve(workspace_id, bucket, direction).await?;
+        resolution.verify_fingerprint(direction)?;
+        Ok(resolution)
     }
 
     /// Resolve the effective pipeline after authentication, before

--- a/crates/gateway/src/pipeline.rs
+++ b/crates/gateway/src/pipeline.rs
@@ -37,6 +37,10 @@ pub struct PipelineLocator {
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PipelineStep {
     pub component_hash: String,
+    /// Exact immutable hosted plugin-version identity. Static catalogs omit
+    /// this so their serialized snapshots and fingerprints stay compatible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plugin_version_id: Option<String>,
     /// Disabled steps remain part of the immutable revision fingerprint but
     /// are not loaded or executed. Older persisted resolutions predate this
     /// field and contained only enabled steps.
@@ -63,6 +67,11 @@ const fn enabled_by_default() -> bool {
 pub struct PipelineResolution {
     pub locator: PipelineLocator,
     pub steps: Vec<PipelineStep>,
+    /// Monotonic hosted publication generation. Static and legacy resolutions
+    /// omit it; a republish can therefore freeze a distinct policy identity
+    /// even when every step is otherwise byte-identical.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_generation: Option<u64>,
     /// An empty chain is legal only when this is true.
     #[serde(default)]
     pub explicit_passthrough: bool,
@@ -74,6 +83,8 @@ struct PersistedPipelineResolution {
     locator: PipelineLocator,
     steps: Vec<PersistedPipelineStep>,
     #[serde(default)]
+    policy_generation: Option<u64>,
+    #[serde(default)]
     explicit_passthrough: bool,
     limits: PipelineLimits,
 }
@@ -81,6 +92,8 @@ struct PersistedPipelineResolution {
 #[derive(serde::Deserialize)]
 struct PersistedPipelineStep {
     component_hash: String,
+    #[serde(default)]
+    plugin_version_id: Option<String>,
     #[serde(default = "enabled_by_default")]
     enabled: bool,
     #[serde(default)]
@@ -106,6 +119,7 @@ impl<'de> serde::Deserialize<'de> for PipelineResolution {
                 .into_iter()
                 .map(|step| PipelineStep {
                     component_hash: step.component_hash,
+                    plugin_version_id: step.plugin_version_id,
                     enabled: step.enabled,
                     version: step.version,
                     config_json: step.config_json,
@@ -117,9 +131,31 @@ impl<'de> serde::Deserialize<'de> for PipelineResolution {
                     }),
                 })
                 .collect(),
+            policy_generation: persisted.policy_generation,
             explicit_passthrough: persisted.explicit_passthrough,
             limits: persisted.limits,
         })
+    }
+}
+
+impl PipelineResolution {
+    /// Verify persisted or externally resolved policy against the canonical
+    /// public fingerprint for this request direction.
+    pub fn verify_fingerprint(&self, direction: PipelineDirection) -> Result<(), S4Error> {
+        let recomputed = resolution_fingerprint_with_generation(
+            direction,
+            &self.steps,
+            self.explicit_passthrough,
+            self.limits,
+            self.policy_generation,
+        );
+        if recomputed != self.locator.fingerprint {
+            return Err(S4Error::new(
+                codes::CONFIG_INVALID,
+                "pipeline fingerprint does not match its immutable resolution",
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -161,6 +197,7 @@ impl StaticPipelineResolver {
             .into_iter()
             .map(|(info, component_hash, capabilities)| PipelineStep {
                 component_hash,
+                plugin_version_id: None,
                 enabled: true,
                 version: Some(info.version),
                 config_json: None,
@@ -179,6 +216,7 @@ impl StaticPipelineResolver {
                 fingerprint,
             },
             steps,
+            policy_generation: None,
             explicit_passthrough,
             limits,
         }
@@ -215,6 +253,49 @@ pub fn resolution_fingerprint(
     let encoded = serde_json::to_vec(&canonical)
         .expect("canonical fingerprint encoding is always serializable");
     hex::encode(Sha256::digest(&encoded))
+}
+
+/// Canonical hosted fingerprint extension. Omitting the generation delegates
+/// to the original byte contract exactly, preserving every static fingerprint.
+pub fn resolution_fingerprint_with_generation(
+    direction: PipelineDirection,
+    steps: &[PipelineStep],
+    explicit_passthrough: bool,
+    limits: PipelineLimits,
+    policy_generation: Option<u64>,
+) -> String {
+    let Some(policy_generation) = policy_generation else {
+        return resolution_fingerprint(direction, steps, explicit_passthrough, limits);
+    };
+    let canonical = serde_json::json!({
+        "direction": format!("{direction:?}").to_ascii_lowercase(),
+        "steps": steps,
+        "explicit_passthrough": explicit_passthrough,
+        "limits": limits,
+        "policy_generation": policy_generation,
+    });
+    let encoded = serde_json::to_vec(&canonical)
+        .expect("canonical fingerprint encoding is always serializable");
+    hex::encode(Sha256::digest(&encoded))
+}
+
+/// Stable count plus digest fingerprint for the enabled component set. Digest
+/// order is canonicalized because compilation COGS is content-addressed, not
+/// execution-position-addressed.
+pub fn component_digest_evidence(steps: &[PipelineStep]) -> String {
+    let mut hashes: Vec<&str> = steps
+        .iter()
+        .filter(|step| step.enabled)
+        .map(|step| step.component_hash.as_str())
+        .collect();
+    hashes.sort_unstable();
+    let canonical =
+        serde_json::to_vec(&hashes).expect("component digest evidence is always serializable");
+    format!(
+        "v1:{}:{}",
+        hashes.len(),
+        hex::encode(Sha256::digest(canonical))
+    )
 }
 
 pub(crate) fn plugin_step_info(step: &PipelineStep) -> PluginInfo {
@@ -292,6 +373,137 @@ mod tests {
         assert_eq!(
             hosted_resolution.steps[0].sensitive_grant,
             s4_wasm_runtime::SensitiveGrant::NONE
+        );
+    }
+
+    #[test]
+    fn canonical_fingerprint_round_trips_and_rejects_persisted_tampering() {
+        let resolver = StaticPipelineResolver::new(Arc::new(PluginRegistry::new()));
+        let resolution = resolver.resolution(PipelineDirection::Write);
+        resolution
+            .verify_fingerprint(PipelineDirection::Write)
+            .unwrap();
+        assert_eq!(
+            resolution
+                .verify_fingerprint(PipelineDirection::Read)
+                .unwrap_err()
+                .code(),
+            codes::CONFIG_INVALID
+        );
+
+        let mut persisted: serde_json::Value = serde_json::to_value(&resolution).unwrap();
+        persisted["explicit_passthrough"] = serde_json::Value::Bool(false);
+        let tampered: PipelineResolution = serde_json::from_value(persisted).unwrap();
+        assert_eq!(
+            tampered
+                .verify_fingerprint(PipelineDirection::Write)
+                .unwrap_err()
+                .code(),
+            codes::CONFIG_INVALID
+        );
+    }
+
+    #[test]
+    fn component_evidence_has_explicit_count_and_order_independent_digest() {
+        let step = |hash: &str| PipelineStep {
+            component_hash: hash.to_string(),
+            plugin_version_id: None,
+            enabled: true,
+            version: None,
+            config_json: None,
+            capabilities: PluginCapabilities::default(),
+            sensitive_grant: s4_wasm_runtime::SensitiveGrant::NONE,
+        };
+        let first = component_digest_evidence(&[step("b"), step("a")]);
+        let second = component_digest_evidence(&[step("a"), step("b")]);
+        assert_eq!(first, second);
+        assert!(first.starts_with("v1:2:"));
+        assert_eq!(first.len(), 69);
+    }
+
+    #[test]
+    fn exact_plugin_version_identity_and_policy_generation_are_fingerprint_inputs() {
+        let step = |plugin_version_id: &str| PipelineStep {
+            component_hash: "a".repeat(64),
+            plugin_version_id: Some(plugin_version_id.to_string()),
+            enabled: true,
+            version: Some("same-label".to_string()),
+            config_json: None,
+            capabilities: PluginCapabilities::default(),
+            sensitive_grant: s4_wasm_runtime::SensitiveGrant::NONE,
+        };
+        let limits = PipelineLimits::default();
+        let first = resolution_fingerprint(
+            PipelineDirection::Write,
+            &[step("version-a")],
+            false,
+            limits,
+        );
+        let second = resolution_fingerprint(
+            PipelineDirection::Write,
+            &[step("version-b")],
+            false,
+            limits,
+        );
+        assert_ne!(
+            first, second,
+            "exact version identity must distinguish identical bytes and labels"
+        );
+
+        let steps = [step("version-a")];
+        let generation_one = resolution_fingerprint_with_generation(
+            PipelineDirection::Write,
+            &steps,
+            false,
+            limits,
+            Some(1),
+        );
+        let generation_two = resolution_fingerprint_with_generation(
+            PipelineDirection::Write,
+            &steps,
+            false,
+            limits,
+            Some(2),
+        );
+        assert_ne!(
+            generation_one, generation_two,
+            "republishing must advance policy identity"
+        );
+    }
+
+    #[test]
+    fn absent_hosted_identity_fields_preserve_static_serialization_and_fingerprint() {
+        let resolver = StaticPipelineResolver::new(Arc::new(PluginRegistry::new()));
+        let resolution = resolver.resolution(PipelineDirection::Write);
+        let serialized = serde_json::to_value(&resolution).unwrap();
+        assert!(serialized.get("policy_generation").is_none());
+        assert!(
+            serialized["steps"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|step| step.get("plugin_version_id").is_none())
+        );
+
+        let legacy_canonical = serde_json::json!({
+            "direction": "write",
+            "steps": resolution.steps,
+            "explicit_passthrough": resolution.explicit_passthrough,
+            "limits": resolution.limits,
+        });
+        let legacy = hex::encode(Sha256::digest(
+            serde_json::to_vec(&legacy_canonical).unwrap(),
+        ));
+        assert_eq!(resolution.locator.fingerprint, legacy);
+        assert_eq!(
+            resolution_fingerprint_with_generation(
+                PipelineDirection::Write,
+                &resolution.steps,
+                resolution.explicit_passthrough,
+                resolution.limits,
+                None,
+            ),
+            legacy
         );
     }
 }

--- a/crates/gateway/src/plugin_registry.rs
+++ b/crates/gateway/src/plugin_registry.rs
@@ -7,8 +7,8 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use s4_error::{S4Error, codes};
 use s4_wasm_runtime::{
-    CancellationToken, ExecutorConfig, FilterEngine, FilterSession, SensitiveGrant,
-    TransformOutcome, WasmExecutor,
+    CancellationToken, ExecutorConfig, FilterEngine, FilterSession, FilterWorldVersion,
+    SensitiveGrant, TransformOutcome, WasmExecutor,
 };
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -16,8 +16,8 @@ use uuid::Uuid;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::pipeline::{
-    ComponentSource, PipelineResolution, PipelineStep, pipeline_requires_passthrough,
-    plugin_step_info,
+    ComponentSource, PipelineResolution, PipelineStep, component_digest_evidence,
+    pipeline_requires_passthrough, plugin_step_info,
 };
 use crate::record::{OutputValidator, Record};
 
@@ -151,12 +151,23 @@ impl PipelineSnapshot {
     ) -> Option<crate::control::PipelineEvidence> {
         let fingerprint = self.fingerprint.as_ref()?;
         let revision = self.revision.as_deref()?;
-        let mut hashes: Vec<&str> = self.component_hashes().into_iter().collect();
-        hashes.sort_unstable();
+        let steps = self
+            .plugins
+            .iter()
+            .map(|plugin| PipelineStep {
+                component_hash: plugin.component_hash.clone(),
+                plugin_version_id: None,
+                enabled: plugin.enabled,
+                version: None,
+                config_json: None,
+                capabilities: plugin.capabilities,
+                sensitive_grant: SensitiveGrant::NONE,
+            })
+            .collect::<Vec<_>>();
         Some(crate::control::PipelineEvidence {
             revision: revision.to_string(),
             fingerprint: fingerprint.clone(),
-            components: hashes.join(","),
+            components: component_digest_evidence(&steps),
             fuel_consumed,
             duration_ms,
             spool_mode: spool_mode.to_string(),
@@ -582,7 +593,14 @@ impl PluginRegistry {
         let mut plugins = Vec::with_capacity(resolution.steps.len());
         for step in &resolution.steps {
             let engine = if step.enabled {
-                Some(self.engine_for(step, source).await?)
+                let engine = self.engine_for(step, source).await?;
+                if step.config_json.is_some() && engine.world_version() == FilterWorldVersion::V01 {
+                    return Err(S4Error::new(
+                        codes::CONFIG_INVALID,
+                        "v0.1 components cannot carry step configuration",
+                    ));
+                }
+                Some(engine)
             } else {
                 None
             };
@@ -2344,6 +2362,7 @@ mod tests {
                 fingerprint: "deadbeef".to_string(),
             },
             steps: Vec::new(),
+            policy_generation: None,
             explicit_passthrough: false,
             limits: PipelineLimits::default(),
         };
@@ -2365,12 +2384,14 @@ mod tests {
             },
             steps: vec![PipelineStep {
                 component_hash: "unavailable-disabled-component".to_string(),
+                plugin_version_id: None,
                 enabled: false,
                 version: None,
                 config_json: None,
                 capabilities: PluginCapabilities::default(),
                 sensitive_grant: SensitiveGrant::NONE,
             }],
+            policy_generation: None,
             explicit_passthrough: false,
             limits: PipelineLimits::default(),
         };
@@ -2391,6 +2412,7 @@ mod tests {
                 fingerprint: "deadbeef".to_string(),
             },
             steps: Vec::new(),
+            policy_generation: None,
             explicit_passthrough: true,
             limits: PipelineLimits::default(),
         };
@@ -2420,6 +2442,7 @@ mod tests {
                 fingerprint: "deadbeef".to_string(),
             },
             steps: Vec::new(),
+            policy_generation: None,
             explicit_passthrough: true,
             limits: PipelineLimits::default(),
         };
@@ -2434,6 +2457,7 @@ mod tests {
         let registry = PluginRegistry::new();
         let step = PipelineStep {
             component_hash: "bogus-not-a-real-sha256".to_string(),
+            plugin_version_id: None,
             enabled: true,
             version: None,
             config_json: None,
@@ -2446,6 +2470,7 @@ mod tests {
                 fingerprint: "deadbeef".to_string(),
             },
             steps: vec![step],
+            policy_generation: None,
             explicit_passthrough: false,
             limits: PipelineLimits::default(),
         };
@@ -2496,6 +2521,7 @@ mod tests {
         let digest = hex::encode(Sha256::digest(&bytes));
         let step = PipelineStep {
             component_hash: digest,
+            plugin_version_id: None,
             enabled: true,
             version: Some("1.0.0".to_string()),
             config_json: None,
@@ -2508,6 +2534,7 @@ mod tests {
                 fingerprint: "deadbeef".to_string(),
             },
             steps: vec![step],
+            policy_generation: None,
             explicit_passthrough: false,
             limits: PipelineLimits::default(),
         };
@@ -2538,12 +2565,14 @@ mod tests {
             },
             steps: vec![PipelineStep {
                 component_hash: digest,
+                plugin_version_id: None,
                 enabled: true,
                 version: Some("0.2.0".to_string()),
                 config_json: Some(r#"{"region":"eu"}"#.to_string()),
                 capabilities: PluginCapabilities::default(),
                 sensitive_grant: SensitiveGrant::NONE,
             }],
+            policy_generation: None,
             explicit_passthrough: false,
             limits: PipelineLimits::default(),
         };
@@ -2564,6 +2593,43 @@ mod tests {
         assert_eq!(
             pipeline.process(Record::new("payload", "")).unwrap(),
             Some(Record::new("payload", ""))
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_for_publicly_rejects_config_on_v01_component() {
+        let bytes = component();
+        let digest = hex::encode(Sha256::digest(&bytes));
+        let registry = PluginRegistry::new();
+        registry.import("v01", &bytes).unwrap();
+        let resolution = PipelineResolution {
+            locator: crate::pipeline::PipelineLocator {
+                revision: "configured-v01".to_string(),
+                fingerprint: "fingerprint".to_string(),
+            },
+            steps: vec![PipelineStep {
+                component_hash: digest,
+                plugin_version_id: None,
+                enabled: true,
+                version: Some("0.1.0".to_string()),
+                config_json: Some(r#"{"forbidden":true}"#.to_string()),
+                capabilities: PluginCapabilities::default(),
+                sensitive_grant: SensitiveGrant::NONE,
+            }],
+            policy_generation: None,
+            explicit_passthrough: false,
+            limits: PipelineLimits::default(),
+        };
+
+        let error = registry
+            .snapshot_for(&resolution, &registry)
+            .await
+            .err()
+            .expect("configured v0.1 step must be rejected");
+        assert_eq!(error.code(), codes::CONFIG_INVALID);
+        assert_eq!(
+            error.message(),
+            "v0.1 components cannot carry step configuration"
         );
     }
 

--- a/crates/gateway/src/s3_error.rs
+++ b/crates/gateway/src/s3_error.rs
@@ -3,6 +3,19 @@ use uuid::Uuid;
 
 use crate::object::harden_object_response_headers;
 
+const MAX_S3_ERROR_FIELD_BYTES: usize = 1024;
+
+fn bounded_field(value: &str) -> String {
+    let mut output = String::with_capacity(value.len().min(MAX_S3_ERROR_FIELD_BYTES));
+    for character in value.chars() {
+        if output.len() + character.len_utf8() > MAX_S3_ERROR_FIELD_BYTES {
+            break;
+        }
+        output.push(character);
+    }
+    output
+}
+
 fn push_xml_text(output: &mut String, value: &str) {
     for character in value.chars() {
         match character {
@@ -34,9 +47,9 @@ fn push_xml_element(output: &mut String, name: &'static str, value: &str) {
 
 fn s3_error_body(code: &str, message: &str, resource: &str, request_id: &str) -> String {
     let mut body = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n");
-    push_xml_element(&mut body, "Code", code);
-    push_xml_element(&mut body, "Message", message);
-    push_xml_element(&mut body, "Key", resource);
+    push_xml_element(&mut body, "Code", &bounded_field(code));
+    push_xml_element(&mut body, "Message", &bounded_field(message));
+    push_xml_element(&mut body, "Key", &bounded_field(resource));
     push_xml_element(&mut body, "RequestId", request_id);
     body.push_str("</Error>");
     body
@@ -69,12 +82,10 @@ pub fn no_such_key(key: &str) -> axum::response::Response {
     )
 }
 
-pub fn internal_error(key: &str, detail: &str) -> axum::response::Response {
-    let mut message = String::from("We encountered an internal error: ");
-    message.push_str(detail);
+pub fn internal_error(key: &str, _detail: &str) -> axum::response::Response {
     s3_error_xml(
         "InternalError",
-        &message,
+        "We encountered an internal error.",
         key,
         StatusCode::INTERNAL_SERVER_ERROR,
     )
@@ -205,7 +216,8 @@ pub fn bucket_not_allowed(bucket: &str) -> axum::response::Response {
 
 #[cfg(test)]
 mod tests {
-    use super::s3_error_body;
+    use super::{MAX_S3_ERROR_FIELD_BYTES, internal_error, s3_error_body};
+    use http_body_util::BodyExt as _;
 
     #[test]
     fn every_dynamic_error_field_is_xml_text_not_markup() {
@@ -231,5 +243,16 @@ mod tests {
             body.contains("bucket/&lt;Injected&gt;resource&lt;/Injected&gt;&amp;&quot;&apos;�")
         );
         assert!(body.contains("request&lt;/RequestId&gt;&lt;Injected request=&quot;1&quot;&gt;"));
+    }
+
+    #[tokio::test]
+    async fn dynamic_fields_are_globally_bounded_and_internal_detail_is_opaque() {
+        let secret = "PRINTABLE_GRANTED_SECRET";
+        let response = internal_error(&"k".repeat(4096), &format!("{secret}{}", "x".repeat(4096)));
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(!body.contains(secret));
+        assert!(body.contains("We encountered an internal error."));
+        assert!(body.len() < MAX_S3_ERROR_FIELD_BYTES + 512);
     }
 }

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -44,8 +44,8 @@ use crate::backend::{
 };
 use crate::control::{
     AuthenticatedRequestContext, AuthorizationDecision, AuthorizationError, AuthorizationGrant,
-    ControlPlane, MeteringError, RequestKind, StreamingWriteMode, UsageAuthorization, UsageEvent,
-    UsageRoute,
+    ControlPlane, MeteringError, PipelineAttempt, RequestKind, StreamingWriteMode,
+    UsageAuthorization, UsageEvent, UsageRoute,
 };
 use crate::customer_headers;
 use crate::integrity::{BodyVerifier, IntegrityError};
@@ -210,6 +210,18 @@ impl OperationIdentity {
             max_processed_bytes,
         )
     }
+
+    fn pipeline_authorization(
+        self,
+        bucket: &str,
+        route: UsageRoute,
+        kind: RequestKind,
+        max_processed_bytes: u64,
+        resolution: &crate::pipeline::PipelineResolution,
+    ) -> UsageAuthorization {
+        self.authorization(bucket, route, kind, max_processed_bytes)
+            .with_pipeline(&resolution.locator)
+    }
 }
 
 fn object_max_processed_bytes(state: &AppState) -> u64 {
@@ -320,6 +332,50 @@ async fn record_usage(
         warn!(event_id = %event.receipt_id(), ?error, "usage event was not recorded");
         metering_error_response(key, error)
     })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn record_failed_pipeline_attempt(
+    control: &dyn ControlPlane,
+    context: &AuthenticatedRequestContext,
+    operation_id: Uuid,
+    bucket: &str,
+    direction: crate::pipeline::PipelineDirection,
+    resolution: Option<&crate::pipeline::PipelineResolution>,
+    error_code: &'static str,
+    duration_ms: u64,
+) {
+    let components =
+        resolution.map(|value| crate::pipeline::component_digest_evidence(&value.steps));
+    let attempt = PipelineAttempt::failed(
+        operation_id,
+        bucket,
+        direction,
+        resolution,
+        components,
+        error_code,
+        0,
+        duration_ms,
+    );
+    warn!(
+        operation_id = %attempt.operation_id(),
+        bucket = attempt.bucket(),
+        direction = ?attempt.direction(),
+        revision = attempt.revision(),
+        fingerprint = attempt.fingerprint(),
+        components = attempt.components(),
+        error_code = attempt.error_code(),
+        fuel_consumed = attempt.fuel_consumed(),
+        duration_ms = attempt.duration_ms(),
+        "pipeline attempt failed without customer usage"
+    );
+    if control
+        .record_pipeline_attempt(context, &attempt)
+        .await
+        .is_err()
+    {
+        warn!(operation_id = %operation_id, error_code, "pipeline attempt evidence was not recorded");
+    }
 }
 
 async fn record_operation(
@@ -2786,45 +2842,14 @@ fn streaming_put_error_response(key: &str, error: StreamingPutError) -> axum::re
             | IntegrityError::DecodedLengthMismatch),
         ) => s3_error::bad_digest(key, &error.to_string()),
         StreamingPutError::Integrity(error) => s3_error::invalid_request(key, &error.to_string()),
-        StreamingPutError::Pipeline(error)
-            if matches!(
-                error.code(),
-                s4_error::codes::LIMIT_INPUT_BYTES
-                    | s4_error::codes::LIMIT_OUTPUT_BYTES
-                    | s4_error::codes::LIMIT_EXPANSION
-                    | s4_error::codes::LIMIT_INTERMEDIATE_BYTES
-                    | s4_error::codes::LIMIT_FINISH_BYTES
-                    | s4_error::codes::RECORD_TOO_LARGE
-            ) =>
-        {
-            s3_error::entity_too_large(key)
-        }
-        StreamingPutError::Pipeline(error) if error.code() == s4_error::codes::WASM_ADMISSION => {
-            s3_error::slow_down(key)
-        }
-        StreamingPutError::Pipeline(error)
-            if matches!(
-                error.code(),
-                s4_error::codes::DECODE_JSON
-                    | s4_error::codes::DECODE_JSONL
-                    | s4_error::codes::DECODE_CSV
-                    | s4_error::codes::DECODE_ENCODING
-                    | s4_error::codes::WASM_REJECT
-                    | s4_error::codes::UNSUPPORTED_FORMAT
-            ) =>
-        {
-            s3_error::invalid_request(key, error.message())
-        }
-        StreamingPutError::Pipeline(error) => s3_error::internal_error(key, error.message()),
+        StreamingPutError::Pipeline(error) => pipeline_error_response(key, &error),
         StreamingPutError::Transaction(
             TransactionError::CapacityExceeded | TransactionError::TooManyParts,
         ) => s3_error::entity_too_large(key),
         StreamingPutError::Transaction(TransactionError::Spool(detail)) => {
-            s3_error::service_unavailable(key, &detail)
+            s3_error::internal_error(key, &detail)
         }
-        StreamingPutError::Transaction(error) => {
-            s3_error::service_unavailable(key, &error.to_string())
-        }
+        StreamingPutError::Transaction(error) => s3_error::internal_error(key, &error.to_string()),
         StreamingPutError::InputTooLarge | StreamingPutError::SourceFrameTooLarge => {
             s3_error::entity_too_large(key)
         }
@@ -2836,6 +2861,30 @@ fn streaming_put_error_response(key: &str, error: StreamingPutError) -> axum::re
             warn!("streaming PUT rejected for {key}: {detail}");
             s3_error::not_implemented(key)
         }
+    }
+}
+
+fn pipeline_error_response(key: &str, error: &s4_error::S4Error) -> axum::response::Response {
+    match error.code() {
+        s4_error::codes::WASM_ADMISSION => s3_error::slow_down(key),
+        s4_error::codes::LIMIT_INPUT_BYTES
+        | s4_error::codes::LIMIT_OUTPUT_BYTES
+        | s4_error::codes::LIMIT_EXPANSION
+        | s4_error::codes::LIMIT_INTERMEDIATE_BYTES
+        | s4_error::codes::LIMIT_FINISH_BYTES
+        | s4_error::codes::RECORD_TOO_LARGE => s3_error::entity_too_large(key),
+        s4_error::codes::DECODE_JSON
+        | s4_error::codes::DECODE_JSONL
+        | s4_error::codes::DECODE_CSV
+        | s4_error::codes::DECODE_ENCODING
+        | s4_error::codes::WASM_REJECT
+        | s4_error::codes::UNSUPPORTED_FORMAT
+        | s4_error::codes::CONFIG_INVALID
+        | s4_error::codes::POLICY_EXPIRED
+        | s4_error::codes::POLICY_TAMPERED => {
+            s3_error::invalid_request(key, "The processing pipeline rejected the request.")
+        }
+        _ => s3_error::internal_error(key, error.code()),
     }
 }
 
@@ -3064,11 +3113,13 @@ impl Drop for SinkAbortGuard {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn streaming_single_put(
     state: &AppState,
     mut authentication: HeaderAuthentication,
     backend: ResolvedBackend,
     usage: AuthorizedUsage<'_>,
+    snapshot: PipelineSnapshot,
     headers: &HeaderMap,
     mut body: axum::body::Body,
     key: &str,
@@ -3137,14 +3188,6 @@ async fn streaming_single_put(
         stable_fields,
     };
     let cancellation = s4_wasm_runtime::CancellationToken::new();
-    let snapshot = state
-        .gateway
-        .resolve_pipeline(
-            authentication.auth.workspace_id().as_str(),
-            grant.bucket(),
-            crate::pipeline::PipelineDirection::Write,
-        )
-        .await?;
     let pipeline_started = std::time::Instant::now();
     let mut pipeline = match snapshot
         .clone()
@@ -3583,6 +3626,24 @@ fn multipart_snapshot(
     }
 }
 
+#[derive(Debug)]
+enum MultipartPipelineRestoreError {
+    LegacyRawSnapshot,
+    Invalid(s4_error::S4Error),
+}
+
+fn restore_multipart_pipeline(
+    snapshot: &serde_json::Value,
+) -> Result<crate::pipeline::PipelineResolution, MultipartPipelineRestoreError> {
+    let resolution =
+        serde_json::from_value::<crate::pipeline::PipelineResolution>(snapshot.clone())
+            .map_err(|_| MultipartPipelineRestoreError::LegacyRawSnapshot)?;
+    resolution
+        .verify_fingerprint(crate::pipeline::PipelineDirection::Write)
+        .map_err(MultipartPipelineRestoreError::Invalid)?;
+    Ok(resolution)
+}
+
 fn staged_part_reservation(headers: &HeaderMap) -> Result<u64, StagingError> {
     // SigV4 streaming carries the decoded length separately; reserving the
     // HTTP framing length would under/over-account the persisted plaintext.
@@ -3909,6 +3970,7 @@ async fn write_completed_record(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn complete_staged_multipart(
     state: &AppState,
     staging: &MultipartStaging,
@@ -3917,6 +3979,7 @@ async fn complete_staged_multipart(
     lease: &CompletionLease,
     operation: AuthorizedOperation<'_>,
     backend: ResolvedBackend,
+    resolution: &crate::pipeline::PipelineResolution,
 ) -> Result<MultipartCompletionResult, MultipartCompletionError> {
     use sha2::Digest as _;
 
@@ -3937,32 +4000,10 @@ async fn complete_staged_multipart(
             "multipart destination changed since initiation".to_string(),
         ));
     }
-    // Phase 2: the snapshot persists the immutable pipeline resolution. The
-    // exact revision is resolved at completion — never the current assignment.
-    // Legacy self-hosted snapshots stored a raw plugin identity list; keep
-    // them working through a static resolution when the registry is unchanged.
-    let snapshot = match serde_json::from_value::<crate::pipeline::PipelineResolution>(
-        upload.snapshot.plugin_snapshot.clone(),
-    ) {
-        Ok(resolution) => state.gateway.snapshot_for(&resolution).await?,
-        Err(_) => {
-            if serde_json::to_value(state.plugins.list()).ok()
-                != Some(upload.snapshot.plugin_snapshot.clone())
-            {
-                return Err(MultipartCompletionError::Invalid(
-                    "multipart plugin snapshot is no longer available".to_string(),
-                ));
-            }
-            state
-                .gateway
-                .resolve_pipeline(
-                    operation.auth.workspace_id().as_str(),
-                    &identity.bucket,
-                    crate::pipeline::PipelineDirection::Write,
-                )
-                .await?
-        }
-    };
+    // Completion executes the exact persisted resolution, never the current
+    // assignment. Legacy raw PluginInfo snapshots are rejected explicitly:
+    // their process-local UUID identities cannot be proven restart-safe.
+    let snapshot = state.gateway.snapshot_for(resolution).await?;
     let pipeline_started = std::time::Instant::now();
     let content_type = upload
         .snapshot
@@ -4829,17 +4870,68 @@ async fn s3_put(
         return response;
     }
     let operation = request_operation_identity();
-    let authorization = operation.authorization(
+    let resolution_started = Instant::now();
+    let resolution = match state
+        .gateway
+        .resolve(
+            auth.workspace_id().as_str(),
+            &bucket,
+            crate::pipeline::PipelineDirection::Write,
+        )
+        .await
+    {
+        Ok(resolution) => resolution,
+        Err(error) => {
+            record_failed_pipeline_attempt(
+                state.control.as_ref(),
+                &auth.context,
+                operation.operation_id,
+                &bucket,
+                crate::pipeline::PipelineDirection::Write,
+                None,
+                error.code(),
+                resolution_started.elapsed().as_millis() as u64,
+            )
+            .await;
+            return pipeline_error_response(&key, &error);
+        }
+    };
+    let authorization = operation.pipeline_authorization(
         &bucket,
         UsageRoute::PutObject,
         RequestKind::Write,
         object_max_processed_bytes(&state),
+        &resolution,
     );
     let grant = match authorize_request(state.control.as_ref(), &auth.context, &authorization, &key)
         .await
     {
         Ok(grant) => grant,
         Err(response) => return response,
+    };
+    let snapshot = match state.gateway.snapshot_for(&resolution).await {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            record_failed_pipeline_attempt(
+                state.control.as_ref(),
+                &auth.context,
+                operation.operation_id,
+                &bucket,
+                crate::pipeline::PipelineDirection::Write,
+                Some(&resolution),
+                error.code(),
+                resolution_started.elapsed().as_millis() as u64,
+            )
+            .await;
+            return release_failure(
+                state.control.as_ref(),
+                &auth.context,
+                &grant,
+                &key,
+                pipeline_error_response(&key, &error),
+            )
+            .await;
+        }
     };
     let tenant_write_mode = state
         .control
@@ -4918,6 +5010,7 @@ async fn s3_put(
         header_auth,
         backend,
         AuthorizedUsage { grant: &grant },
+        snapshot,
         &parts.headers,
         request_body,
         &key,
@@ -4953,6 +5046,25 @@ async fn s3_put(
             response.body(axum::body::Body::empty()).unwrap()
         }
         Err(error) => {
+            let error_code = match &error {
+                StreamingPutError::Pipeline(error) => error.code(),
+                StreamingPutError::PreserveReservation(error) => match error.as_ref() {
+                    StreamingPutError::Pipeline(error) => error.code(),
+                    _ => s4_error::codes::INTERNAL,
+                },
+                _ => s4_error::codes::INTERNAL,
+            };
+            record_failed_pipeline_attempt(
+                state.control.as_ref(),
+                &auth_context,
+                operation.operation_id,
+                &bucket,
+                crate::pipeline::PipelineDirection::Write,
+                Some(&resolution),
+                error_code,
+                resolution_started.elapsed().as_millis() as u64,
+            )
+            .await;
             streaming_put_failure_response(
                 state.control.as_ref(),
                 &auth_context,
@@ -5000,36 +5112,8 @@ fn transformed_read_error_response(
                 "encrypted transformed-read staging capacity is unavailable",
             )
         }
-        TransformedReadError::Spool(error) => {
-            s3_error::service_unavailable(key, &error.to_string())
-        }
-        TransformedReadError::Pipeline(error)
-            if matches!(
-                error.code(),
-                s4_error::codes::LIMIT_INPUT_BYTES
-                    | s4_error::codes::LIMIT_OUTPUT_BYTES
-                    | s4_error::codes::LIMIT_EXPANSION
-                    | s4_error::codes::LIMIT_INTERMEDIATE_BYTES
-                    | s4_error::codes::LIMIT_FINISH_BYTES
-                    | s4_error::codes::RECORD_TOO_LARGE
-            ) =>
-        {
-            s3_error::entity_too_large(key)
-        }
-        TransformedReadError::Pipeline(error)
-            if matches!(
-                error.code(),
-                s4_error::codes::DECODE_JSON
-                    | s4_error::codes::DECODE_JSONL
-                    | s4_error::codes::DECODE_CSV
-                    | s4_error::codes::DECODE_ENCODING
-                    | s4_error::codes::WASM_REJECT
-                    | s4_error::codes::UNSUPPORTED_FORMAT
-            ) =>
-        {
-            s3_error::invalid_request(key, error.message())
-        }
-        TransformedReadError::Pipeline(error) => s3_error::internal_error(key, error.message()),
+        TransformedReadError::Spool(error) => s3_error::internal_error(key, &error.to_string()),
+        TransformedReadError::Pipeline(error) => pipeline_error_response(key, &error),
     }
 }
 
@@ -5439,22 +5523,41 @@ enum DirectReadEvent {
     Data(bytes::Bytes),
     Failed(TransformedReadError),
     Done {
-        fuel_consumed: u64,
-        duration_ms: u64,
+        source_bytes: u64,
+        output_bytes: u64,
+        evidence: Option<crate::control::PipelineEvidence>,
     },
 }
 
-fn direct_read_done_evidence(
-    snapshot: &PipelineSnapshot,
-    event: &DirectReadEvent,
-) -> Option<crate::control::PipelineEvidence> {
-    match event {
-        DirectReadEvent::Done {
-            fuel_consumed,
-            duration_ms,
-        } => snapshot.pipeline_evidence(*fuel_consumed, *duration_ms, "none"),
-        DirectReadEvent::Data(_) | DirectReadEvent::Failed(_) => None,
-    }
+const DIRECT_READ_SETTLEMENT_ATTEMPTS: usize = 3;
+
+type DirectSettlementFuture = std::pin::Pin<
+    Box<dyn std::future::Future<Output = Result<(), MeteringError>> + Send + 'static>,
+>;
+
+fn direct_settlement_future(
+    control: Arc<dyn ControlPlane>,
+    context: AuthenticatedRequestContext,
+    event: UsageEvent,
+) -> DirectSettlementFuture {
+    Box::pin(async move {
+        let mut last_error = MeteringError::Unavailable;
+        for attempt in 1..=DIRECT_READ_SETTLEMENT_ATTEMPTS {
+            match control.record(&context, &event).await {
+                Ok(()) => return Ok(()),
+                Err(error) => {
+                    last_error = error;
+                    warn!(
+                        operation_id = %event.operation_id(),
+                        receipt_id = %event.receipt_id(),
+                        attempt,
+                        "direct transformed-read settlement retry failed"
+                    );
+                }
+            }
+        }
+        Err(last_error)
+    })
 }
 
 struct DirectReadBody {
@@ -5462,6 +5565,15 @@ struct DirectReadBody {
     receiver: tokio::sync::mpsc::Receiver<DirectReadEvent>,
     source_cancellation: s4_wasm_runtime::CancellationToken,
     pipeline_cancellation: s4_wasm_runtime::CancellationToken,
+    control: Arc<dyn ControlPlane>,
+    context: AuthenticatedRequestContext,
+    grant: AuthorizationGrant,
+    failure_operation: OperationIdentity,
+    failure_bucket: String,
+    failure_resolution: crate::pipeline::PipelineResolution,
+    settlement: Option<DirectSettlementFuture>,
+    disclosed: bool,
+    reservation_owned: bool,
     done: bool,
 }
 
@@ -5473,20 +5585,92 @@ impl http_body::Body for DirectReadBody {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        if let Some(settlement) = &mut self.settlement {
+            return match settlement.as_mut().poll(cx) {
+                std::task::Poll::Ready(Ok(())) => {
+                    self.settlement = None;
+                    self.reservation_owned = false;
+                    self.done = true;
+                    std::task::Poll::Ready(None)
+                }
+                std::task::Poll::Ready(Err(_)) => {
+                    self.settlement = None;
+                    self.done = true;
+                    std::task::Poll::Ready(Some(Err(std::io::Error::other(
+                        "direct transformed-read usage settlement failed",
+                    ))))
+                }
+                std::task::Poll::Pending => std::task::Poll::Pending,
+            };
+        }
         if let Some(bytes) = self.first.take() {
+            self.disclosed = true;
             return std::task::Poll::Ready(Some(Ok(http_body::Frame::data(bytes))));
         }
         match self.receiver.poll_recv(cx) {
             std::task::Poll::Ready(Some(DirectReadEvent::Data(bytes))) => {
+                self.disclosed = true;
                 std::task::Poll::Ready(Some(Ok(http_body::Frame::data(bytes))))
             }
             std::task::Poll::Ready(Some(DirectReadEvent::Failed(error))) => {
                 self.done = true;
-                std::task::Poll::Ready(Some(Err(std::io::Error::other(error_to_log(&error)))))
+                let control = self.control.clone();
+                let context = self.context.clone();
+                let operation = self.failure_operation;
+                let bucket = self.failure_bucket.clone();
+                let resolution = self.failure_resolution.clone();
+                let error_code = match &error {
+                    TransformedReadError::Pipeline(error) => error.code(),
+                    _ => s4_error::codes::INTERNAL,
+                };
+                tokio::spawn(async move {
+                    record_failed_pipeline_attempt(
+                        control.as_ref(),
+                        &context,
+                        operation.operation_id,
+                        &bucket,
+                        crate::pipeline::PipelineDirection::Read,
+                        Some(&resolution),
+                        error_code,
+                        0,
+                    )
+                    .await;
+                });
+                if !self.disclosed {
+                    let control = self.control.clone();
+                    let context = self.context.clone();
+                    let operation_id = self.grant.operation_id();
+                    tokio::spawn(async move {
+                        let _ = control.release(&context, operation_id).await;
+                    });
+                    self.reservation_owned = false;
+                }
+                std::task::Poll::Ready(Some(Err(std::io::Error::other(
+                    "direct transformed-read pipeline failed",
+                ))))
             }
-            std::task::Poll::Ready(Some(DirectReadEvent::Done { .. })) => {
-                self.done = true;
-                std::task::Poll::Ready(None)
+            std::task::Poll::Ready(Some(DirectReadEvent::Done {
+                source_bytes,
+                output_bytes,
+                evidence,
+            })) => {
+                if source_bytes.max(output_bytes) > self.grant.max_processed_bytes() {
+                    self.done = true;
+                    return std::task::Poll::Ready(Some(Err(std::io::Error::other(
+                        "direct transformed-read exceeded its authorized size",
+                    ))));
+                }
+                let event = UsageEvent::from_grant(&self.grant, source_bytes, output_bytes);
+                let event = match evidence {
+                    Some(evidence) => event.with_pipeline_evidence(evidence),
+                    None => event,
+                };
+                self.settlement = Some(direct_settlement_future(
+                    self.control.clone(),
+                    self.context.clone(),
+                    event,
+                ));
+                self.poll_frame(cx)
             }
             std::task::Poll::Ready(None) => {
                 self.done = true;
@@ -5506,67 +5690,38 @@ impl Drop for DirectReadBody {
         if !self.done {
             self.source_cancellation.cancel();
             self.pipeline_cancellation.cancel();
+            if self.reservation_owned && !self.disclosed {
+                let control = self.control.clone();
+                let context = self.context.clone();
+                let operation_id = self.grant.operation_id();
+                if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+                    runtime.spawn(async move {
+                        let _ = control.release(&context, operation_id).await;
+                    });
+                }
+                self.reservation_owned = false;
+            }
         }
     }
-}
-
-fn error_to_log(error: &TransformedReadError) -> String {
-    match error {
-        TransformedReadError::InvalidRequest(detail)
-        | TransformedReadError::Capacity(detail)
-        | TransformedReadError::Source(detail) => detail.clone(),
-        TransformedReadError::Pipeline(error) => error.to_string(),
-        TransformedReadError::Spool(error) => error.to_string(),
-    }
-}
-
-fn direct_read_worker_terminated(
-    key: &str,
-    source_cancellation: &s4_wasm_runtime::CancellationToken,
-    pipeline_cancellation: &s4_wasm_runtime::CancellationToken,
-) -> axum::response::Response {
-    source_cancellation.cancel();
-    pipeline_cancellation.cancel();
-    transformed_read_error_response(
-        key,
-        TransformedReadError::Pipeline(s4_error::S4Error::new(
-            s4_error::codes::INTERNAL,
-            "transformed read worker terminated unexpectedly",
-        )),
-    )
 }
 
 #[allow(clippy::too_many_arguments)]
 async fn transformed_read_response(
     state: &AppState,
     auth: &Auth,
+    operation: OperationIdentity,
+    grant: &AuthorizationGrant,
+    resolution: &crate::pipeline::PipelineResolution,
     headers: &HeaderMap,
+    snapshot: PipelineSnapshot,
     preflight: (Format, String),
     response_metadata: ObjectMetadata,
     object: OpenedObject,
     key: &str,
-    bucket: &str,
     pipeline_evidence: &mut Option<crate::control::PipelineEvidence>,
-) -> (axum::response::Response, Option<u64>) {
+) -> (axum::response::Response, Option<u64>, bool) {
     let (format, content_type) = preflight;
     *pipeline_evidence = None;
-    let snapshot = match state
-        .gateway
-        .resolve_pipeline(
-            auth.workspace_id().as_str(),
-            bucket,
-            crate::pipeline::PipelineDirection::Read,
-        )
-        .await
-    {
-        Ok(snapshot) => snapshot,
-        Err(error) => {
-            return (
-                transformed_read_error_response(key, TransformedReadError::Pipeline(error)),
-                None,
-            );
-        }
-    };
     let pipeline_started = std::time::Instant::now();
     let source_cancellation = object.cancellation.clone();
     let source_counters = object.counters.clone();
@@ -5580,17 +5735,24 @@ async fn transformed_read_response(
         .await
     {
         Ok(pipeline) => pipeline,
-        Err(error) => return (transformed_read_error_response(key, error.into()), None),
+        Err(error) => {
+            return (
+                transformed_read_error_response(key, error.into()),
+                None,
+                false,
+            );
+        }
     };
     let direct = snapshot
         .capabilities()
         .iter()
         .all(|capabilities| capabilities.prefix_safe_for_read);
     if direct {
-        // The response body continues executing after this function returns,
-        // so final fuel and duration are not yet knowable. Leave evidence
-        // absent rather than attaching fabricated zero-valued measurements.
         let max_source_frame_bytes = state.source_body_limits.max_frame_bytes;
+        let output_bytes = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let worker_output_bytes = output_bytes.clone();
+        let worker_source_counters = source_counters.clone();
+        let worker_snapshot = snapshot.clone();
         let (sender, mut receiver) = tokio::sync::mpsc::channel(2);
         tokio::spawn(async move {
             let result = process_transformed_source(
@@ -5600,7 +5762,10 @@ async fn transformed_read_response(
                 max_source_frame_bytes,
                 |bytes| {
                     let sender = sender.clone();
+                    let output_bytes = worker_output_bytes.clone();
                     async move {
+                        output_bytes
+                            .fetch_add(bytes.len() as u64, std::sync::atomic::Ordering::Relaxed);
                         sender
                             .send(DirectReadEvent::Data(bytes))
                             .await
@@ -5615,57 +5780,91 @@ async fn transformed_read_response(
             .await;
             let event = match result {
                 Ok(fuel_consumed) => DirectReadEvent::Done {
-                    fuel_consumed,
-                    duration_ms: pipeline_started.elapsed().as_millis() as u64,
+                    source_bytes: worker_source_counters.bytes(),
+                    output_bytes: worker_output_bytes.load(std::sync::atomic::Ordering::Relaxed),
+                    evidence: worker_snapshot.pipeline_evidence(
+                        fuel_consumed,
+                        pipeline_started.elapsed().as_millis() as u64,
+                        "none",
+                    ),
                 },
                 Err(error) => DirectReadEvent::Failed(error),
             };
             let _ = sender.send(event).await;
         });
-        return match receiver.recv().await {
-            Some(DirectReadEvent::Data(first)) => {
-                let mut response = axum::response::Response::builder().status(StatusCode::OK);
-                response
-                    .headers_mut()
-                    .unwrap()
-                    .extend(transformed_response_headers(&response_metadata, None));
-                (
-                    response
-                        .body(axum::body::Body::new(DirectReadBody {
-                            first: Some(first),
-                            receiver,
-                            source_cancellation,
-                            pipeline_cancellation,
-                            done: false,
-                        }))
-                        .unwrap(),
-                    None,
-                )
-            }
-            Some(event @ DirectReadEvent::Done { .. }) => {
-                *pipeline_evidence = direct_read_done_evidence(&snapshot, &event);
-                let mut response = axum::response::Response::builder().status(StatusCode::OK);
-                response
-                    .headers_mut()
-                    .unwrap()
-                    .extend(transformed_response_headers(&response_metadata, Some(0)));
-                (
-                    response.body(axum::body::Body::empty()).unwrap(),
-                    Some(source_counters.bytes()),
-                )
-            }
-            None => {
-                let response = direct_read_worker_terminated(
+        let first_event = receiver.recv().await;
+        if let Some(DirectReadEvent::Failed(error)) = first_event {
+            return (transformed_read_error_response(key, error), None, false);
+        }
+        if first_event.is_none() {
+            source_cancellation.cancel();
+            pipeline_cancellation.cancel();
+            return (
+                transformed_read_error_response(
                     key,
-                    &source_cancellation,
-                    &pipeline_cancellation,
-                );
-                (response, None)
+                    TransformedReadError::Pipeline(s4_error::S4Error::new(
+                        s4_error::codes::INTERNAL,
+                        "transformed read worker terminated unexpectedly",
+                    )),
+                ),
+                None,
+                false,
+            );
+        }
+        let (first, content_length, settlement) = match first_event {
+            Some(DirectReadEvent::Data(bytes)) => (Some(bytes), None, None),
+            Some(DirectReadEvent::Done {
+                source_bytes,
+                output_bytes,
+                evidence,
+            }) => {
+                let event = UsageEvent::from_grant(grant, source_bytes, output_bytes);
+                let event = match evidence {
+                    Some(evidence) => event.with_pipeline_evidence(evidence),
+                    None => event,
+                };
+                (
+                    None,
+                    Some(output_bytes),
+                    Some(direct_settlement_future(
+                        state.control.clone(),
+                        auth.context.clone(),
+                        event,
+                    )),
+                )
             }
-            Some(DirectReadEvent::Failed(error)) => {
-                (transformed_read_error_response(key, error), None)
-            }
+            Some(DirectReadEvent::Failed(_)) | None => unreachable!("handled above"),
         };
+        let mut response = axum::response::Response::builder().status(StatusCode::OK);
+        response
+            .headers_mut()
+            .unwrap()
+            .extend(transformed_response_headers(
+                &response_metadata,
+                content_length,
+            ));
+        return (
+            response
+                .body(axum::body::Body::new(DirectReadBody {
+                    first,
+                    receiver,
+                    source_cancellation,
+                    pipeline_cancellation,
+                    control: state.control.clone(),
+                    context: auth.context.clone(),
+                    grant: grant.clone(),
+                    failure_operation: operation,
+                    failure_bucket: grant.bucket().to_string(),
+                    failure_resolution: resolution.clone(),
+                    settlement,
+                    disclosed: false,
+                    reservation_owned: true,
+                    done: false,
+                }))
+                .unwrap(),
+            None,
+            true,
+        );
     }
     if !state.transformed_read_spool_enabled {
         source_cancellation.cancel();
@@ -5678,6 +5877,7 @@ async fn transformed_read_response(
                 ),
             ),
             None,
+            false,
         );
     }
     let spool = match EncryptedReadSpool::begin(
@@ -5688,7 +5888,13 @@ async fn transformed_read_response(
     .await
     {
         Ok(spool) => spool,
-        Err(error) => return (transformed_read_error_response(key, error.into()), None),
+        Err(error) => {
+            return (
+                transformed_read_error_response(key, error.into()),
+                None,
+                false,
+            );
+        }
     };
     let (spool_sender, mut spool_receiver) = tokio::sync::mpsc::channel(2);
     let spool_writer = tokio::spawn(async move {
@@ -5724,12 +5930,12 @@ async fn transformed_read_response(
         Ok(fuel) => fuel,
         Err(error) => {
             let _ = spool_writer.await;
-            return (transformed_read_error_response(key, error), None);
+            return (transformed_read_error_response(key, error), None, false);
         }
     };
     let spool = match spool_writer.await {
         Ok(Ok(spool)) => spool,
-        Ok(Err(error)) => return (transformed_read_error_response(key, error), None),
+        Ok(Err(error)) => return (transformed_read_error_response(key, error), None, false),
         Err(error) => {
             return (
                 transformed_read_error_response(
@@ -5739,6 +5945,7 @@ async fn transformed_read_response(
                     )),
                 ),
                 None,
+                false,
             );
         }
     };
@@ -5749,7 +5956,13 @@ async fn transformed_read_response(
     );
     let (body, content_length) = match spool.into_body(source_cancellation).await {
         Ok(result) => result,
-        Err(error) => return (transformed_read_error_response(key, error.into()), None),
+        Err(error) => {
+            return (
+                transformed_read_error_response(key, error.into()),
+                None,
+                false,
+            );
+        }
     };
     let mut response = axum::response::Response::builder().status(StatusCode::OK);
     response
@@ -5759,7 +5972,11 @@ async fn transformed_read_response(
             &response_metadata,
             Some(content_length),
         ));
-    (response.body(body).unwrap(), Some(source_counters.bytes()))
+    (
+        response.body(body).unwrap(),
+        Some(source_counters.bytes()),
+        false,
+    )
 }
 
 async fn s3_get(
@@ -5835,17 +6052,84 @@ async fn s3_get(
         };
     }
     let operation = request_operation_identity();
-    let authorization = operation.authorization(
-        &bucket,
-        UsageRoute::GetObject,
-        RequestKind::Read,
-        object_max_processed_bytes(&state),
-    );
+    let resolution_started = Instant::now();
+    let resolution = if transformed_read {
+        match state
+            .gateway
+            .resolve(
+                auth.workspace_id().as_str(),
+                &bucket,
+                crate::pipeline::PipelineDirection::Read,
+            )
+            .await
+        {
+            Ok(resolution) => Some(resolution),
+            Err(error) => {
+                record_failed_pipeline_attempt(
+                    state.control.as_ref(),
+                    &auth.context,
+                    operation.operation_id,
+                    &bucket,
+                    crate::pipeline::PipelineDirection::Read,
+                    None,
+                    error.code(),
+                    resolution_started.elapsed().as_millis() as u64,
+                )
+                .await;
+                return pipeline_error_response(&key, &error);
+            }
+        }
+    } else {
+        None
+    };
+    let authorization = match &resolution {
+        Some(resolution) => operation.pipeline_authorization(
+            &bucket,
+            UsageRoute::GetObject,
+            RequestKind::Read,
+            object_max_processed_bytes(&state),
+            resolution,
+        ),
+        None => operation.authorization(
+            &bucket,
+            UsageRoute::GetObject,
+            RequestKind::Read,
+            object_max_processed_bytes(&state),
+        ),
+    };
     let grant = match authorize_request(state.control.as_ref(), &auth.context, &authorization, &key)
         .await
     {
         Ok(grant) => grant,
         Err(response) => return response,
+    };
+    let pipeline_snapshot = if let Some(resolution) = &resolution {
+        match state.gateway.snapshot_for(resolution).await {
+            Ok(snapshot) => Some(snapshot),
+            Err(error) => {
+                record_failed_pipeline_attempt(
+                    state.control.as_ref(),
+                    &auth.context,
+                    operation.operation_id,
+                    &bucket,
+                    crate::pipeline::PipelineDirection::Read,
+                    Some(resolution),
+                    error.code(),
+                    resolution_started.elapsed().as_millis() as u64,
+                )
+                .await;
+                return release_failure(
+                    state.control.as_ref(),
+                    &auth.context,
+                    &grant,
+                    &key,
+                    pipeline_error_response(&key, &error),
+                )
+                .await;
+            }
+        }
+    } else {
+        None
     };
     if transformed_read && state.streaming_read_mode != StreamingReadMode::Transformed {
         return release_failure(
@@ -6030,18 +6314,39 @@ async fn s3_get(
         let source_bytes = content_length(&object.metadata.headers);
         let response_metadata = object.metadata.clone();
         let mut pipeline_evidence = None;
-        let (response, completed_source_bytes) = transformed_read_response(
+        let (response, completed_source_bytes, direct) = transformed_read_response(
             &state,
             &auth,
+            operation,
+            &grant,
+            resolution
+                .as_ref()
+                .expect("transformed reads resolve an immutable pipeline"),
             &headers,
+            pipeline_snapshot.expect("transformed reads resolve a pipeline snapshot"),
             preflight,
             response_metadata,
             object,
             &key,
-            &bucket,
             &mut pipeline_evidence,
         )
         .await;
+        if direct {
+            return response;
+        }
+        if !response.status().is_success() {
+            record_failed_pipeline_attempt(
+                state.control.as_ref(),
+                &auth.context,
+                operation.operation_id,
+                &bucket,
+                crate::pipeline::PipelineDirection::Read,
+                resolution.as_ref(),
+                s4_error::codes::INTERNAL,
+                resolution_started.elapsed().as_millis() as u64,
+            )
+            .await;
+        }
         return metered_read_response(
             state.control.clone(),
             &auth,
@@ -6759,8 +7064,92 @@ mod tests {
         )
         .await;
 
-        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert!(control.releases.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn pipeline_failure_taxonomy_is_stable_bounded_and_opaque() {
+        for (code, status, s3_code) in [
+            (
+                s4_error::codes::WASM_ADMISSION,
+                StatusCode::SERVICE_UNAVAILABLE,
+                "SlowDown",
+            ),
+            (
+                s4_error::codes::CONFIG_INVALID,
+                StatusCode::BAD_REQUEST,
+                "InvalidRequest",
+            ),
+            (
+                s4_error::codes::POLICY_TAMPERED,
+                StatusCode::BAD_REQUEST,
+                "InvalidRequest",
+            ),
+            (
+                s4_error::codes::COMPONENT_LOAD,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalError",
+            ),
+            (
+                s4_error::codes::INTERNAL,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalError",
+            ),
+        ] {
+            let response = pipeline_error_response(
+                "key",
+                &s4_error::S4Error::new(code, "PRINTABLE_GRANTED_SECRET"),
+            );
+            assert_eq!(response.status(), status);
+            let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let body = String::from_utf8_lossy(&body);
+            assert!(body.contains(&format!("<Code>{s3_code}</Code>")));
+            assert!(!body.contains("PRINTABLE_GRANTED_SECRET"));
+        }
+    }
+
+    #[test]
+    fn multipart_pipeline_restore_accepts_new_static_and_rejects_legacy_or_tampered_state() {
+        let limits = PipelineLimits::default();
+        let resolution = crate::pipeline::PipelineResolution {
+            locator: crate::pipeline::PipelineLocator {
+                revision: "static".to_string(),
+                fingerprint: crate::pipeline::resolution_fingerprint(
+                    crate::pipeline::PipelineDirection::Write,
+                    &[],
+                    true,
+                    limits,
+                ),
+            },
+            steps: Vec::new(),
+            policy_generation: None,
+            explicit_passthrough: true,
+            limits,
+        };
+        let snapshot = serde_json::to_value(&resolution).unwrap();
+        assert_eq!(restore_multipart_pipeline(&snapshot).unwrap(), resolution);
+
+        let legacy = serde_json::json!([{
+            "id": Uuid::new_v4(),
+            "name": "legacy",
+            "version": "0.1.0",
+            "enabled": true,
+            "description": ""
+        }]);
+        assert!(matches!(
+            restore_multipart_pipeline(&legacy),
+            Err(MultipartPipelineRestoreError::LegacyRawSnapshot)
+        ));
+
+        let mut tampered = snapshot;
+        tampered["explicit_passthrough"] = serde_json::Value::Bool(false);
+        assert!(matches!(
+            restore_multipart_pipeline(&tampered),
+            Err(MultipartPipelineRestoreError::Invalid(_))
+        ));
     }
 
     #[tokio::test]
@@ -6922,67 +7311,6 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn direct_body_truncates_after_a_late_pipeline_failure_and_cancels_on_drop() {
-        let source_cancellation = s4_wasm_runtime::CancellationToken::new();
-        let pipeline_cancellation = s4_wasm_runtime::CancellationToken::new();
-        let (sender, receiver) = tokio::sync::mpsc::channel(2);
-        sender
-            .send(DirectReadEvent::Data(Bytes::from_static(b"safe-prefix")))
-            .await
-            .unwrap();
-        sender
-            .send(DirectReadEvent::Failed(TransformedReadError::Source(
-                "injected late failure".to_string(),
-            )))
-            .await
-            .unwrap();
-        let mut body = DirectReadBody {
-            first: None,
-            receiver,
-            source_cancellation: source_cancellation.clone(),
-            pipeline_cancellation: pipeline_cancellation.clone(),
-            done: false,
-        };
-        let first = body.frame().await.unwrap().unwrap().into_data().unwrap();
-        assert_eq!(first, Bytes::from_static(b"safe-prefix"));
-        assert!(body.frame().await.unwrap().is_err());
-        drop(body);
-        assert!(!source_cancellation.is_cancelled());
-        assert!(!pipeline_cancellation.is_cancelled());
-
-        let source_cancellation = s4_wasm_runtime::CancellationToken::new();
-        let pipeline_cancellation = s4_wasm_runtime::CancellationToken::new();
-        let (sender, receiver) = tokio::sync::mpsc::channel(1);
-        drop(sender);
-        let mut body = DirectReadBody {
-            first: None,
-            receiver,
-            source_cancellation: source_cancellation.clone(),
-            pipeline_cancellation: pipeline_cancellation.clone(),
-            done: false,
-        };
-        let error = body.frame().await.unwrap().unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            "transformed read worker terminated unexpectedly"
-        );
-        assert!(source_cancellation.is_cancelled());
-        assert!(pipeline_cancellation.is_cancelled());
-
-        let source_cancellation = s4_wasm_runtime::CancellationToken::new();
-        let pipeline_cancellation = s4_wasm_runtime::CancellationToken::new();
-        let response = direct_read_worker_terminated(
-            "private-key",
-            &source_cancellation,
-            &pipeline_cancellation,
-        );
-        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
-        assert!(response.headers().get(header::ETAG).is_none());
-        assert!(source_cancellation.is_cancelled());
-        assert!(pipeline_cancellation.is_cancelled());
-    }
-
     #[tokio::test(flavor = "current_thread")]
     async fn transformed_source_returns_post_finish_fuel_for_spooled_evidence() {
         let component = std::fs::read(
@@ -7082,11 +7410,9 @@ mod tests {
                 .is_none()
         );
         let (_, fuel_consumed) = pipeline.finish().await.unwrap();
-        let event = DirectReadEvent::Done {
-            fuel_consumed,
-            duration_ms: 5,
-        };
-        let evidence = direct_read_done_evidence(&snapshot, &event).unwrap();
+        let evidence = snapshot
+            .pipeline_evidence(fuel_consumed, 5, "none")
+            .unwrap();
         assert_eq!(evidence.fuel_consumed, fuel_consumed);
         assert!(evidence.fuel_consumed > 0);
         assert_eq!(evidence.duration_ms, 5);
@@ -7660,6 +7986,29 @@ async fn s3_post(
         if let Some(response) = client_metering_id_rejection(&parts.headers, &key) {
             return response;
         }
+        let Some(staging) = staged_multipart(&state).cloned() else {
+            return s3_error::multipart_not_supported(&key);
+        };
+        let identity = multipart_identity(&authentication.auth, &bucket, &key, upload_id);
+        let upload = match staging.repository.get_authorized(&identity).await {
+            Ok(upload) => upload,
+            Err(StagingError::NotFound) => return s3_error::no_such_upload(&key),
+            Err(error) => return s3_error::internal_error(&key, &error.to_string()),
+        };
+        let persisted_resolution = match restore_multipart_pipeline(
+            &upload.snapshot.plugin_snapshot,
+        ) {
+            Ok(resolution) => resolution,
+            Err(MultipartPipelineRestoreError::LegacyRawSnapshot) => {
+                return s3_error::invalid_request(
+                    &key,
+                    "Legacy multipart pipeline snapshots cannot be resumed safely; abort and restart the upload.",
+                );
+            }
+            Err(MultipartPipelineRestoreError::Invalid(error)) => {
+                return pipeline_error_response(&key, &error);
+            }
+        };
         let backend = match resolve_backend(
             &state,
             &authentication.auth,
@@ -7711,19 +8060,6 @@ async fn s3_post(
                 return s3_error::invalid_request(&key, &error);
             }
         };
-        let Some(staging) = staged_multipart(&state).cloned() else {
-            return s3_error::multipart_not_supported(&key);
-        };
-        let identity = multipart_identity(&auth, &bucket, &key, upload_id);
-        let upload = match staging.repository.get_authorized(&identity).await {
-            Ok(upload) => upload,
-            Err(StagingError::NotFound) => {
-                return s3_error::no_such_upload(&key);
-            }
-            Err(error) => {
-                return s3_error::internal_error(&key, &error.to_string());
-            }
-        };
         if let ResolvedBackend::Managed(storage) = &backend {
             let Some(epoch) = upload.namespace_epoch else {
                 let response = s3_error::service_unavailable(
@@ -7747,11 +8083,12 @@ async fn s3_post(
         };
         // Exact retries share an operation; conflicting canonical requests do not.
         let operation = multipart_completion_operation_identity(upload_id, &fingerprint);
-        let authorization = operation.authorization(
+        let authorization = operation.pipeline_authorization(
             &bucket,
             UsageRoute::CompleteMultipartUpload,
             RequestKind::Write,
             object_max_processed_bytes(&state),
+            &persisted_resolution,
         );
         let grant =
             match authorize_request(state.control.as_ref(), &auth.context, &authorization, &key)
@@ -7913,6 +8250,7 @@ async fn s3_post(
                         grant: &grant,
                     },
                     backend,
+                    &persisted_resolution,
                 ),
             )
             .await;
@@ -7975,6 +8313,33 @@ async fn s3_post(
     info!("POST /{bucket}/{key} user={}", auth.user_id());
 
     if params.uploads.is_some() {
+        let resolution_started = Instant::now();
+        let resolution = match state
+            .gateway
+            .resolve(
+                auth.workspace_id().as_str(),
+                &bucket,
+                crate::pipeline::PipelineDirection::Write,
+            )
+            .await
+        {
+            Ok(resolution) => resolution,
+            Err(error) => {
+                let operation = request_operation_identity();
+                record_failed_pipeline_attempt(
+                    state.control.as_ref(),
+                    &auth.context,
+                    operation.operation_id,
+                    &bucket,
+                    crate::pipeline::PipelineDirection::Write,
+                    None,
+                    error.code(),
+                    resolution_started.elapsed().as_millis() as u64,
+                )
+                .await;
+                return pipeline_error_response(&key, &error);
+            }
+        };
         let backend =
             match resolve_backend(&state, &auth, &parts.headers, StorageOperation::Multipart).await
             {
@@ -8006,20 +8371,9 @@ async fn s3_post(
         // Freeze and serialize policy before creating managed multipart state.
         // Resolver or serialization failures therefore cannot orphan a managed
         // registration without a corresponding staging upload.
-        let plugin_snapshot = match state
-            .gateway
-            .resolve(
-                auth.workspace_id().as_str(),
-                &bucket,
-                crate::pipeline::PipelineDirection::Write,
-            )
-            .await
-        {
-            Ok(resolution) => match serde_json::to_value(&resolution) {
-                Ok(snapshot) => snapshot,
-                Err(error) => return s3_error::internal_error(&key, &error.to_string()),
-            },
-            Err(error) => return s3_error::invalid_request(&key, error.message()),
+        let plugin_snapshot = match serde_json::to_value(&resolution) {
+            Ok(snapshot) => snapshot,
+            Err(error) => return s3_error::internal_error(&key, &error.to_string()),
         };
         let upload_id = Uuid::now_v7().to_string();
         let managed_registration = if let ResolvedBackend::Managed(storage) = &backend {
@@ -9358,6 +9712,119 @@ fn validate_storage_boundary_startup(
     Ok(())
 }
 
+#[derive(Clone, Copy)]
+struct MultipartStartupDependencies {
+    durable_wrapping: bool,
+    database: bool,
+    endpoint: bool,
+    bucket: bool,
+    access_key: bool,
+    secret_key: bool,
+    region: bool,
+    directory: bool,
+    tenant_quota: bool,
+    global_quota: bool,
+    streaming_all: bool,
+}
+
+fn validate_multipart_startup(
+    mode: MultipartMode,
+    dependencies: MultipartStartupDependencies,
+) -> anyhow::Result<()> {
+    if mode != MultipartMode::Staged {
+        return Ok(());
+    }
+    let checks = [
+        (dependencies.durable_wrapping, "durable key wrapping"),
+        (dependencies.database, "DATABASE_URL"),
+        (dependencies.endpoint, "S4_MULTIPART_STAGING_ENDPOINT"),
+        (dependencies.bucket, "S4_MULTIPART_STAGING_BUCKET"),
+        (
+            dependencies.access_key,
+            "S4_MULTIPART_STAGING_ACCESS_KEY_ID",
+        ),
+        (
+            dependencies.secret_key,
+            "S4_MULTIPART_STAGING_SECRET_ACCESS_KEY",
+        ),
+        (dependencies.region, "S4_MULTIPART_STAGING_REGION"),
+        (dependencies.directory, "S4_MULTIPART_STAGING_DIR"),
+        (
+            dependencies.tenant_quota,
+            "S4_MULTIPART_STAGING_TENANT_QUOTA_BYTES",
+        ),
+        (
+            dependencies.global_quota,
+            "S4_MULTIPART_STAGING_GLOBAL_QUOTA_BYTES",
+        ),
+        (
+            dependencies.streaming_all,
+            "MASKURA_STREAMING_WRITE_MODE=all",
+        ),
+    ];
+    let missing = checks
+        .into_iter()
+        .filter_map(|(configured, name)| (!configured).then_some(name))
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        anyhow::bail!(
+            "staged multipart requires complete durable startup dependencies: {}",
+            missing.join(", ")
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[test]
+fn staged_multipart_startup_requires_every_production_dependency() {
+    let complete = MultipartStartupDependencies {
+        durable_wrapping: true,
+        database: true,
+        endpoint: true,
+        bucket: true,
+        access_key: true,
+        secret_key: true,
+        region: true,
+        directory: true,
+        tenant_quota: true,
+        global_quota: true,
+        streaming_all: true,
+    };
+    validate_multipart_startup(MultipartMode::Staged, complete).unwrap();
+    validate_multipart_startup(
+        MultipartMode::Reject,
+        MultipartStartupDependencies {
+            durable_wrapping: false,
+            ..complete
+        },
+    )
+    .unwrap();
+
+    let missing_one: [fn(&mut MultipartStartupDependencies); 11] = [
+        |value| value.durable_wrapping = false,
+        |value| value.database = false,
+        |value| value.endpoint = false,
+        |value| value.bucket = false,
+        |value| value.access_key = false,
+        |value| value.secret_key = false,
+        |value| value.region = false,
+        |value| value.directory = false,
+        |value| value.tenant_quota = false,
+        |value| value.global_quota = false,
+        |value| value.streaming_all = false,
+    ];
+    for remove in missing_one {
+        let mut incomplete = complete;
+        remove(&mut incomplete);
+        assert!(validate_multipart_startup(MultipartMode::Staged, incomplete).is_err());
+    }
+}
+
+fn nonempty_env(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|value| !value.trim().is_empty())
+}
+
 fn source_body_limits_from_env() -> anyhow::Result<BodyLimits> {
     Ok(BodyLimits {
         max_frame_bytes: resolve_customer_env(customer_env::SOURCE_MAX_FRAME_BYTES)?
@@ -9504,6 +9971,22 @@ pub async fn build_state_with_pipeline_template(
         })
         .transpose()?;
     let streaming_write_mode = streaming_write_mode()?;
+    validate_multipart_startup(
+        multipart_mode,
+        MultipartStartupDependencies {
+            durable_wrapping: wrapping.is_durable(),
+            database: nonempty_env("DATABASE_URL"),
+            endpoint: nonempty_env("S4_MULTIPART_STAGING_ENDPOINT"),
+            bucket: nonempty_env("S4_MULTIPART_STAGING_BUCKET"),
+            access_key: nonempty_env("S4_MULTIPART_STAGING_ACCESS_KEY_ID"),
+            secret_key: nonempty_env("S4_MULTIPART_STAGING_SECRET_ACCESS_KEY"),
+            region: nonempty_env("S4_MULTIPART_STAGING_REGION"),
+            directory: nonempty_env("S4_MULTIPART_STAGING_DIR"),
+            tenant_quota: nonempty_env("S4_MULTIPART_STAGING_TENANT_QUOTA_BYTES"),
+            global_quota: nonempty_env("S4_MULTIPART_STAGING_GLOBAL_QUOTA_BYTES"),
+            streaming_all: streaming_write_mode >= StreamingWriteMode::All,
+        },
+    )?;
     let s3_streaming_capabilities = configured_s3_streaming_capabilities()?;
     let managed_streaming_capabilities = configured_managed_streaming_capabilities();
     let spool_max_object_bytes = resolve_customer_env(customer_env::SPOOL_MAX_OBJECT_BYTES)?

--- a/crates/gateway/tests/db_keys_test.rs
+++ b/crates/gateway/tests/db_keys_test.rs
@@ -2655,6 +2655,8 @@ fn router_staged_multipart_flow_is_durable_and_idempotent() {
             std::env::set_var("S4_MULTIPART_STAGING_ACCESS_KEY_ID", "test-access");
             std::env::set_var("S4_MULTIPART_STAGING_SECRET_ACCESS_KEY", "test-secret");
             std::env::set_var("S4_MULTIPART_STAGING_REGION", "us-east-1");
+            std::env::set_var("S4_MULTIPART_STAGING_TENANT_QUOTA_BYTES", "67108864");
+            std::env::set_var("S4_MULTIPART_STAGING_GLOBAL_QUOTA_BYTES", "268435456");
         }
 
         let control = Arc::new(MultipartBillingControl::default());
@@ -2733,6 +2735,18 @@ fn router_staged_multipart_flow_is_durable_and_idempotent() {
             "{list_xml}"
         );
 
+        // Rebuild a fully independent gateway process against the same
+        // Postgres and staging backend. Completion must use the persisted
+        // immutable resolution rather than process-local plugin identities.
+        let restarted_state = build_state(
+            control.clone(),
+            Arc::new(LocalKeyWrapping::with_kek(TEST_KEK)),
+            Arc::new(s4_gateway::workspace_storage::InMemoryWorkspaceStorageRepository::new()),
+        )
+        .await
+        .expect("restart gateway with durable staged multipart");
+        let restarted_app = build_router(restarted_state);
+
         // CompleteMultipartUpload with the strict sorted XML document.
         let complete_xml = format!(
             "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>{etag1}</ETag></Part><Part><PartNumber>2</PartNumber><ETag>{etag2}</ETag></Part></CompleteMultipartUpload>"
@@ -2748,7 +2762,7 @@ fn router_staged_multipart_flow_is_durable_and_idempotent() {
         mock_state
             .block_destination_put
             .store(true, Ordering::Release);
-        let first_completion = tokio::spawn(app.clone().oneshot(complete));
+        let first_completion = tokio::spawn(restarted_app.clone().oneshot(complete));
         tokio::time::timeout(
             Duration::from_secs(5),
             mock_state.destination_put_started.notified(),
@@ -2763,7 +2777,7 @@ fn router_staged_multipart_flow_is_durable_and_idempotent() {
                 .unwrap(),
             &hdrs,
         );
-        let busy_response = app.clone().oneshot(busy).await.unwrap();
+        let busy_response = restarted_app.clone().oneshot(busy).await.unwrap();
         assert_eq!(
             busy_response.status(),
             StatusCode::SERVICE_UNAVAILABLE,

--- a/crates/gateway/tests/s3_frontdoor_test.rs
+++ b/crates/gateway/tests/s3_frontdoor_test.rs
@@ -19,6 +19,10 @@ use s4_gateway::control::{
 };
 use s4_gateway::key_cipher::{KeyWrapping, LocalKeyWrapping, SecretCipher, default_wrapping};
 use s4_gateway::object::BodyLimits;
+use s4_gateway::pipeline::{
+    ComponentSource, PipelineDirection, PipelineResolution, PipelineResolver,
+    StaticPipelineResolver,
+};
 use s4_gateway::plugin_registry::{PipelineLimits, PluginRegistry};
 use s4_gateway::server::{
     AppState, StatePipelineTemplate, StreamingReadMode, build_router,
@@ -66,6 +70,10 @@ struct FrameSequenceBody {
     frames: VecDeque<Result<Frame<Bytes>, std::io::Error>>,
 }
 
+struct ChannelBody {
+    receiver: tokio::sync::mpsc::Receiver<Bytes>,
+}
+
 impl FrameSequenceBody {
     fn data(frames: impl IntoIterator<Item = Bytes>) -> Self {
         Self {
@@ -86,6 +94,20 @@ impl http_body::Body for FrameSequenceBody {
         _cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         Poll::Ready(self.frames.pop_front())
+    }
+}
+
+impl http_body::Body for ChannelBody {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        self.receiver
+            .poll_recv(cx)
+            .map(|value| value.map(|bytes| Ok(Frame::data(bytes))))
     }
 }
 
@@ -137,11 +159,145 @@ struct RecordedUsage {
 #[derive(Debug, Default)]
 struct RecordingMeteringControl {
     events: Mutex<Vec<RecordedUsage>>,
+    attempts: Mutex<Vec<s4_gateway::control::PipelineAttempt>>,
     authorizations: Mutex<Vec<(AuthenticatedRequestContext, UsageAuthorization)>>,
     releases: Mutex<Vec<(AuthenticatedRequestContext, uuid::Uuid)>>,
     authorization_failure: Option<AuthorizationError>,
     block_reason: Option<BlockReason>,
     failure: Option<MeteringError>,
+}
+
+#[derive(Debug, Default)]
+struct PipelineAttemptControl {
+    resolved: Arc<std::sync::atomic::AtomicBool>,
+    authorizations: AtomicUsize,
+    releases: AtomicUsize,
+    usage: AtomicUsize,
+    attempts: Mutex<Vec<s4_gateway::control::PipelineAttempt>>,
+}
+
+#[async_trait::async_trait]
+impl ControlPlane for PipelineAttemptControl {
+    async fn authorize(
+        &self,
+        _context: &AuthenticatedRequestContext,
+        authorization: &UsageAuthorization,
+    ) -> Result<AuthorizationDecision, AuthorizationError> {
+        assert!(
+            self.resolved.load(Ordering::Acquire),
+            "pipeline resolution must precede authorization"
+        );
+        self.authorizations.fetch_add(1, Ordering::Relaxed);
+        Ok(AuthorizationDecision::Granted(test_authorization_grant(
+            authorization,
+        )))
+    }
+
+    async fn release(
+        &self,
+        _context: &AuthenticatedRequestContext,
+        _operation_id: uuid::Uuid,
+    ) -> Result<(), AuthorizationError> {
+        self.releases.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    async fn record(
+        &self,
+        _context: &AuthenticatedRequestContext,
+        _event: &UsageEvent,
+    ) -> Result<(), MeteringError> {
+        self.usage.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    async fn record_pipeline_attempt(
+        &self,
+        _context: &AuthenticatedRequestContext,
+        attempt: &s4_gateway::control::PipelineAttempt,
+    ) -> Result<(), MeteringError> {
+        self.attempts.lock().unwrap().push(attempt.clone());
+        Ok(())
+    }
+}
+
+struct TestPipelineResolver {
+    resolution: PipelineResolution,
+    calls: Mutex<Vec<(String, String, PipelineDirection)>>,
+    resolved: Arc<std::sync::atomic::AtomicBool>,
+    failure_code: Option<&'static str>,
+}
+
+#[async_trait::async_trait]
+impl PipelineResolver for TestPipelineResolver {
+    async fn resolve(
+        &self,
+        workspace_id: &str,
+        bucket: &str,
+        direction: PipelineDirection,
+    ) -> Result<PipelineResolution, s4_error::S4Error> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push((workspace_id.to_string(), bucket.to_string(), direction));
+        self.resolved.store(true, Ordering::Release);
+        if let Some(code) = self.failure_code {
+            return Err(s4_error::S4Error::new(code, "private resolver detail"));
+        }
+        let mut resolution = self.resolution.clone();
+        resolution.locator.fingerprint = s4_gateway::pipeline::resolution_fingerprint(
+            direction,
+            &resolution.steps,
+            resolution.explicit_passthrough,
+            resolution.limits,
+        );
+        Ok(resolution)
+    }
+}
+
+struct CorruptComponentSource;
+
+#[async_trait::async_trait]
+impl ComponentSource for CorruptComponentSource {
+    async fn load(&self, _component_hash: &str) -> Result<Bytes, s4_error::S4Error> {
+        Ok(Bytes::from_static(b"corrupt artifact bytes"))
+    }
+}
+
+struct FixedComponentSource(Bytes);
+
+#[async_trait::async_trait]
+impl ComponentSource for FixedComponentSource {
+    async fn load(&self, _component_hash: &str) -> Result<Bytes, s4_error::S4Error> {
+        Ok(self.0.clone())
+    }
+}
+
+struct SwitchingResolver {
+    current: Mutex<PipelineResolution>,
+    first_resolved: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+}
+
+#[async_trait::async_trait]
+impl PipelineResolver for SwitchingResolver {
+    async fn resolve(
+        &self,
+        _workspace_id: &str,
+        _bucket: &str,
+        direction: PipelineDirection,
+    ) -> Result<PipelineResolution, s4_error::S4Error> {
+        let mut resolution = self.current.lock().unwrap().clone();
+        resolution.locator.fingerprint = s4_gateway::pipeline::resolution_fingerprint(
+            direction,
+            &resolution.steps,
+            resolution.explicit_passthrough,
+            resolution.limits,
+        );
+        if let Some(sender) = self.first_resolved.lock().unwrap().take() {
+            let _ = sender.send(());
+        }
+        Ok(resolution)
+    }
 }
 
 #[async_trait::async_trait]
@@ -188,6 +344,57 @@ impl ControlPlane for RecordingMeteringControl {
             event: event.clone(),
         });
         self.failure.map_or(Ok(()), Err)
+    }
+
+    async fn record_pipeline_attempt(
+        &self,
+        _context: &AuthenticatedRequestContext,
+        attempt: &s4_gateway::control::PipelineAttempt,
+    ) -> Result<(), MeteringError> {
+        self.attempts.lock().unwrap().push(attempt.clone());
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct RetryMeteringControl {
+    failures_remaining: AtomicUsize,
+    calls: Mutex<Vec<UsageEvent>>,
+    releases: AtomicUsize,
+}
+
+#[async_trait::async_trait]
+impl ControlPlane for RetryMeteringControl {
+    async fn authorize(
+        &self,
+        _context: &AuthenticatedRequestContext,
+        authorization: &UsageAuthorization,
+    ) -> Result<AuthorizationDecision, AuthorizationError> {
+        Ok(AuthorizationDecision::Granted(test_authorization_grant(
+            authorization,
+        )))
+    }
+
+    async fn release(
+        &self,
+        _context: &AuthenticatedRequestContext,
+        _operation_id: uuid::Uuid,
+    ) -> Result<(), AuthorizationError> {
+        self.releases.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    async fn record(
+        &self,
+        _context: &AuthenticatedRequestContext,
+        event: &UsageEvent,
+    ) -> Result<(), MeteringError> {
+        self.calls.lock().unwrap().push(event.clone());
+        self.failures_remaining
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .map_or(Ok(()), |_| Err(MeteringError::Unavailable))
     }
 }
 
@@ -730,6 +937,27 @@ async fn unsafe_transformed_test_state(later_filter: bool) -> Arc<AppState> {
         .plugins
         .import("test-failure", &test_filter_component())
         .unwrap();
+    state
+}
+
+async fn direct_passthrough_test_state(control: Arc<dyn ControlPlane>) -> Arc<AppState> {
+    let mut state = test_state().await;
+    let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
+    state_mut.streaming_read_mode = StreamingReadMode::Transformed;
+    state_mut.transformed_read_spool_enabled = false;
+    state_mut.control = control;
+    for plugin in state_mut.plugins.list() {
+        state_mut.plugins.set_enabled(&plugin.id, false);
+    }
+    state_mut.store.put(
+        "direct",
+        "records.txt",
+        Bytes::from_static(b"first\nsecond\n"),
+        "text/plain",
+    );
+    state_mut
+        .store
+        .put("direct", "empty.txt", Bytes::new(), "text/plain");
     state
 }
 
@@ -2177,6 +2405,9 @@ async fn launch_contract_billable_handlers_generate_distinct_server_usage_event_
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+    let _ = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
 
     let response = app
         .clone()
@@ -2289,6 +2520,11 @@ async fn launch_contract_billable_handlers_generate_distinct_server_usage_event_
         .expect("PUT records the resolved pipeline");
     assert_eq!(write_pipeline.revision, "static");
     assert!(!write_pipeline.fingerprint.is_empty());
+    let component_parts = write_pipeline.components.split(':').collect::<Vec<_>>();
+    assert_eq!(component_parts.len(), 3);
+    assert_eq!(component_parts[0], "v1");
+    assert!(component_parts[1].parse::<usize>().is_ok());
+    assert_eq!(component_parts[2].len(), 64);
     assert!(
         events[1..]
             .iter()
@@ -2304,6 +2540,16 @@ async fn launch_contract_billable_handlers_generate_distinct_server_usage_event_
         assert_eq!(authorization.kind(), event.event.kind());
         assert_eq!(authorization.route(), event.event.route());
     }
+    assert_eq!(authorizations[0].1.pipeline_revision(), Some("static"));
+    assert_eq!(
+        authorizations[0].1.pipeline_fingerprint(),
+        Some(write_pipeline.fingerprint.as_str())
+    );
+    assert!(
+        authorizations[1..]
+            .iter()
+            .all(|(_, authorization)| authorization.pipeline_revision().is_none())
+    );
     assert_eq!(
         authorizations
             .iter()
@@ -3339,7 +3585,7 @@ async fn presigned_transport_failure_never_discloses_signed_url_material() {
             .to_vec(),
     )
     .unwrap();
-    assert!(body.contains("presigned backend request failed"), "{body}");
+    assert!(body.contains("We encountered an internal error."), "{body}");
     let address = address.to_string();
     for sensitive in [
         signed_url.as_str(),
@@ -5371,11 +5617,13 @@ async fn unsafe_transformed_read_stages_then_sanitizes_source_headers() {
     let spool_dir =
         std::env::temp_dir().join(format!("s4-read-spool-router-{}", uuid::Uuid::now_v7()));
     let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
+    let control = Arc::new(RecordingMeteringControl::default());
     state_mut.streaming_read_mode = StreamingReadMode::Transformed;
     state_mut.transformed_read_spool_enabled = true;
     state_mut.spool_config.directory = spool_dir.clone();
     state_mut.spool_config.max_object_bytes = 1024;
     state_mut.spool_quota = Arc::new(SpoolQuota::new(2048));
+    state_mut.control = control.clone();
     state.store.put(
         "read",
         "raw.txt",
@@ -5416,6 +5664,16 @@ async fn unsafe_transformed_read_stages_then_sanitizes_source_headers() {
     assert!(
         std::fs::read_dir(&spool_dir).unwrap().next().is_none(),
         "staged ciphertext must be removed after replay"
+    );
+    let events = control.events.lock().unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0]
+            .event
+            .pipeline_evidence()
+            .expect("unsafe read records pipeline evidence")
+            .spool_mode,
+        "encrypted"
     );
 }
 
@@ -5468,6 +5726,242 @@ async fn transformed_read_rejects_range_part_head_encoding_and_unknown_format() 
             assert!(String::from_utf8_lossy(&body).contains("<Code>InvalidRequest</Code>"));
         }
         assert!(!String::from_utf8_lossy(&body).contains("alice@example.com"));
+    }
+}
+
+#[tokio::test]
+async fn resolver_precedes_authorization_and_isolates_workspace_bucket_and_direction() {
+    let mut state = test_state().await;
+    let baseline = StaticPipelineResolver::new(state.plugins.clone())
+        .resolve("seed", "seed", PipelineDirection::Write)
+        .await
+        .unwrap();
+    let resolved = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let resolver = Arc::new(TestPipelineResolver {
+        resolution: baseline,
+        calls: Mutex::default(),
+        resolved: resolved.clone(),
+        failure_code: None,
+    });
+    let control = Arc::new(PipelineAttemptControl {
+        resolved,
+        ..PipelineAttemptControl::default()
+    });
+    let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
+    state_mut.streaming_read_mode = StreamingReadMode::Transformed;
+    state_mut.transformed_read_spool_enabled = true;
+    state_mut.control = control.clone();
+    state_mut.gateway = Arc::new(
+        state_mut
+            .gateway
+            .as_ref()
+            .clone()
+            .with_resolver(resolver.clone(), state_mut.plugins.clone()),
+    );
+    let first = make_key_for(&state, "workspace-a").await;
+    let second = make_key_for(&state, "workspace-b").await;
+    let app = build_router(state);
+
+    for (credentials, key) in [(&first, "a.txt"), (&second, "b.txt")] {
+        control.resolved.store(false, Ordering::Release);
+        let response = app
+            .clone()
+            .oneshot(add_headers(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/same-bucket/{key}"))
+                    .header(header::CONTENT_TYPE, "text/plain")
+                    .body(Body::from("alice@example.com"))
+                    .unwrap(),
+                &auth_headers(&credentials.0, &credentials.1),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    control.resolved.store(false, Ordering::Release);
+    let response = app
+        .oneshot(add_headers(
+            Request::builder()
+                .method("GET")
+                .uri("/same-bucket/a.txt")
+                .header("x-s4-process", "read")
+                .body(Body::empty())
+                .unwrap(),
+            &auth_headers(&first.0, &first.1),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let _ = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let calls = resolver.calls.lock().unwrap().clone();
+    assert_eq!(
+        calls,
+        vec![
+            (
+                "workspace-a".to_string(),
+                "same-bucket".to_string(),
+                PipelineDirection::Write,
+            ),
+            (
+                "workspace-b".to_string(),
+                "same-bucket".to_string(),
+                PipelineDirection::Write,
+            ),
+            (
+                "workspace-a".to_string(),
+                "same-bucket".to_string(),
+                PipelineDirection::Read,
+            ),
+        ]
+    );
+    assert_eq!(control.authorizations.load(Ordering::Relaxed), 3);
+    assert_eq!(control.usage.load(Ordering::Relaxed), 3);
+    assert!(control.attempts.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn in_flight_put_keeps_the_assignment_frozen_before_body_polling() {
+    let mut state = test_state().await;
+    let frozen = StaticPipelineResolver::new(state.plugins.clone())
+        .resolve("seed", "seed", PipelineDirection::Write)
+        .await
+        .unwrap();
+    let mut replacement = frozen.clone();
+    replacement.locator.revision = "replacement".to_string();
+    replacement.steps.clear();
+    replacement.explicit_passthrough = true;
+    let (resolved_sender, resolved_receiver) = tokio::sync::oneshot::channel();
+    let resolver = Arc::new(SwitchingResolver {
+        current: Mutex::new(frozen),
+        first_resolved: Mutex::new(Some(resolved_sender)),
+    });
+    let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
+    state_mut.gateway = Arc::new(
+        state_mut
+            .gateway
+            .as_ref()
+            .clone()
+            .with_resolver(resolver.clone(), state_mut.plugins.clone()),
+    );
+    let credentials = make_key(&state).await;
+    let app = build_router(state);
+    let (body_sender, body_receiver) = tokio::sync::mpsc::channel(1);
+    let request = add_headers(
+        Request::builder()
+            .method("PUT")
+            .uri("/freeze/object.txt")
+            .header(header::CONTENT_TYPE, "text/plain")
+            .body(Body::new(ChannelBody {
+                receiver: body_receiver,
+            }))
+            .unwrap(),
+        &auth_headers(&credentials.0, &credentials.1),
+    );
+    let request_task = tokio::spawn(app.clone().oneshot(request));
+    resolved_receiver
+        .await
+        .expect("request resolves before polling the body");
+    *resolver.current.lock().unwrap() = replacement;
+    body_sender
+        .send(Bytes::from_static(b"alice@example.com"))
+        .await
+        .unwrap();
+    drop(body_sender);
+    let response = request_task.await.unwrap().unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(add_headers(
+            Request::builder()
+                .method("GET")
+                .uri("/freeze/object.txt")
+                .body(Body::empty())
+                .unwrap(),
+            &auth_headers(&credentials.0, &credentials.1),
+        ))
+        .await
+        .unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(body, "[REDACTED_EMAIL]");
+}
+
+#[tokio::test]
+async fn resolver_outage_and_artifact_corruption_fail_closed_without_body_or_charge() {
+    for artifact_corruption in [false, true] {
+        let mut state = test_state().await;
+        let mut resolution = StaticPipelineResolver::new(state.plugins.clone())
+            .resolve("seed", "seed", PipelineDirection::Write)
+            .await
+            .unwrap();
+        if artifact_corruption {
+            resolution.steps[0].component_hash = "a".repeat(64);
+        }
+        let resolved = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let resolver = Arc::new(TestPipelineResolver {
+            resolution,
+            calls: Mutex::default(),
+            resolved: resolved.clone(),
+            failure_code: (!artifact_corruption).then_some(s4_error::codes::INTERNAL),
+        });
+        let control = Arc::new(PipelineAttemptControl {
+            resolved,
+            ..PipelineAttemptControl::default()
+        });
+        let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
+        state_mut.control = control.clone();
+        let source: Arc<dyn ComponentSource> = if artifact_corruption {
+            Arc::new(CorruptComponentSource)
+        } else {
+            state_mut.plugins.clone()
+        };
+        state_mut.gateway = Arc::new(
+            state_mut
+                .gateway
+                .as_ref()
+                .clone()
+                .with_resolver(resolver, source),
+        );
+        let credentials = make_key(&state).await;
+        let polls = Arc::new(AtomicUsize::new(0));
+        let response = build_router(state)
+            .oneshot(add_headers(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/failure/object.txt")
+                    .header(header::CONTENT_TYPE, "text/plain")
+                    .body(Body::new(PollTrackingBody {
+                        polls: polls.clone(),
+                        data: Some(Bytes::from_static(b"must-not-be-polled")),
+                    }))
+                    .unwrap(),
+                &auth_headers(&credentials.0, &credentials.1),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&body);
+        assert!(body.contains("<Code>InternalError</Code>"));
+        assert!(!body.contains("private resolver detail"));
+        assert!(!body.contains("corrupt artifact bytes"));
+        assert_eq!(polls.load(Ordering::Relaxed), 0);
+        assert_eq!(control.usage.load(Ordering::Relaxed), 0);
+        assert_eq!(control.attempts.lock().unwrap().len(), 1);
+        if artifact_corruption {
+            assert_eq!(control.authorizations.load(Ordering::Relaxed), 1);
+            assert_eq!(control.releases.load(Ordering::Relaxed), 1);
+        } else {
+            assert_eq!(control.authorizations.load(Ordering::Relaxed), 0);
+            assert_eq!(control.releases.load(Ordering::Relaxed), 0);
+        }
     }
 }
 
@@ -5600,7 +6094,7 @@ async fn unsafe_transformed_source_limit_has_no_disclosure() {
 }
 
 #[tokio::test]
-async fn empty_prefix_safe_snapshot_streams_without_length_or_staging() {
+async fn nonempty_prefix_safe_reads_stream_and_settle_without_spool() {
     async fn unknown_length_source(
         method: axum::http::Method,
         uri: axum::http::Uri,
@@ -5634,8 +6128,14 @@ async fn empty_prefix_safe_snapshot_streams_without_length_or_staging() {
     let mut state = test_state().await;
     let control = Arc::new(RecordingMeteringControl::default());
     let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
+    let spool_dir =
+        std::env::temp_dir().join(format!("s4-direct-read-no-spool-{}", uuid::Uuid::now_v7()));
+    let spool_quota = Arc::new(SpoolQuota::new(2048));
     state_mut.streaming_read_mode = StreamingReadMode::Transformed;
     state_mut.transformed_read_spool_enabled = false;
+    state_mut.spool_config.directory = spool_dir.clone();
+    state_mut.spool_config.max_object_bytes = 1024;
+    state_mut.spool_quota = spool_quota.clone();
     state_mut.control = control.clone();
     state_mut.s3_client = Some(aws_sdk_s3::Client::from_conf(
         aws_sdk_s3::Config::builder()
@@ -5695,7 +6195,14 @@ async fn empty_prefix_safe_snapshot_streams_without_length_or_staging() {
         ))
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(!response.headers().contains_key(header::CONTENT_LENGTH));
+    assert_eq!(
+        axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+        "one\ntwo\n"
+    );
 
     assert_eq!(
         control
@@ -5712,17 +6219,247 @@ async fn empty_prefix_safe_snapshot_streams_without_length_or_staging() {
                 )
             })
             .collect::<Vec<_>>(),
-        vec![(RequestKind::Read, UsageRoute::GetObject, 0, 0)]
+        vec![
+            (RequestKind::Read, UsageRoute::GetObject, 0, 0),
+            (RequestKind::Read, UsageRoute::GetObject, 8, 8),
+        ]
     );
     let events = control.events.lock().unwrap();
-    let evidence = events[0]
-        .event
-        .pipeline_evidence()
-        .expect("completed empty direct read must retain measured evidence");
-    assert_eq!(evidence.revision, "static");
-    assert_eq!(evidence.fuel_consumed, 0);
-    assert_eq!(evidence.spool_mode, "none");
+    for event in events.iter() {
+        let evidence = event
+            .event
+            .pipeline_evidence()
+            .expect("completed prefix-safe read must retain measured evidence");
+        assert_eq!(evidence.revision, "static");
+        assert_eq!(evidence.fuel_consumed, 0);
+        assert_eq!(evidence.spool_mode, "none");
+        assert!(evidence.components.starts_with("v1:0:"));
+    }
+    assert_eq!(spool_quota.reserved_bytes(), 0);
+    assert!(
+        std::fs::read_dir(&spool_dir)
+            .map(|mut entries| entries.next().is_none())
+            .unwrap_or(true),
+        "direct reads must not create encrypted spool files"
+    );
     task.abort();
+}
+
+#[tokio::test]
+async fn direct_read_retries_the_exact_terminal_event_before_eof() {
+    let control = Arc::new(RetryMeteringControl {
+        failures_remaining: AtomicUsize::new(2),
+        calls: Mutex::default(),
+        releases: AtomicUsize::new(0),
+    });
+    let state = direct_passthrough_test_state(control.clone()).await;
+    let credentials = make_key(&state).await;
+    let response = build_router(state)
+        .oneshot(add_headers(
+            Request::builder()
+                .method("GET")
+                .uri("/direct/records.txt")
+                .header("x-s4-process", "read")
+                .body(Body::empty())
+                .unwrap(),
+            &auth_headers(&credentials.0, &credentials.1),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+        "first\nsecond\n"
+    );
+    let calls = control.calls.lock().unwrap();
+    assert_eq!(calls.len(), 3);
+    assert!(calls.windows(2).all(|pair| pair[0] == pair[1]));
+    assert_eq!(
+        calls[0]
+            .pipeline_evidence()
+            .expect("direct settlement includes evidence")
+            .spool_mode,
+        "none"
+    );
+    assert_eq!(control.releases.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn direct_read_settlement_exhaustion_errors_after_disclosure_and_preserves_reservation() {
+    let control = Arc::new(RetryMeteringControl {
+        failures_remaining: AtomicUsize::new(usize::MAX),
+        calls: Mutex::default(),
+        releases: AtomicUsize::new(0),
+    });
+    let state = direct_passthrough_test_state(control.clone()).await;
+    let credentials = make_key(&state).await;
+    let response = build_router(state)
+        .oneshot(add_headers(
+            Request::builder()
+                .method("GET")
+                .uri("/direct/records.txt")
+                .header("x-s4-process", "read")
+                .body(Body::empty())
+                .unwrap(),
+            &auth_headers(&credentials.0, &credentials.1),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut body = response.into_body();
+    let first = http_body_util::BodyExt::frame(&mut body)
+        .await
+        .unwrap()
+        .unwrap()
+        .into_data()
+        .unwrap();
+    assert!(
+        !first.is_empty(),
+        "transformed output is disclosed before settlement"
+    );
+    let mut terminal_error = None;
+    while let Some(frame) = http_body_util::BodyExt::frame(&mut body).await {
+        if let Err(error) = frame {
+            terminal_error = Some(error);
+            break;
+        }
+    }
+    assert!(terminal_error.is_some());
+    assert_eq!(control.calls.lock().unwrap().len(), 3);
+    assert_eq!(control.releases.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn direct_read_client_cancellation_after_disclosure_preserves_recoverable_reservation() {
+    let control = Arc::new(RecordingMeteringControl::default());
+    let state = direct_passthrough_test_state(control.clone()).await;
+    let credentials = make_key(&state).await;
+    let app = build_router(state);
+    let response = app
+        .clone()
+        .oneshot(add_headers(
+            Request::builder()
+                .method("GET")
+                .uri("/direct/records.txt")
+                .header("x-s4-process", "read")
+                .body(Body::empty())
+                .unwrap(),
+            &auth_headers(&credentials.0, &credentials.1),
+        ))
+        .await
+        .unwrap();
+    let mut body = response.into_body();
+    let first = http_body_util::BodyExt::frame(&mut body)
+        .await
+        .unwrap()
+        .unwrap()
+        .into_data()
+        .unwrap();
+    assert!(!first.is_empty());
+    drop(body);
+    tokio::task::yield_now().await;
+    assert!(control.events.lock().unwrap().is_empty());
+    assert!(control.releases.lock().unwrap().is_empty());
+
+    let response = app
+        .oneshot(add_headers(
+            Request::builder()
+                .method("GET")
+                .uri("/direct/empty.txt")
+                .header("x-s4-process", "read")
+                .body(Body::empty())
+                .unwrap(),
+            &auth_headers(&credentials.0, &credentials.1),
+        ))
+        .await
+        .unwrap();
+    drop(response.into_body());
+    tokio::task::yield_now().await;
+    assert_eq!(control.releases.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn direct_read_terminal_plugin_error_never_settles_customer_usage() {
+    let component = std::fs::read(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../target/test-components/test-filter.component.wasm"),
+    )
+    .expect("test-filter.component.wasm; run just build-filters");
+    let registry = Arc::new(PluginRegistry::new());
+    registry.import("prefix-safe-test", &component).unwrap();
+    let mut resolution = StaticPipelineResolver::new(registry.clone())
+        .resolve("seed", "seed", PipelineDirection::Read)
+        .await
+        .unwrap();
+    resolution.steps[0].capabilities.prefix_safe_for_read = true;
+    let resolver = Arc::new(TestPipelineResolver {
+        resolution,
+        calls: Mutex::default(),
+        resolved: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        failure_code: None,
+    });
+    let execution_registry = Arc::new(PluginRegistry::new());
+    let mut state = test_state().await;
+    let control = Arc::new(RecordingMeteringControl::default());
+    let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
+    state_mut.streaming_read_mode = StreamingReadMode::Transformed;
+    state_mut.transformed_read_spool_enabled = false;
+    state_mut.control = control.clone();
+    state_mut.plugins = execution_registry.clone();
+    state_mut.gateway = Arc::new(
+        Gateway::with_registry(
+            s4_wasm_runtime::FilterEngine::new(&component).unwrap(),
+            execution_registry,
+        )
+        .with_resolver(resolver, Arc::new(FixedComponentSource(component.into()))),
+    );
+    state_mut.store.put(
+        "direct",
+        "failure.txt",
+        Bytes::from_static(b"safe\ntrap\n"),
+        "text/plain",
+    );
+    let credentials = make_key(&state).await;
+    let response = build_router(state)
+        .oneshot(add_headers(
+            Request::builder()
+                .method("GET")
+                .uri("/direct/failure.txt")
+                .header("x-s4-process", "read")
+                .body(Body::empty())
+                .unwrap(),
+            &auth_headers(&credentials.0, &credentials.1),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut body = response.into_body();
+    let first = http_body_util::BodyExt::frame(&mut body)
+        .await
+        .unwrap()
+        .unwrap()
+        .into_data()
+        .unwrap();
+    assert_eq!(first, "safe");
+    let mut disclosed = first.to_vec();
+    let mut terminal_error = false;
+    while let Some(frame) = http_body_util::BodyExt::frame(&mut body).await {
+        match frame {
+            Ok(frame) => disclosed.extend_from_slice(&frame.into_data().unwrap()),
+            Err(_) => {
+                terminal_error = true;
+                break;
+            }
+        }
+    }
+    assert!(terminal_error);
+    assert_eq!(disclosed, b"safe\n");
+    tokio::task::yield_now().await;
+    assert!(control.events.lock().unwrap().is_empty());
+    assert!(control.releases.lock().unwrap().is_empty());
+    assert_eq!(control.attempts.lock().unwrap().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/gateway/tests/s3_protocol.rs
+++ b/crates/gateway/tests/s3_protocol.rs
@@ -37,7 +37,8 @@ fn s3_internal_error_returns_500_xml() {
     assert_eq!(status_of(&resp), StatusCode::INTERNAL_SERVER_ERROR);
     let body = body_of(resp);
     assert!(body.contains("<Code>InternalError</Code>"));
-    assert!(body.contains("something broke"));
+    assert!(body.contains("We encountered an internal error."));
+    assert!(!body.contains("something broke"));
 }
 
 #[test]

--- a/crates/wasm-runtime/src/lib.rs
+++ b/crates/wasm-runtime/src/lib.rs
@@ -48,32 +48,32 @@ const DEFAULT_MAX_MEMORIES: usize = 4;
 const DEFAULT_TABLE_ELEMENTS: usize = 10_000;
 const EPOCH_TICK: Duration = Duration::from_millis(10);
 
-/// Maximum length of a guest-supplied diagnostic or reject reason after
-/// sanitization. Guest messages are untrusted input; they must never be
-/// forwarded verbatim into logs, HTTP responses, or operator surfaces.
-pub const MAX_GUEST_DIAGNOSTIC_BYTES: usize = 4 * 1024;
+/// Maximum length of the irreversible guest-diagnostic correlation token.
+/// Guest messages are untrusted and never appear in the returned value.
+pub const MAX_GUEST_DIAGNOSTIC_BYTES: usize = 96;
 
-/// Sanitizes an untrusted guest diagnostic (trap message, `reject` reason, or
-/// `result::<_, string>` error) before it is recorded in an `S4Error`.
-///
-/// The value is bounded to [`MAX_GUEST_DIAGNOSTIC_BYTES`] and control
-/// characters (including embedded newlines and ANSI escape sequences) are
-/// replaced with spaces so a hostile filter cannot forge log lines, inject
-/// terminal escapes, or embed secret payloads in operator-visible output.
+/// Converts an untrusted guest diagnostic into an irreversible, bounded token
+/// suitable only for correlating identical validation failures. Runtime errors
+/// remain generic, and neither printable text nor control characters survive.
 pub fn sanitize_guest_diagnostic(raw: &str) -> String {
-    const MAX: usize = MAX_GUEST_DIAGNOSTIC_BYTES;
-    let mut out = String::with_capacity(raw.len().min(MAX));
-    for ch in raw.chars() {
-        if out.len() >= MAX {
-            break;
-        }
-        if ch.is_control() || ch == '\u{7f}' {
-            out.push(' ');
-        } else {
-            out.push(ch);
-        }
-    }
-    out
+    use sha2::{Digest as _, Sha256};
+
+    format!(
+        "guest-diagnostic-sha256:{}",
+        hex::encode(Sha256::digest(raw.as_bytes()))
+    )
+}
+
+fn guest_failure(code: &'static str, stage: &'static str) -> S4Error {
+    let message = match code {
+        codes::WASM_REJECT => "filter rejected the input",
+        codes::WASM_INIT => "filter initialization failed",
+        _ => match stage {
+            "finish" => "filter finalization failed",
+            _ => "filter execution failed",
+        },
+    };
+    S4Error::new(code, message)
 }
 
 #[derive(Debug)]
@@ -307,15 +307,11 @@ impl FilterSession {
         let decision = self
             .runtime
             .complete_call(window, result, "transform", codes::WASM_TRAP)?;
-        let decision = decision
-            .map_err(|error| S4Error::new(codes::WASM_TRAP, sanitize_guest_diagnostic(&error)))?;
+        let decision = decision.map_err(|_| guest_failure(codes::WASM_TRAP, "transform"))?;
         match decision {
             Decision::Emit(data) => Ok(TransformOutcome::Emit(data)),
             Decision::Drop => Ok(TransformOutcome::Drop),
-            Decision::Reject(reason) => Err(S4Error::new(
-                codes::WASM_REJECT,
-                sanitize_guest_diagnostic(&reason),
-            )),
+            Decision::Reject(_) => Err(guest_failure(codes::WASM_REJECT, "transform")),
         }
     }
 
@@ -330,7 +326,7 @@ impl FilterSession {
         let output = self
             .runtime
             .complete_call(window, result, "finish", codes::WASM_TRAP)?
-            .map_err(|error| S4Error::new(codes::WASM_TRAP, sanitize_guest_diagnostic(&error)))?;
+            .map_err(|_| guest_failure(codes::WASM_TRAP, "finish"))?;
         Ok((output, self.runtime.fuel_consumed))
     }
 
@@ -371,7 +367,7 @@ impl FilterSession {
         let result = funcs.call_begin(&mut self.runtime.store, context);
         self.runtime
             .complete_call(window, result, "begin", codes::WASM_INIT)?
-            .map_err(|error| S4Error::new(codes::WASM_INIT, sanitize_guest_diagnostic(&error)))
+            .map_err(|_| guest_failure(codes::WASM_INIT, "begin"))
     }
 
     fn call_begin_v02(
@@ -386,7 +382,7 @@ impl FilterSession {
         let result = funcs.call_begin(&mut self.runtime.store, context);
         self.runtime
             .complete_call(window, result, "begin", codes::WASM_INIT)?
-            .map_err(|error| S4Error::new(codes::WASM_INIT, sanitize_guest_diagnostic(&error)))
+            .map_err(|_| guest_failure(codes::WASM_INIT, "begin"))
     }
 }
 
@@ -451,9 +447,14 @@ impl RuntimeSession {
             } else {
                 default_code
             };
-            S4Error::new(
+            let _ = error;
+            guest_failure(
                 code,
-                format!("{stage}: {}", sanitize_guest_diagnostic(&error.to_string())),
+                match stage {
+                    "begin" => "begin",
+                    "finish" => "finish",
+                    _ => "transform",
+                },
             )
         })
     }
@@ -464,6 +465,10 @@ const DEFAULT_FUEL: u64 = 10_000_000;
 impl FilterEngine {
     pub fn new(component_bytes: &[u8]) -> anyhow::Result<Self> {
         Self::with_fuel(component_bytes, DEFAULT_FUEL)
+    }
+
+    pub fn world_version(&self) -> FilterWorldVersion {
+        self.runtime.world_version
     }
 
     pub fn with_fuel(component_bytes: &[u8], fuel: u64) -> anyhow::Result<Self> {
@@ -832,7 +837,8 @@ impl RuntimeComponent {
                 } else {
                     instantiation_code
                 };
-                S4Error::new(code, sanitize_guest_diagnostic(&error.to_string()))
+                let _ = error;
+                guest_failure(code, "begin")
             })?;
         let remaining_after_start = store
             .get_fuel()
@@ -940,7 +946,8 @@ fn startup_error(
     } else {
         default_code
     };
-    S4Error::new(code, sanitize_guest_diagnostic(&error.to_string()))
+    let _ = error;
+    guest_failure(code, "begin")
 }
 
 fn register_epoch_engine(engine: &Arc<EpochEngine>) {
@@ -1367,19 +1374,100 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_guest_diagnostic_strips_control_characters() {
+    fn guest_diagnostic_correlation_token_is_irreversible_stable_and_bounded() {
         let raw = "secret\u{1b}[31mred\u{0a}next\u{07}";
         let sanitized = sanitize_guest_diagnostic(raw);
-        assert_eq!(sanitized, "secret [31mred next ");
-        assert!(!sanitized.contains('\u{1b}'));
-        assert!(!sanitized.contains('\n'));
-        assert!(!sanitized.contains('\u{07}'));
-        assert_eq!(sanitize_guest_diagnostic("plain"), "plain");
+        assert!(sanitized.starts_with("guest-diagnostic-sha256:"));
+        assert!(!sanitized.contains("secret"));
+        assert_eq!(sanitized, sanitize_guest_diagnostic(raw));
+        assert_ne!(sanitized, sanitize_guest_diagnostic("different"));
         let big = "x".repeat(MAX_GUEST_DIAGNOSTIC_BYTES + 10_000);
-        assert_eq!(
-            sanitize_guest_diagnostic(&big).len(),
-            MAX_GUEST_DIAGNOSTIC_BYTES
-        );
+        assert!(sanitize_guest_diagnostic(&big).len() <= MAX_GUEST_DIAGNOSTIC_BYTES);
+    }
+
+    fn granted_secret_session(action: Option<String>) -> Session {
+        let mut configured = session();
+        configured.config_json = action;
+        configured.public_key_pem = Some("PRINTABLE_PUBLIC_KEY_SECRET".to_string());
+        configured.stable_key = Some(b"PRINTABLE_STABLE_KEY_SECRET".to_vec());
+        configured.stable_fields = Some("PRINTABLE_STABLE_FIELDS_SECRET".to_string());
+        configured
+    }
+
+    fn assert_opaque_guest_error(error: &S4Error, expected_code: &'static str) {
+        assert_eq!(error.code(), expected_code);
+        assert!(error.message().len() <= MAX_GUEST_DIAGNOSTIC_BYTES);
+        for forbidden in [
+            "SECRET=",
+            "PRINTABLE_PUBLIC_KEY_SECRET",
+            "PRINTABLE_STABLE_KEY_SECRET",
+            "PRINTABLE_STABLE_FIELDS_SECRET",
+        ] {
+            assert!(
+                !error.to_string().contains(forbidden),
+                "guest diagnostic exposed {forbidden}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_granted_secret_is_opaque_across_guest_reject_error_and_trap_paths() {
+        let engine = FilterEngine::new(&test_component_v02()).unwrap();
+        let fields = ["public-key", "entropy", "stable-key", "stable-fields"];
+
+        for field in fields {
+            for (action, code) in [
+                (format!("begin-error:{field}"), codes::WASM_INIT),
+                (format!("begin-trap:{field}"), codes::WASM_INIT),
+            ] {
+                let error = engine
+                    .start_session_with_control_and_grant(
+                        &granted_secret_session(Some(action)),
+                        CancellationToken::new(),
+                        u64::MAX,
+                        Instant::now() + Duration::from_secs(5),
+                        SensitiveGrant::ALL,
+                    )
+                    .err()
+                    .expect("guest begin must fail");
+                assert_opaque_guest_error(&error, code);
+            }
+
+            for (action, code) in [
+                (format!("reject:{field}"), codes::WASM_REJECT),
+                (format!("error:{field}"), codes::WASM_TRAP),
+                (format!("trap:{field}"), codes::WASM_TRAP),
+            ] {
+                let mut filter = engine
+                    .start_session_with_control_and_grant(
+                        &granted_secret_session(None),
+                        CancellationToken::new(),
+                        u64::MAX,
+                        Instant::now() + Duration::from_secs(5),
+                        SensitiveGrant::ALL,
+                    )
+                    .unwrap();
+                let error = filter.transform(action.as_bytes()).unwrap_err();
+                assert_opaque_guest_error(&error, code);
+            }
+
+            for action in [
+                format!("finish-error:{field}"),
+                format!("finish-trap:{field}"),
+            ] {
+                let filter = engine
+                    .start_session_with_control_and_grant(
+                        &granted_secret_session(Some(action)),
+                        CancellationToken::new(),
+                        u64::MAX,
+                        Instant::now() + Duration::from_secs(5),
+                        SensitiveGrant::ALL,
+                    )
+                    .unwrap();
+                let error = filter.finish().unwrap_err();
+                assert_opaque_guest_error(&error, codes::WASM_TRAP);
+            }
+        }
     }
 
     #[test]

--- a/docs/security.md
+++ b/docs/security.md
@@ -246,7 +246,13 @@ deliberately strict:
   pipeline snapshot is marked prefix-safe for read (operator-declared via
   `MASKURA_PREFIX_SAFE_COMPONENT_HASHES` at process start — imported components are
   unsafe by default and the capability is immutable per component hash), the
-  transformed output is streamed directly.
+  transformed output is streamed directly with bounded backpressure and no
+  disk spool. Actual source/output bytes, fuel, duration, and component evidence
+  are settled only after successful pipeline completion. EOF is withheld during
+  bounded exact settlement retries. Cancellation before disclosure releases the
+  reservation; cancellation, pipeline failure, or exhausted settlement after
+  disclosure leaves the reservation for bounded control-plane recovery and
+  never records successful customer usage.
 - **Encrypted read spool otherwise.** Any snapshot containing an unsafe
   component is rejected unless `MASKURA_TRANSFORMED_READ_SPOOL=encrypted` is set.
   The transformed output is then written to a disk spool in independently

--- a/filters/test-filter-v02/src/lib.rs
+++ b/filters/test-filter-v02/src/lib.rs
@@ -3,12 +3,48 @@
 
 #[cfg(target_arch = "wasm32")]
 mod guest {
+    use std::sync::{LazyLock, Mutex};
+
     wit_bindgen::generate!({
         world: "filter",
         path: "../../wit/s4-filter-v0.2/world.wit",
     });
 
     struct TestFilterV02;
+
+    #[derive(Default)]
+    struct GrantedValues {
+        public_key_pem: String,
+        entropy_seed: String,
+        stable_key: String,
+        stable_fields: String,
+        finish_action: Option<String>,
+    }
+
+    impl GrantedValues {
+        fn value(&self, field: &str) -> String {
+            match field {
+                "public-key" => format!("PUBLIC_KEY_SECRET={}", self.public_key_pem),
+                "entropy" => format!("ENTROPY_SECRET={}", self.entropy_seed),
+                "stable-key" => format!("STABLE_KEY_SECRET={}", self.stable_key),
+                "stable-fields" => format!("STABLE_FIELDS_SECRET={}", self.stable_fields),
+                _ => "UNKNOWN_SECRET_FIELD".to_string(),
+            }
+        }
+    }
+
+    static GRANTED: LazyLock<Mutex<GrantedValues>> =
+        LazyLock::new(|| Mutex::new(GrantedValues::default()));
+
+    fn encode(bytes: &[u8]) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut output = String::with_capacity(bytes.len() * 2);
+        for byte in bytes {
+            output.push(HEX[(byte >> 4) as usize] as char);
+            output.push(HEX[(byte & 0xf) as usize] as char);
+        }
+        output
+    }
 
     impl Guest for TestFilterV02 {
         fn begin(context: Context) -> Result<(), String> {
@@ -24,14 +60,61 @@ mod guest {
             {
                 return Err("per-step context mismatch".to_string());
             }
+            let action = context.config_json.clone();
+            let mut granted = GrantedValues {
+                public_key_pem: context.public_key_pem.unwrap_or_default(),
+                entropy_seed: encode(context.entropy_seed.as_deref().unwrap_or_default()),
+                stable_key: encode(context.stable_key.as_deref().unwrap_or_default()),
+                stable_fields: context.stable_fields.unwrap_or_default(),
+                finish_action: action.clone(),
+            };
+            if let Some(field) = action
+                .as_deref()
+                .and_then(|value| value.strip_prefix("begin-error:"))
+            {
+                return Err(granted.value(field));
+            }
+            if let Some(field) = action
+                .as_deref()
+                .and_then(|value| value.strip_prefix("begin-trap:"))
+            {
+                panic!("{}", granted.value(field));
+            }
+            *GRANTED.lock().map_err(|error| error.to_string())? = std::mem::take(&mut granted);
             Ok(())
         }
 
         fn transform(payload: Vec<u8>) -> Result<Decision, String> {
+            let command = String::from_utf8(payload.clone()).unwrap_or_default();
+            let granted = GRANTED.lock().map_err(|error| error.to_string())?;
+            if let Some(field) = command.strip_prefix("reject:") {
+                return Ok(Decision::Reject(granted.value(field)));
+            }
+            if let Some(field) = command.strip_prefix("error:") {
+                return Err(granted.value(field));
+            }
+            if let Some(field) = command.strip_prefix("trap:") {
+                panic!("{}", granted.value(field));
+            }
             Ok(Decision::Emit(payload))
         }
 
         fn finish() -> Result<Vec<u8>, String> {
+            let granted = GRANTED.lock().map_err(|error| error.to_string())?;
+            if let Some(field) = granted
+                .finish_action
+                .as_deref()
+                .and_then(|value| value.strip_prefix("finish-error:"))
+            {
+                return Err(granted.value(field));
+            }
+            if let Some(field) = granted
+                .finish_action
+                .as_deref()
+                .and_then(|value| value.strip_prefix("finish-trap:"))
+            {
+                panic!("{}", granted.value(field));
+            }
             Ok(Vec::new())
         }
     }


### PR DESCRIPTION
## Summary
- make guest failures opaque and bind immutable pipeline identity before authorization/backend access
- correct pipeline failure taxonomy and bound every S3 error field
- preserve true prefix-safe direct reads with terminal exact settlement and complete evidence
- keep unsafe/custom reads encrypted and completion-spooled
- add exact plugin-version and policy-generation fingerprint inputs
- record non-billable failed pipeline attempt evidence and canonical component count/digest evidence
- fail startup on incomplete staged multipart configuration and verify persisted fingerprints

## Verification
- filter component rebuild passed
- cargo fmt passed
- strict clippy passed
- full workspace tests passed
- gateway: 349 tests passed
- front door: 98 passed, 1 soak test ignored
- PostgreSQL: 21 tests passed
- Wasm runtime: 47 tests passed
- protocol, property, RSS, SDK/CLI, docs and doctests passed