### PR TITLE
feat(gateway): enqueue placement rebalance repairs

### DIFF
--- a/crates/gateway/src/managed.rs
+++ b/crates/gateway/src/managed.rs
@@ -618,6 +618,26 @@ pub struct AuthorityListPage {
     pub next_after: Option<String>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuthorityPlacementCursor {
+    pub tenant_id: String,
+    pub bucket: String,
+    pub key: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuthorityPlacementPageQuery {
+    pub target_placement_version: u32,
+    pub after: Option<AuthorityPlacementCursor>,
+    pub limit: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuthorityPlacementPage {
+    pub objects: Vec<ObjectAuthority>,
+    pub next_after: Option<AuthorityPlacementCursor>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ManagedListVersion {
     V1,
@@ -901,6 +921,11 @@ pub trait ManagedRepository: Send + Sync {
         &self,
         query: AuthorityListQuery,
     ) -> Result<AuthorityListPage, ManagedError>;
+    async fn list_authority_below_placement_version(
+        &self,
+        query: AuthorityPlacementPageQuery,
+    ) -> Result<AuthorityPlacementPage, ManagedError>;
+
     async fn create_list_cursor(
         &self,
         request: ManagedListCursorRequest,
@@ -978,6 +1003,12 @@ pub trait ManagedRepository: Send + Sync {
         &self,
         authority: ObjectAuthority,
         expected_cas: Option<u64>,
+    ) -> Result<ObjectAuthority, ManagedError>;
+    async fn advance_placement_version(
+        &self,
+        logical: &LogicalObjectKey,
+        expected_cas: u64,
+        placement: &Placement,
     ) -> Result<ObjectAuthority, ManagedError>;
     async fn tombstone(
         &self,
@@ -3479,6 +3510,68 @@ impl ManagedRepository for PostgresManagedRepository {
         })
     }
 
+    async fn list_authority_below_placement_version(
+        &self,
+        query: AuthorityPlacementPageQuery,
+    ) -> Result<AuthorityPlacementPage, ManagedError> {
+        if query.limit > MANAGED_AUTHORITY_LIST_MAX_KEYS || query.target_placement_version == 0 {
+            return Err(ManagedError::Conflict);
+        }
+        if query.limit == 0 {
+            return Ok(AuthorityPlacementPage {
+                objects: Vec::new(),
+                next_after: None,
+            });
+        }
+        let mut select = managed_object_authority::Entity::find()
+            .filter(managed_object_authority::Column::Tombstone.eq(false))
+            .filter(
+                managed_object_authority::Column::PlacementVersion
+                    .lt(i64::from(query.target_placement_version)),
+            )
+            .order_by_asc(managed_object_authority::Column::TenantId)
+            .order_by_asc(managed_object_authority::Column::Bucket)
+            .order_by_asc(managed_object_authority::Column::LogicalKey)
+            .limit(query.limit.saturating_add(1));
+        if let Some(after) = &query.after {
+            select = select.filter(
+                Condition::any()
+                    .add(managed_object_authority::Column::TenantId.gt(&after.tenant_id))
+                    .add(
+                        Condition::all()
+                            .add(managed_object_authority::Column::TenantId.eq(&after.tenant_id))
+                            .add(managed_object_authority::Column::Bucket.gt(&after.bucket)),
+                    )
+                    .add(
+                        Condition::all()
+                            .add(managed_object_authority::Column::TenantId.eq(&after.tenant_id))
+                            .add(managed_object_authority::Column::Bucket.eq(&after.bucket))
+                            .add(managed_object_authority::Column::LogicalKey.gt(&after.key)),
+                    ),
+            );
+        }
+        let mut objects = select
+            .all(&self.db)
+            .await
+            .map_err(persistence)?
+            .into_iter()
+            .map(authority_from_model)
+            .collect::<Result<Vec<_>, _>>()?;
+        let next_after = (objects.len() as u64 > query.limit).then(|| {
+            let authority = &objects[query.limit as usize - 1];
+            AuthorityPlacementCursor {
+                tenant_id: authority.logical.tenant_id.clone(),
+                bucket: authority.logical.bucket.clone(),
+                key: authority.logical.key.clone(),
+            }
+        });
+        objects.truncate(query.limit as usize);
+        Ok(AuthorityPlacementPage {
+            objects,
+            next_after,
+        })
+    }
+
     async fn create_list_cursor(
         &self,
         request: ManagedListCursorRequest,
@@ -4080,6 +4173,88 @@ impl ManagedRepository for PostgresManagedRepository {
         }
         txn.commit().await.map_err(persistence)?;
         Ok(authority)
+    }
+
+    async fn advance_placement_version(
+        &self,
+        logical: &LogicalObjectKey,
+        expected_cas: u64,
+        placement: &Placement,
+    ) -> Result<ObjectAuthority, ManagedError> {
+        let txn = self.db.begin().await.map_err(persistence)?;
+        require_active_namespace(&txn, &logical.tenant_id).await?;
+        let authority = managed_object_authority::Entity::find_by_id((
+            logical.tenant_id.clone(),
+            logical.bucket.clone(),
+            logical.key.clone(),
+        ))
+        .lock(LockType::Update)
+        .one(&txn)
+        .await
+        .map_err(persistence)?
+        .map(authority_from_model)
+        .transpose()?
+        .ok_or(ManagedError::Conflict)?;
+        let locations_match = authority.primary_backend_id == placement.primary_backend_id
+            && authority.primary_status == CopyStatus::Ready
+            && match placement.replica_backend_id.as_deref() {
+                Some(replica) => {
+                    authority.replica_backend_id.as_deref() == Some(replica)
+                        && authority.replica_status == CopyStatus::Ready
+                }
+                None => {
+                    authority.replica_backend_id.is_none()
+                        && authority.replica_status == CopyStatus::Absent
+                }
+            };
+        if authority.tombstone
+            || authority.cas_version != expected_cas
+            || placement.version <= authority.placement_version
+            || !locations_match
+        {
+            return Err(ManagedError::Conflict);
+        }
+        let now = crate::transaction::unix_time_ms();
+        let result = managed_object_authority::Entity::update_many()
+            .col_expr(
+                managed_object_authority::Column::PlacementVersion,
+                Expr::value(i64::from(placement.version)),
+            )
+            .col_expr(
+                managed_object_authority::Column::CasVersion,
+                Expr::value(i64::try_from(expected_cas.saturating_add(1)).map_err(|_| {
+                    ManagedError::Corrupt("authority CAS exceeds BIGINT".to_string())
+                })?),
+            )
+            .col_expr(
+                managed_object_authority::Column::UpdatedAtMs,
+                Expr::value(now),
+            )
+            .filter(managed_object_authority::Column::TenantId.eq(&logical.tenant_id))
+            .filter(managed_object_authority::Column::Bucket.eq(&logical.bucket))
+            .filter(managed_object_authority::Column::LogicalKey.eq(&logical.key))
+            .filter(
+                managed_object_authority::Column::CasVersion
+                    .eq(i64::try_from(expected_cas).map_err(|_| ManagedError::Conflict)?),
+            )
+            .exec(&txn)
+            .await
+            .map_err(persistence)?;
+        if result.rows_affected != 1 {
+            return Err(ManagedError::Conflict);
+        }
+        let advanced = managed_object_authority::Entity::find_by_id((
+            logical.tenant_id.clone(),
+            logical.bucket.clone(),
+            logical.key.clone(),
+        ))
+        .one(&txn)
+        .await
+        .map_err(persistence)?
+        .ok_or(ManagedError::Conflict)
+        .and_then(authority_from_model)?;
+        txn.commit().await.map_err(persistence)?;
+        Ok(advanced)
     }
 
     async fn tombstone(
@@ -6267,6 +6442,67 @@ impl ManagedRepository for InMemoryManagedRepository {
         })
     }
 
+    async fn list_authority_below_placement_version(
+        &self,
+        query: AuthorityPlacementPageQuery,
+    ) -> Result<AuthorityPlacementPage, ManagedError> {
+        if query.limit > MANAGED_AUTHORITY_LIST_MAX_KEYS || query.target_placement_version == 0 {
+            return Err(ManagedError::Conflict);
+        }
+        if query.limit == 0 {
+            return Ok(AuthorityPlacementPage {
+                objects: Vec::new(),
+                next_after: None,
+            });
+        }
+        let state = self.state.lock().await;
+        let mut objects: Vec<_> = state
+            .authorities
+            .values()
+            .filter(|authority| {
+                !authority.tombstone
+                    && authority.placement_version < query.target_placement_version
+                    && query.after.as_ref().is_none_or(|after| {
+                        (
+                            authority.logical.tenant_id.as_str(),
+                            authority.logical.bucket.as_str(),
+                            authority.logical.key.as_str(),
+                        ) > (
+                            after.tenant_id.as_str(),
+                            after.bucket.as_str(),
+                            after.key.as_str(),
+                        )
+                    })
+            })
+            .cloned()
+            .collect();
+        objects.sort_by(|left, right| {
+            (
+                left.logical.tenant_id.as_str(),
+                left.logical.bucket.as_str(),
+                left.logical.key.as_str(),
+            )
+                .cmp(&(
+                    right.logical.tenant_id.as_str(),
+                    right.logical.bucket.as_str(),
+                    right.logical.key.as_str(),
+                ))
+        });
+        let next_after = (objects.len() as u64 > query.limit).then(|| {
+            let authority = &objects[query.limit as usize - 1];
+            AuthorityPlacementCursor {
+                tenant_id: authority.logical.tenant_id.clone(),
+                bucket: authority.logical.bucket.clone(),
+                key: authority.logical.key.clone(),
+            }
+        });
+        objects.truncate(query.limit as usize);
+        Ok(AuthorityPlacementPage {
+            objects,
+            next_after,
+        })
+    }
+
     async fn create_list_cursor(
         &self,
         request: ManagedListCursorRequest,
@@ -6550,6 +6786,45 @@ impl ManagedRepository for InMemoryManagedRepository {
             }
         }
         Ok(authority)
+    }
+
+    async fn advance_placement_version(
+        &self,
+        logical: &LogicalObjectKey,
+        expected_cas: u64,
+        placement: &Placement,
+    ) -> Result<ObjectAuthority, ManagedError> {
+        let mut state = self.state.lock().await;
+        if state.fenced_namespaces.contains_key(&logical.tenant_id) {
+            return Err(ManagedError::NamespaceFenced);
+        }
+        let authority = state
+            .authorities
+            .get_mut(logical)
+            .ok_or(ManagedError::Conflict)?;
+        let locations_match = authority.primary_backend_id == placement.primary_backend_id
+            && authority.primary_status == CopyStatus::Ready
+            && match placement.replica_backend_id.as_deref() {
+                Some(replica) => {
+                    authority.replica_backend_id.as_deref() == Some(replica)
+                        && authority.replica_status == CopyStatus::Ready
+                }
+                None => {
+                    authority.replica_backend_id.is_none()
+                        && authority.replica_status == CopyStatus::Absent
+                }
+            };
+        if authority.tombstone
+            || authority.cas_version != expected_cas
+            || placement.version <= authority.placement_version
+            || !locations_match
+        {
+            return Err(ManagedError::Conflict);
+        }
+        authority.placement_version = placement.version;
+        authority.cas_version = authority.cas_version.saturating_add(1);
+        authority.updated_at_ms = crate::transaction::unix_time_ms();
+        Ok(authority.clone())
     }
 
     async fn tombstone(
@@ -9045,5 +9320,88 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn global_placement_pages_are_ordered_resumable_and_exclude_tombstones() {
+        let repository = InMemoryManagedRepository::new();
+        for (tenant, bucket, key, version, tombstone) in [
+            ("a", "b", "one", 1, false),
+            ("a", "b", "two", 1, false),
+            ("b", "a", "one", 1, false),
+            ("b", "a", "tombstone", 1, true),
+            ("z", "z", "current", 2, false),
+        ] {
+            let mut object = authority(LogicalObjectKey::new(tenant, bucket, key), Uuid::now_v7());
+            object.placement_version = version;
+            object.tombstone = tombstone;
+            repository.publish(object, None).await.unwrap();
+        }
+        let first = repository
+            .list_authority_below_placement_version(AuthorityPlacementPageQuery {
+                target_placement_version: 2,
+                after: None,
+                limit: 2,
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            first
+                .objects
+                .iter()
+                .map(|object| object.logical.key.as_str())
+                .collect::<Vec<_>>(),
+            ["one", "two"]
+        );
+        let second = repository
+            .list_authority_below_placement_version(AuthorityPlacementPageQuery {
+                target_placement_version: 2,
+                after: first.next_after.clone(),
+                limit: 2,
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            second
+                .objects
+                .iter()
+                .map(|object| object.logical.tenant_id.as_str())
+                .collect::<Vec<_>>(),
+            ["b"]
+        );
+        assert!(second.next_after.is_none());
+    }
+
+    #[tokio::test]
+    async fn placement_advance_requires_current_cas_and_ready_locations() {
+        let repository = InMemoryManagedRepository::new();
+        let logical = LogicalObjectKey::new("tenant", "bucket", "key");
+        let mut object = authority(logical.clone(), Uuid::now_v7());
+        object.replica_status = CopyStatus::Ready;
+        let published = repository.publish(object, None).await.unwrap();
+        let desired = Placement {
+            version: 2,
+            primary_backend_id: "a".to_string(),
+            replica_backend_id: Some("b".to_string()),
+        };
+        let advanced = repository
+            .advance_placement_version(&logical, published.cas_version, &desired)
+            .await
+            .unwrap();
+        assert_eq!(advanced.placement_version, 2);
+        assert!(matches!(
+            repository
+                .advance_placement_version(
+                    &logical,
+                    published.cas_version,
+                    &Placement {
+                        version: 3,
+                        primary_backend_id: "a".to_string(),
+                        replica_backend_id: Some("b".to_string())
+                    }
+                )
+                .await,
+            Err(ManagedError::Conflict)
+        ));
     }
 }

--- a/crates/gateway/src/managed.rs
+++ b/crates/gateway/src/managed.rs
@@ -1204,6 +1204,34 @@ fn publication_repairs(authority: &ObjectAuthority) -> Vec<RepairRecord> {
     }
 }
 
+fn placement_cleanup_repairs(
+    previous: &ObjectAuthority,
+    authority: &ObjectAuthority,
+) -> Vec<RepairRecord> {
+    let mut old_locations = vec![Some(previous.primary_backend_id.clone())];
+    old_locations.push(previous.replica_backend_id.clone());
+    old_locations
+        .into_iter()
+        .flatten()
+        .filter(|backend| {
+            backend != &authority.primary_backend_id
+                && authority.replica_backend_id.as_deref() != Some(backend)
+        })
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .map(|backend| {
+            RepairRecord::copy(
+                RepairKind::DeleteGeneration,
+                authority,
+                None,
+                backend,
+                RepairTargetRole::Cleanup,
+                authority.placement_version,
+            )
+        })
+        .collect()
+}
+
 fn apply_repair_to_authority(
     authority: &mut ObjectAuthority,
     repair: &RepairRecord,
@@ -1658,6 +1686,31 @@ fn repair_active(repair: RepairRecord) -> Result<managed_object_repair::ActiveMo
 
 fn persistence(error: impl std::fmt::Display) -> ManagedError {
     ManagedError::Persistence(error.to_string())
+}
+
+async fn insert_waiting_placement_cleanup<C>(
+    db: &C,
+    repair: RepairRecord,
+) -> Result<(), ManagedError>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let mut active = repair_active(repair)?;
+    active.state = Set("WAITING_CUTOVER".to_string());
+    managed_object_repair::Entity::insert(active)
+        .on_conflict(
+            OnConflict::columns([
+                managed_object_repair::Column::Kind,
+                managed_object_repair::Column::Generation,
+                managed_object_repair::Column::TargetBackendId,
+            ])
+            .do_nothing()
+            .to_owned(),
+        )
+        .exec_without_returning(db)
+        .await
+        .map_err(persistence)?;
+    Ok(())
 }
 
 async fn locked_namespace<C>(
@@ -4503,8 +4556,7 @@ impl ManagedRepository for PostgresManagedRepository {
             if let Some(current) = current {
                 let mut authority = authority_from_model(current.clone())?;
                 if authority.generation == repair.generation
-                    && (repair.kind == RepairKind::Placement
-                        || authority.cas_version == repair.authority_cas_version)
+                    && authority.cas_version == repair.authority_cas_version
                     && !authority.tombstone
                     && apply_repair_to_authority(&mut authority, repair)?
                 {
@@ -4531,6 +4583,49 @@ impl ManagedRepository for PostgresManagedRepository {
                         return Err(ManagedError::Conflict);
                     }
                     authority_updated = true;
+                    if repair.kind == RepairKind::Placement {
+                        for mut cleanup in
+                            placement_cleanup_repairs(&authority_from_model(current)?, &authority)
+                        {
+                            cleanup.namespace_epoch = repair.namespace_epoch;
+                            cleanup.placement_version = repair.placement_version;
+                            insert_waiting_placement_cleanup(&txn, cleanup).await?;
+                        }
+                        if authority.placement_version == repair.placement_version {
+                            managed_object_repair::Entity::update_many()
+                                .col_expr(
+                                    managed_object_repair::Column::State,
+                                    Expr::value("PENDING"),
+                                )
+                                .col_expr(
+                                    managed_object_repair::Column::UpdatedAtMs,
+                                    Expr::value(crate::transaction::unix_time_ms()),
+                                )
+                                .filter(managed_object_repair::Column::State.eq("WAITING_CUTOVER"))
+                                .filter(
+                                    managed_object_repair::Column::TenantId
+                                        .eq(&repair.logical.tenant_id),
+                                )
+                                .filter(
+                                    managed_object_repair::Column::Bucket
+                                        .eq(&repair.logical.bucket),
+                                )
+                                .filter(
+                                    managed_object_repair::Column::LogicalKey
+                                        .eq(&repair.logical.key),
+                                )
+                                .filter(
+                                    managed_object_repair::Column::Generation.eq(repair.generation),
+                                )
+                                .filter(
+                                    managed_object_repair::Column::PlacementVersion
+                                        .eq(i64::from(repair.placement_version)),
+                                )
+                                .exec(&txn)
+                                .await
+                                .map_err(persistence)?;
+                        }
+                    }
                 }
             }
         }
@@ -5680,6 +5775,19 @@ fn insert_memory_repair(state: &mut MemoryState, repair: RepairRecord) {
         state
             .repairs
             .insert(repair.repair_id, (repair, "PENDING".to_string()));
+    }
+}
+
+fn insert_memory_waiting_placement_cleanup(state: &mut MemoryState, repair: RepairRecord) {
+    let duplicate = state.repairs.values().any(|(existing, _)| {
+        existing.kind == repair.kind
+            && existing.generation == repair.generation
+            && existing.target_backend_id == repair.target_backend_id
+    });
+    if !duplicate {
+        state
+            .repairs
+            .insert(repair.repair_id, (repair, "WAITING_CUTOVER".to_string()));
     }
 }
 
@@ -7005,17 +7113,40 @@ impl ManagedRepository for InMemoryManagedRepository {
             stored.updated_at_ms = now;
         }
         let mut updated = false;
+        let mut cleanups = Vec::new();
+        let mut activate_cleanup = false;
         if repair.kind != RepairKind::DeleteGeneration
             && let Some(authority) = state.authorities.get_mut(&repair.logical)
             && authority.generation == repair.generation
-            && (repair.kind == RepairKind::Placement
-                || authority.cas_version == repair.authority_cas_version)
+            && authority.cas_version == repair.authority_cas_version
             && !authority.tombstone
-            && apply_repair_to_authority(authority, repair)?
         {
-            authority.cas_version = authority.cas_version.saturating_add(1);
-            authority.updated_at_ms = crate::transaction::unix_time_ms();
-            updated = true;
+            let previous = authority.clone();
+            if apply_repair_to_authority(authority, repair)? {
+                authority.cas_version = authority.cas_version.saturating_add(1);
+                authority.updated_at_ms = crate::transaction::unix_time_ms();
+                updated = true;
+                if repair.kind == RepairKind::Placement {
+                    cleanups = placement_cleanup_repairs(&previous, authority);
+                    activate_cleanup = authority.placement_version == repair.placement_version;
+                }
+            }
+        }
+        for mut cleanup in cleanups {
+            cleanup.namespace_epoch = repair.namespace_epoch;
+            cleanup.placement_version = repair.placement_version;
+            insert_memory_waiting_placement_cleanup(&mut state, cleanup);
+        }
+        if activate_cleanup {
+            for (cleanup, status) in state.repairs.values_mut() {
+                if *status == "WAITING_CUTOVER"
+                    && cleanup.logical == repair.logical
+                    && cleanup.generation == repair.generation
+                    && cleanup.placement_version == repair.placement_version
+                {
+                    *status = "PENDING".to_string();
+                }
+            }
         }
         Ok(updated)
     }
@@ -9201,15 +9332,49 @@ mod tests {
         assert_eq!(partial.replica_backend_id.as_deref(), Some("b"));
         assert_eq!(partial.placement_version, initial.placement_version);
 
-        repository.complete_repair(&replica).await.unwrap();
+        assert!(
+            !repository.complete_repair(&replica).await.unwrap(),
+            "a leg leased before another leg's CAS update must not mutate authority"
+        );
+        repository
+            .enqueue(RepairRecord::placement(
+                &partial,
+                Some("c".to_string()),
+                "d".to_string(),
+                RepairTargetRole::Replica,
+                &placement,
+            ))
+            .await
+            .unwrap();
+        let retry = repository
+            .claim_repairs(
+                "placement-worker",
+                crate::transaction::unix_time_ms() + 30_000,
+                1,
+            )
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+        assert!(repository.complete_repair(&retry).await.unwrap());
         let converged = repository.get(&logical).await.unwrap().unwrap();
         assert_eq!(converged.primary_backend_id, "c");
         assert_eq!(converged.replica_backend_id.as_deref(), Some("d"));
         assert_eq!(converged.placement_version, placement.version);
+        let cleanup = repository
+            .claim_repairs("cleanup", crate::transaction::unix_time_ms() + 30_000, 10)
+            .await
+            .unwrap();
+        assert_eq!(cleanup.len(), 2);
+        assert!(cleanup.iter().all(|repair| {
+            repair.kind == RepairKind::DeleteGeneration
+                && repair.target_role == RepairTargetRole::Cleanup
+                && matches!(repair.target_backend_id.as_str(), "a" | "b")
+        }));
     }
 
     #[tokio::test]
-    async fn concurrent_placement_repair_completions_converge() {
+    async fn concurrent_placement_repair_completions_fence_stale_legs() {
         let repository = InMemoryManagedRepository::new();
         let logical = LogicalObjectKey::new("tenant", "bucket", "placement-race");
         let mut initial = authority(logical.clone(), Uuid::now_v7());
@@ -9247,8 +9412,34 @@ mod tests {
             repository.complete_repair(&repairs[0]),
             repository.complete_repair(&repairs[1]),
         );
-        left.unwrap();
-        right.unwrap();
+        assert_ne!(left.unwrap(), right.unwrap());
+        let partial = repository.get(&logical).await.unwrap().unwrap();
+        let (target_backend_id, target_role) = if partial.primary_backend_id == "c" {
+            ("d".to_string(), RepairTargetRole::Replica)
+        } else {
+            ("c".to_string(), RepairTargetRole::Primary)
+        };
+        repository
+            .enqueue(RepairRecord::placement(
+                &partial,
+                Some(partial.primary_backend_id.clone()),
+                target_backend_id,
+                target_role,
+                &placement,
+            ))
+            .await
+            .unwrap();
+        let retry = repository
+            .claim_repairs(
+                "placement-retry",
+                crate::transaction::unix_time_ms() + 30_000,
+                1,
+            )
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+        assert!(repository.complete_repair(&retry).await.unwrap());
         let converged = repository.get(&logical).await.unwrap().unwrap();
         assert_eq!(converged.primary_backend_id, "c");
         assert_eq!(converged.replica_backend_id.as_deref(), Some("d"));

--- a/crates/gateway/src/service_storage.rs
+++ b/crates/gateway/src/service_storage.rs
@@ -1915,6 +1915,19 @@ impl ServiceStorage {
         let repository = self
             .authority_repository_required()
             .map_err(|error| error.to_string())?;
+        if let Some(authority) = repository
+            .get(&repair.logical)
+            .await
+            .map_err(|error| error.to_string())?
+            && !authority.tombstone
+            && authority.generation == repair.generation
+            && (authority.primary_backend_id == repair.target_backend_id
+                || authority.replica_backend_id.as_deref() == Some(&repair.target_backend_id))
+        {
+            return Err(
+                "cleanup target is currently authoritative for this generation".to_string(),
+            );
+        }
         let versions = repository
             .physical_versions(
                 &repair.logical.tenant_id,

--- a/crates/gateway/src/service_storage.rs
+++ b/crates/gateway/src/service_storage.rs
@@ -10,13 +10,14 @@ use tracing::{info, warn};
 
 use crate::control::{RequestKind, UsageEvent, UsageRoute};
 use crate::managed::{
-    AuthorityListPage, AuthorityListQuery, BackendVersioningCapability, BackendVersioningMode,
-    CopyStatus, DurablePhysicalWriteIntent, LogicalObjectKey, ManagedError,
-    ManagedLogicalOperationIntent, ManagedLogicalOperationState, ManagedMutationKind,
-    ManagedRepository, ManagedStreamingMode, ManagedUsageEvidence, NamespacePurgeRequest,
-    NamespacePurgeStatus, ObjectAuthority, PLACEMENT_VERSION_V1, PhysicalVersionTarget,
-    PhysicalWriteIntent, Placement, ProviderStorageIdentity, RepairKind, RepairRecord,
-    RepairTargetRole, generation_physical_key, weighted_rendezvous_placement,
+    AuthorityListPage, AuthorityListQuery, AuthorityPlacementCursor, AuthorityPlacementPage,
+    AuthorityPlacementPageQuery, BackendVersioningCapability, BackendVersioningMode, CopyStatus,
+    DurablePhysicalWriteIntent, LogicalObjectKey, ManagedError, ManagedLogicalOperationIntent,
+    ManagedLogicalOperationState, ManagedMutationKind, ManagedRepository, ManagedStreamingMode,
+    ManagedUsageEvidence, NamespacePurgeRequest, NamespacePurgeStatus, ObjectAuthority,
+    PLACEMENT_VERSION_V1, PhysicalVersionTarget, PhysicalWriteIntent, Placement,
+    ProviderStorageIdentity, RepairKind, RepairRecord, RepairTargetRole, generation_physical_key,
+    weighted_rendezvous_placement,
 };
 use crate::s3_safety::{
     record_s3_body_failure, record_s3_failure, s3_retry_config, s3_timeout_config,
@@ -225,6 +226,109 @@ impl ServiceStorage {
         self.authority_repository_required()?
             .list_authority(query)
             .await
+    }
+
+    /// Reconciles one stale authority to a desired placement. A ready authority
+    /// that already occupies every desired location advances by CAS without a
+    /// provider copy; otherwise only the missing placement repair legs are
+    /// enqueued from an already verified ready authority location.
+    pub async fn reconcile_authority_placement(
+        &self,
+        authority: &ObjectAuthority,
+        desired: &Placement,
+    ) -> Result<(), ManagedError> {
+        if authority.tombstone || authority.placement_version >= desired.version {
+            return Ok(());
+        }
+        let repository = self.authority_repository_required()?;
+        let locations_match = authority.primary_backend_id == desired.primary_backend_id
+            && authority.primary_status == CopyStatus::Ready
+            && match desired.replica_backend_id.as_deref() {
+                Some(replica) => {
+                    authority.replica_backend_id.as_deref() == Some(replica)
+                        && authority.replica_status == CopyStatus::Ready
+                }
+                None => {
+                    authority.replica_backend_id.is_none()
+                        && authority.replica_status == CopyStatus::Absent
+                }
+            };
+        if locations_match {
+            repository
+                .advance_placement_version(&authority.logical, authority.cas_version, desired)
+                .await?;
+            return Ok(());
+        }
+
+        let source = if authority.primary_status == CopyStatus::Ready {
+            Some(authority.primary_backend_id.clone())
+        } else if authority.replica_status == CopyStatus::Ready {
+            authority.replica_backend_id.clone()
+        } else {
+            None
+        }
+        .ok_or_else(|| {
+            ManagedError::Persistence(
+                "stale authority has no verified ready source for placement repair".to_string(),
+            )
+        })?;
+
+        let primary_matches = authority.primary_backend_id == desired.primary_backend_id
+            && authority.primary_status == CopyStatus::Ready;
+        // A primary leg is also the durable way to remove an obsolete replica.
+        if !primary_matches
+            || (desired.replica_backend_id.is_none() && authority.replica_backend_id.is_some())
+        {
+            repository
+                .enqueue(RepairRecord::placement(
+                    authority,
+                    Some(source.clone()),
+                    desired.primary_backend_id.clone(),
+                    RepairTargetRole::Primary,
+                    desired,
+                ))
+                .await?;
+        }
+        if let Some(replica) = &desired.replica_backend_id
+            && (authority.replica_backend_id.as_deref() != Some(replica)
+                || authority.replica_status != CopyStatus::Ready)
+        {
+            repository
+                .enqueue(RepairRecord::placement(
+                    authority,
+                    Some(source),
+                    replica.clone(),
+                    RepairTargetRole::Replica,
+                    desired,
+                ))
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Processes one bounded global page of authorities behind this storage's
+    /// placement version. The returned cursor can resume the same keyset scan.
+    pub async fn reconcile_authority_placement_page(
+        &self,
+        after: Option<AuthorityPlacementCursor>,
+        limit: u64,
+    ) -> Result<AuthorityPlacementPage, ManagedError> {
+        let repository = self.authority_repository_required()?;
+        let page = repository
+            .list_authority_below_placement_version(AuthorityPlacementPageQuery {
+                target_placement_version: self.placement_version,
+                after,
+                limit,
+            })
+            .await?;
+        for authority in &page.objects {
+            let desired = self.placement(&authority.logical).ok_or_else(|| {
+                ManagedError::Persistence("managed storage has no backends".to_string())
+            })?;
+            self.reconcile_authority_placement(authority, &desired)
+                .await?;
+        }
+        Ok(page)
     }
 
     /// Validate the launch topology before enabling transactional managed
@@ -3690,5 +3794,90 @@ mod tests {
             error.to_string().contains("mutation"),
             "unexpected admission error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn placement_reconciliation_advances_without_copy_and_deduplicates_repairs() {
+        let repository = Arc::new(InMemoryManagedRepository::new());
+        let storage = ServiceStorage::with_management(
+            parse_service_backends(
+                "b2|one|account-1|1|https://s3.example|us-east-1|bucket-one|key|secret;b2|two|account-2|1|https://s3.example|us-east-1|bucket-two|key|secret",
+            ).unwrap(),
+            repository.clone(),
+            ManagedStreamingMode::Enforce,
+            2,
+        );
+        let logical = LogicalObjectKey::new("tenant-placement", "bucket", "ready");
+        let desired = storage.placement(&logical).unwrap();
+        let ready = ObjectAuthority {
+            logical: logical.clone(),
+            generation: uuid::Uuid::now_v7(),
+            digest: "digest".to_string(),
+            size: 3,
+            metadata: BTreeMap::new(),
+            placement_version: 1,
+            primary_backend_id: desired.primary_backend_id.clone(),
+            primary_version_id: None,
+            replica_backend_id: desired.replica_backend_id.clone(),
+            primary_status: CopyStatus::Ready,
+            replica_status: if desired.replica_backend_id.is_some() {
+                CopyStatus::Ready
+            } else {
+                CopyStatus::Absent
+            },
+            tombstone: false,
+            cas_version: 0,
+            created_at_ms: 0,
+            updated_at_ms: 0,
+        };
+        let ready = repository.publish(ready, None).await.unwrap();
+        storage
+            .reconcile_authority_placement(&ready, &desired)
+            .await
+            .unwrap();
+        assert_eq!(
+            repository
+                .get(&logical)
+                .await
+                .unwrap()
+                .unwrap()
+                .placement_version,
+            2
+        );
+        assert!(
+            repository
+                .claim_repairs("no-copy", crate::transaction::unix_time_ms() + 1_000, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        let stale = LogicalObjectKey::new("tenant-placement", "bucket", "stale");
+        let mut stale_authority = repository.get(&logical).await.unwrap().unwrap();
+        stale_authority.logical = stale.clone();
+        stale_authority.generation = uuid::Uuid::now_v7();
+        stale_authority.placement_version = 1;
+        stale_authority.primary_backend_id = "old".to_string();
+        stale_authority.replica_backend_id = None;
+        stale_authority.primary_status = CopyStatus::Ready;
+        stale_authority.replica_status = CopyStatus::Absent;
+        let stale_authority = repository.publish(stale_authority, None).await.unwrap();
+        storage
+            .reconcile_authority_placement(&stale_authority, &storage.placement(&stale).unwrap())
+            .await
+            .unwrap();
+        storage
+            .reconcile_authority_placement(&stale_authority, &storage.placement(&stale).unwrap())
+            .await
+            .unwrap();
+        let repairs = repository
+            .claim_repairs(
+                "deduplicated",
+                crate::transaction::unix_time_ms() + 1_000,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(repairs.len(), 2, "one leg per desired primary and replica");
     }
 }

--- a/crates/gateway/tests/db_keys_test.rs
+++ b/crates/gateway/tests/db_keys_test.rs
@@ -1371,8 +1371,6 @@ fn postgres_managed_authority_publish_repair_lease_and_tombstone_are_atomic() {
             .await
             .unwrap()
             .len();
-        assert_eq!(cleanup_count, 4);
-
         managed_object_repair::Entity::delete_many()
             .filter(managed_object_repair::Column::TenantId.eq(&tenant))
             .exec(&db)
@@ -1392,6 +1390,10 @@ fn postgres_managed_authority_publish_repair_lease_and_tombstone_are_atomic() {
             .exec(&db)
             .await
             .unwrap();
+
+        // Cleanup precedes the assertion so a future expectation mismatch
+        // cannot contaminate later tests sharing this database.
+        assert_eq!(cleanup_count, 5);
     });
 }
 

--- a/crates/gateway/tests/db_keys_test.rs
+++ b/crates/gateway/tests/db_keys_test.rs
@@ -22,13 +22,14 @@ use s4_gateway::entity::multipart_upload;
 use s4_gateway::entity::object_operation;
 use s4_gateway::key_cipher::{KeyWrapping, LocalKeyWrapping, SecretCipher};
 use s4_gateway::managed::{
-    AuthorityListQuery, BackendVersioningCapability, BackendVersioningMode, CopyStatus,
-    InMemoryManagedRepository, LogicalObjectKey, MANAGED_LIST_CURSOR_RESPONSE_MAX_BYTES,
-    MANAGED_LIST_CURSOR_WORKSPACE_LIMIT, ManagedListCursorBinding, ManagedListCursorPosition,
-    ManagedListCursorRequest, ManagedListCursorState, ManagedListVersion,
-    ManagedLogicalOperationIntent, ManagedLogicalOperationState, ManagedMutationKind,
-    ManagedProvenPhysicalAllocation, ManagedRepository, ManagedRouteFence, ManagedUsageEvidence,
-    NamespacePurgeRequest, NamespacePurgeStatus, ObjectAuthority, PhysicalWriteIntent, Placement,
+    AuthorityListQuery, AuthorityPlacementPageQuery, BackendVersioningCapability,
+    BackendVersioningMode, CopyStatus, InMemoryManagedRepository, LogicalObjectKey,
+    MANAGED_LIST_CURSOR_RESPONSE_MAX_BYTES, MANAGED_LIST_CURSOR_WORKSPACE_LIMIT,
+    ManagedListCursorBinding, ManagedListCursorPosition, ManagedListCursorRequest,
+    ManagedListCursorState, ManagedListVersion, ManagedLogicalOperationIntent,
+    ManagedLogicalOperationState, ManagedMutationKind, ManagedProvenPhysicalAllocation,
+    ManagedRepository, ManagedRouteFence, ManagedUsageEvidence, NamespacePurgeRequest,
+    NamespacePurgeStatus, ObjectAuthority, PhysicalWriteIntent, Placement,
     PostgresManagedRepository, ProviderStorageIdentity, generation_physical_key,
 };
 use s4_gateway::multipart_staging::{
@@ -1008,6 +1009,66 @@ fn postgres_multipart_completion_cas_replay_and_fencing_are_durable() {
             .exec(&db)
             .await
             .expect("delete multipart completion test rows");
+    });
+}
+
+#[test]
+fn postgres_global_authority_placement_page_has_stable_boundaries() {
+    with_pool(|pool| async move {
+        let repository = PostgresManagedRepository::new(pool);
+        let tenant = format!("managed-placement-page-{}", uuid::Uuid::new_v4());
+        for key in ["a", "b", "c"] {
+            let logical = LogicalObjectKey::new(&tenant, "bucket", key);
+            let generation = uuid::Uuid::now_v7();
+            let version = ledger_managed_test_version(
+                &repository,
+                &tenant,
+                "primary",
+                &generation_physical_key(&logical, generation),
+            )
+            .await;
+            repository
+                .publish(
+                    ObjectAuthority {
+                        logical,
+                        generation,
+                        digest: "digest".to_string(),
+                        size: 3,
+                        metadata: std::collections::BTreeMap::new(),
+                        placement_version: 1,
+                        primary_backend_id: "primary".to_string(),
+                        primary_version_id: Some(version),
+                        replica_backend_id: None,
+                        primary_status: CopyStatus::Ready,
+                        replica_status: CopyStatus::Absent,
+                        tombstone: false,
+                        cas_version: 0,
+                        created_at_ms: 0,
+                        updated_at_ms: 0,
+                    },
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+        let first = repository
+            .list_authority_below_placement_version(AuthorityPlacementPageQuery {
+                target_placement_version: 2,
+                after: None,
+                limit: 2,
+            })
+            .await
+            .unwrap();
+        assert_eq!(first.objects.len(), 2);
+        let second = repository
+            .list_authority_below_placement_version(AuthorityPlacementPageQuery {
+                target_placement_version: 2,
+                after: first.next_after,
+                limit: 2,
+            })
+            .await
+            .unwrap();
+        assert_eq!(second.objects.len(), 1);
     });
 }
 

--- a/crates/gateway/tests/db_keys_test.rs
+++ b/crates/gateway/tests/db_keys_test.rs
@@ -1286,8 +1286,16 @@ fn postgres_managed_authority_publish_repair_lease_and_tombstone_are_atomic() {
             .claim_repairs("process-placement-race", unix_time_ms() + 30_000, 10)
             .await
             .unwrap();
-        assert_eq!(migration_repairs.len(), 2);
-        for repair in &migration_repairs {
+        // A prior completed placement may have released cleanup work as well;
+        // only its two placement legs participate in this cutover race.
+        let (placement_repairs, cleanup_repairs): (Vec<_>, Vec<_>) = migration_repairs
+            .into_iter()
+            .partition(|repair| repair.kind == s4_gateway::managed::RepairKind::Placement);
+        assert_eq!(placement_repairs.len(), 2);
+        for repair in cleanup_repairs {
+            assert!(!repository.complete_repair(&repair).await.unwrap());
+        }
+        for repair in &placement_repairs {
             let _ = ledger_managed_test_version(
                 &repository,
                 &tenant,
@@ -1297,8 +1305,8 @@ fn postgres_managed_authority_publish_repair_lease_and_tombstone_are_atomic() {
             .await;
         }
         let (left, right) = tokio::join!(
-            repository.complete_repair(&migration_repairs[0]),
-            repository.complete_repair(&migration_repairs[1]),
+            repository.complete_repair(&placement_repairs[0]),
+            repository.complete_repair(&placement_repairs[1]),
         );
         assert_ne!(left.unwrap(), right.unwrap());
         let partial = repository.get(&logical).await.unwrap().unwrap();
@@ -1363,7 +1371,7 @@ fn postgres_managed_authority_publish_repair_lease_and_tombstone_are_atomic() {
             .await
             .unwrap()
             .len();
-        assert_eq!(cleanup_count, 2);
+        assert_eq!(cleanup_count, 4);
 
         managed_object_repair::Entity::delete_many()
             .filter(managed_object_repair::Column::TenantId.eq(&tenant))

--- a/crates/gateway/tests/db_keys_test.rs
+++ b/crates/gateway/tests/db_keys_test.rs
@@ -1015,6 +1015,7 @@ fn postgres_multipart_completion_cas_replay_and_fencing_are_durable() {
 #[test]
 fn postgres_global_authority_placement_page_has_stable_boundaries() {
     with_pool(|pool| async move {
+        let db = sea_db(pool.clone());
         let repository = PostgresManagedRepository::new(pool);
         let tenant = format!("managed-placement-page-{}", uuid::Uuid::new_v4());
         for key in ["a", "b", "c"] {
@@ -1069,6 +1070,23 @@ fn postgres_global_authority_placement_page_has_stable_boundaries() {
             .await
             .unwrap();
         assert_eq!(second.objects.len(), 1);
+
+        // This global-page test must not leave stale placement candidates for
+        // later router tests sharing the same Postgres database.
+        managed_object_authority::Entity::delete_many()
+            .filter(managed_object_authority::Column::TenantId.eq(&tenant))
+            .exec(&db)
+            .await
+            .unwrap();
+        managed_physical_object_version::Entity::delete_many()
+            .filter(managed_physical_object_version::Column::TenantId.eq(&tenant))
+            .exec(&db)
+            .await
+            .unwrap();
+        managed_namespace::Entity::delete_by_id(&tenant)
+            .exec(&db)
+            .await
+            .unwrap();
     });
 }
 
@@ -1282,8 +1300,36 @@ fn postgres_managed_authority_publish_repair_lease_and_tombstone_are_atomic() {
             repository.complete_repair(&migration_repairs[0]),
             repository.complete_repair(&migration_repairs[1]),
         );
-        left.unwrap();
-        right.unwrap();
+        assert_ne!(left.unwrap(), right.unwrap());
+        let partial = repository.get(&logical).await.unwrap().unwrap();
+        let (target_backend_id, target_role) = if partial.primary_backend_id == "primary-v3" {
+            (
+                "replica-v3".to_string(),
+                s4_gateway::managed::RepairTargetRole::Replica,
+            )
+        } else {
+            (
+                "primary-v3".to_string(),
+                s4_gateway::managed::RepairTargetRole::Primary,
+            )
+        };
+        repository
+            .enqueue(s4_gateway::managed::RepairRecord::placement(
+                &partial,
+                Some(partial.primary_backend_id.clone()),
+                target_backend_id,
+                target_role,
+                &full_placement,
+            ))
+            .await
+            .unwrap();
+        let retry = repository
+            .claim_repairs("process-placement-retry", unix_time_ms() + 30_000, 1)
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+        assert!(repository.complete_repair(&retry).await.unwrap());
         let converged = repository.get(&logical).await.unwrap().unwrap();
         assert_eq!(converged.primary_backend_id, "primary-v3");
         assert_eq!(converged.replica_backend_id.as_deref(), Some("replica-v3"));

--- a/migrations/20260904000001_managed_authority_placement_page.sql
+++ b/migrations/20260904000001_managed_authority_placement_page.sql
@@ -1,0 +1,4 @@
+-- Global, keyset-paginated placement reconciliation scans only live authorities.
+create index if not exists managed_object_authorities_placement_page_idx
+    on managed_object_authorities (tenant_id, bucket, logical_key, placement_version)
+    where tombstone = false;

--- a/migrations/20260904000002_managed_placement_cutover_wait.sql
+++ b/migrations/20260904000002_managed_placement_cutover_wait.sql
@@ -1,0 +1,6 @@
+-- Placement cleanup is persisted but cannot be claimed until authority CAS has
+-- durably installed every required destination.
+alter table managed_object_repairs
+    drop constraint if exists managed_object_repairs_state_check,
+    add constraint managed_object_repairs_state_check
+        check (state in ('PENDING', 'WAITING_CUTOVER', 'LEASED', 'DONE'));


### PR DESCRIPTION
## Summary
- page non-tombstoned authorities below a target placement version deterministically
- advance no-copy placement versions by authority CAS
- enqueue idempotent durable placement repairs when destinations differ

## Test plan
- focused managed placement page, CAS, repair enqueue, and Postgres boundary tests