### PR TITLE
fix(gateway): record managed multipart usage before commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "card-detect"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "email-detect"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-encrypt"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "maskura-customer-config"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "thiserror 2.0.20",
 ]
@@ -3231,7 +3231,7 @@ dependencies = [
 
 [[package]]
 name = "noop"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "pii-default"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "pii-shared"
-version = "0.3.5"
+version = "0.3.6"
 
 [[package]]
 name = "pin-project-lite"
@@ -4470,14 +4470,14 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s4-error"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "s4-gateway"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aes-gcm",
  "aes-siv",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "s4-mcp"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -4565,7 +4565,7 @@ dependencies = [
 
 [[package]]
 name = "s4-policy"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ciborium",
  "ed25519-dalek",
@@ -4578,7 +4578,7 @@ dependencies = [
 
 [[package]]
 name = "s4-wasm-runtime"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "hex",
@@ -4593,7 +4593,7 @@ dependencies = [
 
 [[package]]
 name = "s4ctl"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -5295,7 +5295,7 @@ dependencies = [
 
 [[package]]
 name = "ssn-detect"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -5303,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "stable-encrypt"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aes-siv",
  "base64 0.22.1",
@@ -5483,21 +5483,21 @@ dependencies = [
 
 [[package]]
 name = "test-binary-reductor"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]
 
 [[package]]
 name = "test-filter"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]
 
 [[package]]
 name = "test-filter-v02"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/231self/S4"

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -4668,14 +4668,16 @@ async fn complete_staged_multipart(
             size_bytes: output_bytes,
             pipeline_evidence: pipeline_evidence.clone(),
         };
+        let usage_event = multipart_completion_event(operation.grant, &precommit_result);
         persist_transaction_usage_evidence(
             state.operation_journal.as_ref(),
             sink.durable_operation_id(),
-            &multipart_completion_event(operation.grant, &precommit_result),
+            &usage_event,
         )
         .await
         .map_err(TransactionError::from)
         .map_err(StreamingPutError::from)?;
+        sink.record_usage_evidence(&usage_event).await?;
         renew_and_fence_completion(staging, identity, lease).await?;
         let stored = sink.complete().await?;
         let result = MultipartCompletionResult {
@@ -5286,14 +5288,16 @@ async fn complete_staged_avro_multipart(
             size_bytes: output_bytes,
             pipeline_evidence: None,
         };
+        let usage_event = multipart_completion_event(operation.grant, &precommit_result);
         persist_transaction_usage_evidence(
             state.operation_journal.as_ref(),
             sink.durable_operation_id(),
-            &multipart_completion_event(operation.grant, &precommit_result),
+            &usage_event,
         )
         .await
         .map_err(TransactionError::from)
         .map_err(StreamingPutError::from)?;
+        sink.record_usage_evidence(&usage_event).await?;
         renew_and_fence_completion(staging, identity, lease).await?;
         let stored = sink.complete().await?;
         let result = MultipartCompletionResult {


### PR DESCRIPTION
## Summary
- record managed logical usage after durable journal evidence and before staged multipart commit
- apply the same ordering to Avro staged multipart completion
- bump the workspace patch version to 0.3.6

## Root cause
ManagedLogicalSink requires record_usage_evidence before complete. The staged multipart paths persisted only journal evidence, so managed completion failed internally after part validation.

## Verification
- cargo fmt --check
- cargo test -p s4-gateway --lib server::tests::multipart_success_and_exact_replay_meter_with_one_stable_identity
- cargo test --locked -p s4-gateway --lib (347 passed; 27 fixture-only failures because generated test Wasm components are absent; run just build-filters)