### PR TITLE
test(e2e): split local e2e into discrete feature scripts + s4→maskura renames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,16 +114,16 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: s4
+          POSTGRES_DB: maskura
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U postgres -d s4"
+          --health-cmd "pg_isready -U postgres -d maskura"
           --health-interval 2s
           --health-timeout 5s
           --health-retries 15
     env:
-      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/s4
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/maskura
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -158,7 +158,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Unmodified-client interop (AWS CLI + boto3)
         env:
-          S4_RUN_EXTERNAL_CLIENT_INTEROP: "1"
+          MASKURA_RUN_EXTERNAL_CLIENT_INTEROP: "1"
         run: cargo test --locked -p s4-gateway --test s3_frontdoor_test available_aws_cli_and_boto3_interoperate
 
   # Aggregate status so branch protection's required `check` keeps working

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,7 +69,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Unmodified-client interop (AWS CLI + boto3)
         env:
-          S4_RUN_EXTERNAL_CLIENT_INTEROP: "1"
+          MASKURA_RUN_EXTERNAL_CLIENT_INTEROP: "1"
         run: cargo test --locked -p s4-gateway --test s3_frontdoor_test available_aws_cli_and_boto3_interoperate
 
   e2e:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build Wasm filters
         run: bash scripts/build-filters.sh
       - name: Soak streaming round-trips (500 iterations)
-        run: S4_SOAK_ITERATIONS=500 cargo test --locked -p s4-gateway --test s3_frontdoor_test soak_streaming_roundtrip_holds_under_repetition -- --ignored --nocapture
+        run: MASKURA_SOAK_ITERATIONS=500 cargo test --locked -p s4-gateway --test s3_frontdoor_test soak_streaming_roundtrip_holds_under_repetition -- --ignored --nocapture
 
   property:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thanks for considering a contribution to Maskura.
 - Rust 2024 edition. No warnings allowed: production code builds with
   `RUSTFLAGS=-D warnings`.
 - Every functional change ships with tests. Maskura favors unit tests in the crate plus
-  end-to-end coverage (`just e2e`).
+  end-to-end coverage (`just e2e`, broken down feature-by-feature in `docs/e2e.md`).
 - No raw SQL strings inline; use `sqlx` (runtime-checked queries) and migrations in
   `migrations/`. Never apply schema changes by hand.
 - Keep the Wasm filter boundary clean: plugins are pure byte-in/byte-out, no host

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ just dev-up
 maskura put ./data.csv ingest/data.csv --bucket s4-local
 
 # End-to-end validation:
-just e2e
+just e2e                # see docs/e2e.md for the feature-by-feature breakdown
 ```
 
 **Agent-safe reads — raw at rest, scrubbed on the way out**

--- a/crates/gateway/src/avro.rs
+++ b/crates/gateway/src/avro.rs
@@ -288,7 +288,7 @@ fn schema_node_to_json(node: &SchemaNode, records: &mut u32) -> Result<JsonValue
             json!({"type":"map","values":schema_node_to_json(values, records)?})
         }
         SchemaKind::Record { fields } => {
-            let name = format!("s4_record_{records}");
+            let name = format!("maskura_record_{records}");
             *records = records.saturating_add(1);
             let fields = fields
                 .iter()

--- a/crates/gateway/src/backend.rs
+++ b/crates/gateway/src/backend.rs
@@ -256,7 +256,7 @@ impl BackendResolver {
 
         // The request-level shortcut is a single-tenant development feature.
         // Hosted routing must consult persisted workspace state first so a BYO
-        // workspace cannot be redirected into S4-managed storage by a header.
+        // workspace cannot be redirected into Maskura-managed storage by a header.
         if self.explicit_single_tenant && managed_requested {
             if self.managed.is_empty() {
                 return Err("managed storage is not configured (no S4_SERVICE_BUCKETS)".to_string());
@@ -319,7 +319,7 @@ impl BackendResolver {
                     resolution.routing,
                 );
                 let credentials =
-                    Credentials::new(access_key, secret_key, None, None, "s4-backend");
+                    Credentials::new(access_key, secret_key, None, None, "maskura-backend");
                 // Tenant-selected destinations must never inherit process proxy
                 // settings. DNS is intentionally resolved again by the SDK: in
                 // multi-tenant mode the hostname belongs to an operator-trusted
@@ -419,7 +419,7 @@ impl BackendResolver {
         let workspace_streaming =
             workspace_streaming_binding(&endpoint, Some(identity), resolution.routing)
                 .ok_or_else(|| "historical workspace storage attestation is invalid".to_string())?;
-        let credentials = Credentials::new(access_key, secret_key, None, None, "s4-recovery");
+        let credentials = Credentials::new(access_key, secret_key, None, None, "maskura-recovery");
         let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
             .region(Region::new(region))
             .endpoint_url(endpoint.as_str())
@@ -2035,7 +2035,7 @@ mod tests {
 
     #[test]
     fn byo_s3_custom_endpoint_uses_path_style_and_ignores_environment_proxies() {
-        const CHILD_ENV: &str = "S4_TEST_WORKSPACE_S3_NO_PROXY_CHILD";
+        const CHILD_ENV: &str = "MASKURA_TEST_WORKSPACE_S3_NO_PROXY_CHILD";
         const TEST_NAME: &str = "backend::tests::byo_s3_custom_endpoint_uses_path_style_and_ignores_environment_proxies";
         if std::env::var_os(CHILD_ENV).is_none() {
             let poison_proxy = "http://127.0.0.1:1";

--- a/crates/gateway/src/managed.rs
+++ b/crates/gateway/src/managed.rs
@@ -9071,7 +9071,7 @@ mod tests {
 
     #[test]
     fn placement_process_helper() {
-        if std::env::var_os("S4_PLACEMENT_PROCESS_HELPER").is_some() {
+        if std::env::var_os("MASKURA_PLACEMENT_PROCESS_HELPER").is_some() {
             let placement = rendezvous_placement(
                 1,
                 "tenant-a",
@@ -9082,7 +9082,7 @@ mod tests {
             )
             .unwrap();
             println!(
-                "S4_PLACEMENT={}:{}",
+                "MASKURA_PLACEMENT={}:{}",
                 placement.primary_backend_id,
                 placement.replica_backend_id.unwrap()
             );
@@ -9097,13 +9097,13 @@ mod tests {
                 "managed::tests::placement_process_helper",
                 "--nocapture",
             ])
-            .env("S4_PLACEMENT_PROCESS_HELPER", "1")
+            .env("MASKURA_PLACEMENT_PROCESS_HELPER", "1")
             .output()
             .unwrap();
         assert!(output.status.success());
         assert!(
             String::from_utf8_lossy(&output.stdout)
-                .contains("S4_PLACEMENT=s3:bucket-b:b2:bucket-a")
+                .contains("MASKURA_PLACEMENT=s3:bucket-b:b2:bucket-a")
         );
     }
 

--- a/crates/gateway/src/multipart_staging.rs
+++ b/crates/gateway/src/multipart_staging.rs
@@ -2956,7 +2956,7 @@ mod tests {
 
     #[tokio::test]
     async fn ciphertext_does_not_contain_plaintext_and_aad_is_identity_bound() {
-        let directory = std::env::temp_dir().join(format!("s4-stage-test-{}", Uuid::now_v7()));
+        let directory = std::env::temp_dir().join(format!("maskura-stage-test-{}", Uuid::now_v7()));
         let wrapping = Arc::new(LocalKeyWrapping::with_kek([7; 32]));
         let mut writer = EncryptedPartWriter::begin(
             &directory,
@@ -3025,7 +3025,7 @@ mod tests {
 
     #[tokio::test]
     async fn encrypted_parts_feed_one_decoder_across_record_and_utf8_boundaries() {
-        let directory = std::env::temp_dir().join(format!("s4-stage-test-{}", Uuid::now_v7()));
+        let directory = std::env::temp_dir().join(format!("maskura-stage-test-{}", Uuid::now_v7()));
         let wrapping = Arc::new(LocalKeyWrapping::with_kek([8; 32]));
         let snapshot = snapshot();
         let mut first_writer = EncryptedPartWriter::begin(
@@ -3109,7 +3109,7 @@ mod tests {
 
     #[tokio::test]
     async fn ephemeral_wrapping_cannot_start_durable_staging() {
-        let directory = std::env::temp_dir().join(format!("s4-stage-test-{}", Uuid::now_v7()));
+        let directory = std::env::temp_dir().join(format!("maskura-stage-test-{}", Uuid::now_v7()));
         let result = EncryptedPartWriter::begin(
             &directory,
             &identity(),
@@ -3164,7 +3164,7 @@ mod tests {
             .await
             .unwrap();
         let artifacts = MemoryStagingArtifactStore::default();
-        let path = std::env::temp_dir().join(format!("s4-crash-artifact-{}", Uuid::now_v7()));
+        let path = std::env::temp_dir().join(format!("maskura-crash-artifact-{}", Uuid::now_v7()));
         tokio::fs::write(&path, b"ciphertext-only-test-artifact")
             .await
             .unwrap();

--- a/crates/gateway/src/pipeline.rs
+++ b/crates/gateway/src/pipeline.rs
@@ -178,10 +178,10 @@ pub trait ComponentSource: Send + Sync {
 
 /// OSS/self-hosted resolver: the catalog's enabled plugins in order.
 ///
-/// `S4_PLUGINS_DIR` and the bundled default component remain a *catalog* of
-/// available artifacts; this resolver decides the pipeline from that catalog
-/// exactly as the historical global chain did. An empty enabled set is the
-/// operator's explicit pass-through choice.
+/// `MASKURA_PLUGINS_DIR` (legacy `S4_PLUGINS_DIR`) and the bundled default
+/// component remain a *catalog* of available artifacts; this resolver decides
+/// the pipeline from that catalog exactly as the historical global chain did.
+/// An empty enabled set is the operator's explicit pass-through choice.
 pub struct StaticPipelineResolver {
     registry: Arc<PluginRegistry>,
 }

--- a/crates/gateway/src/plugin_registry.rs
+++ b/crates/gateway/src/plugin_registry.rs
@@ -1611,7 +1611,7 @@ mod tests {
 
     #[test]
     fn directory_catalog_preserves_digest_identical_steps() {
-        let directory = std::env::temp_dir().join(format!("s4-plugin-dir-{}", Uuid::now_v7()));
+        let directory = std::env::temp_dir().join(format!("maskura-plugin-dir-{}", Uuid::now_v7()));
         std::fs::create_dir_all(&directory).unwrap();
         let bytes = component();
         std::fs::write(directory.join("a.wasm"), &bytes).unwrap();
@@ -1661,7 +1661,7 @@ mod tests {
 
     #[test]
     fn standard_image_excludes_only_the_explicit_component_path() {
-        let directory = std::env::temp_dir().join(format!("s4-image-dir-{}", Uuid::now_v7()));
+        let directory = std::env::temp_dir().join(format!("maskura-image-dir-{}", Uuid::now_v7()));
         std::fs::create_dir_all(&directory).unwrap();
         let bytes = component();
         let explicit = directory.join("pii-default.component.wasm");

--- a/crates/gateway/src/read_spool.rs
+++ b/crates/gateway/src/read_spool.rs
@@ -336,7 +336,7 @@ mod tests {
     use http_body_util::BodyExt as _;
 
     fn directory() -> PathBuf {
-        std::env::temp_dir().join(format!("s4-read-spool-test-{}", Uuid::now_v7()))
+        std::env::temp_dir().join(format!("maskura-read-spool-test-{}", Uuid::now_v7()))
     }
 
     async fn wait_for_release(quota: &SpoolQuota) {

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -11125,7 +11125,7 @@ pub async fn build_state_with_pipeline_template(
     let spool_config = CompatibilitySpoolConfig {
         directory: resolve_customer_env(customer_env::SPOOL_DIR)?
             .map(PathBuf::from)
-            .unwrap_or_else(|| std::env::temp_dir().join("s4-spool")),
+            .unwrap_or_else(|| std::env::temp_dir().join("maskura-spool")),
         max_object_bytes: spool_max_object_bytes,
         stale_after: Duration::from_secs(24 * 60 * 60),
     };

--- a/crates/gateway/src/service_storage.rs
+++ b/crates/gateway/src/service_storage.rs
@@ -107,7 +107,7 @@ impl ServiceBackend {
         let secret_key = self.secret_key.clone();
         let region = self.region.clone();
         let endpoint = self.endpoint.clone();
-        let creds = Credentials::new(access_key, secret_key, None, None, "s4-service");
+        let creds = Credentials::new(access_key, secret_key, None, None, "maskura-service");
         let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
             .region(Region::new(region))
             .endpoint_url(&endpoint)

--- a/crates/gateway/src/sigv4.rs
+++ b/crates/gateway/src/sigv4.rs
@@ -405,7 +405,7 @@ impl RequestAuthorization {
             secret.to_string(),
             None,
             None,
-            "s4-front-door",
+            "maskura-front-door",
         )
         .into();
         let params: SigningParams = v4::SigningParams::builder()
@@ -927,8 +927,8 @@ mod tests {
     #[test]
     fn validates_sdk_canonical_path_query_and_headers() {
         for uri in [
-            "http://s4.local/bucket/a%20b//c?z=last&a=first",
-            "http://s4.local/bucket/%E2%98%83?empty=&repeat=b&repeat=a",
+            "http://maskura.local/bucket/a%20b//c?z=last&a=first",
+            "http://maskura.local/bucket/%E2%98%83?empty=&repeat=b&repeat=a",
         ] {
             let (uri, headers, time) = signed_request(uri, "us-east-1", &[]);
             let auth = RequestAuthorization::parse(&uri, &headers)
@@ -949,7 +949,8 @@ mod tests {
 
     #[test]
     fn rejects_wrong_scope_skew_and_duplicate_or_unsorted_headers() {
-        let (uri, headers, time) = signed_request("http://s4.local/bucket/key", "eu-west-1", &[]);
+        let (uri, headers, time) =
+            signed_request("http://maskura.local/bucket/key", "eu-west-1", &[]);
         let auth = RequestAuthorization::parse(&uri, &headers)
             .unwrap()
             .unwrap();
@@ -968,7 +969,8 @@ mod tests {
             SigV4Error::InvalidScope
         );
 
-        let (uri, headers, time) = signed_request("http://s4.local/bucket/key", "us-east-1", &[]);
+        let (uri, headers, time) =
+            signed_request("http://maskura.local/bucket/key", "us-east-1", &[]);
         let auth = RequestAuthorization::parse(&uri, &headers)
             .unwrap()
             .unwrap();
@@ -1022,7 +1024,7 @@ mod tests {
             },
         ] {
             let mut baseline_headers = HeaderMap::new();
-            baseline_headers.insert("host", HeaderValue::from_static("s4.local"));
+            baseline_headers.insert("host", HeaderValue::from_static("maskura.local"));
             let mut baseline_signed = vec!["host".to_string()];
             if location == Location::Header {
                 baseline_headers.insert("x-amz-date", HeaderValue::from_static(DATE));
@@ -1062,7 +1064,7 @@ mod tests {
         }
 
         let mut query_headers = HeaderMap::new();
-        query_headers.insert("host", HeaderValue::from_static("s4.local"));
+        query_headers.insert("host", HeaderValue::from_static("maskura.local"));
         query_headers.insert(
             "x-amz-content-sha256",
             HeaderValue::from_static("UNSIGNED-PAYLOAD"),
@@ -1110,7 +1112,7 @@ mod tests {
         ];
         for (name, value) in canonical_values {
             let mut headers = HeaderMap::new();
-            headers.insert("host", HeaderValue::from_static("s4.local"));
+            headers.insert("host", HeaderValue::from_static("maskura.local"));
             headers.insert("x-amz-date", HeaderValue::from_static(DATE));
             headers.insert(
                 "x-amz-content-sha256",
@@ -1143,7 +1145,7 @@ mod tests {
         }
 
         let mut invalid_utf8 = HeaderMap::new();
-        invalid_utf8.insert("host", HeaderValue::from_static("s4.local"));
+        invalid_utf8.insert("host", HeaderValue::from_static("maskura.local"));
         invalid_utf8.insert(
             "x-amz-meta-project",
             HeaderValue::from_bytes(&[0xff]).unwrap(),
@@ -1160,7 +1162,7 @@ mod tests {
         );
 
         let mut excluded_amz = HeaderMap::new();
-        excluded_amz.insert("host", HeaderValue::from_static("s4.local"));
+        excluded_amz.insert("host", HeaderValue::from_static("maskura.local"));
         excluded_amz.append("x-amz-user-agent", HeaderValue::from_static(" agent "));
         excluded_amz.append("x-amz-user-agent", HeaderValue::from_static("second"));
         excluded_amz.append("x-amz-checksum-mode", HeaderValue::from_static(" ENABLED "));
@@ -1202,7 +1204,7 @@ mod tests {
             ("x-amz-meta-project", "one,two", "one", "two"),
         ] {
             let (uri, headers, time) = signed_request(
-                "http://s4.local/bucket/duplicate",
+                "http://maskura.local/bucket/duplicate",
                 "us-east-1",
                 &[(name, combined)],
             );
@@ -1255,7 +1257,7 @@ mod tests {
             ("x-amz-tagging", " project=one&owner=two"),
         ] {
             let (uri, headers, time) = signed_request(
-                "http://s4.local/bucket/noncanonical",
+                "http://maskura.local/bucket/noncanonical",
                 "us-east-1",
                 &[(name, raw)],
             );
@@ -1288,7 +1290,7 @@ mod tests {
             ("x-amz-meta-project", "project one"),
         ] {
             let (uri, headers, time) = signed_request(
-                "http://s4.local/bucket/canonical",
+                "http://maskura.local/bucket/canonical",
                 "us-east-1",
                 &[(name, canonical)],
             );
@@ -1326,7 +1328,7 @@ mod tests {
             ("x-amz-meta-dynamic-name", "one", "two"),
         ] {
             let (uri, headers, time) = signed_request(
-                "http://s4.local/bucket/semantic",
+                "http://maskura.local/bucket/semantic",
                 "us-east-1",
                 &[(name, value)],
             );
@@ -1415,7 +1417,7 @@ mod tests {
     #[test]
     fn accepts_sdk_generated_presign_and_rejects_expiry_replay() {
         let (uri, headers, time) =
-            presigned_request("https://s4.local/bucket/a%20b?versionId=one", &[]);
+            presigned_request("https://maskura.local/bucket/a%20b?versionId=one", &[]);
         let authorization = RequestAuthorization::parse(&uri, &headers)
             .unwrap()
             .unwrap();
@@ -1452,7 +1454,7 @@ mod tests {
 
     #[test]
     fn presign_rejects_headers_appended_after_host_only_signing() {
-        let (uri, headers, time) = presigned_request("https://s4.local/bucket/object", &[]);
+        let (uri, headers, time) = presigned_request("https://maskura.local/bucket/object", &[]);
         let authorization = RequestAuthorization::parse(&uri, &headers)
             .unwrap()
             .unwrap();

--- a/crates/gateway/src/store.rs
+++ b/crates/gateway/src/store.rs
@@ -2044,7 +2044,7 @@ mod tests {
     }
 
     fn temp_keys_file() -> PathBuf {
-        let path = std::env::temp_dir().join(format!("s4-file-keys-{}.json", Uuid::new_v4()));
+        let path = std::env::temp_dir().join(format!("maskura-file-keys-{}.json", Uuid::new_v4()));
         let _ = std::fs::remove_file(&path);
         path
     }
@@ -2118,7 +2118,7 @@ mod tests {
 
     #[tokio::test]
     async fn file_store_creation_establishes_snapshot_parent_directory() {
-        let root = std::env::temp_dir().join(format!("s4-file-parent-{}", Uuid::new_v4()));
+        let root = std::env::temp_dir().join(format!("maskura-file-parent-{}", Uuid::new_v4()));
         let path = root.join("nested").join("keys.json");
         assert!(!root.exists());
 
@@ -2132,7 +2132,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn file_readers_never_observe_failed_persisted_mutations() {
-        let parent = std::env::temp_dir().join(format!("s4-file-visibility-{}", Uuid::new_v4()));
+        let parent =
+            std::env::temp_dir().join(format!("maskura-file-visibility-{}", Uuid::new_v4()));
         let durable_parent = parent.with_extension("durable");
         std::fs::create_dir_all(&parent).unwrap();
         let path = parent.join("keys.json");
@@ -2310,7 +2311,7 @@ mod tests {
 
     #[tokio::test]
     async fn file_key_store_rolls_back_public_key_when_persist_fails_and_restart_keeps_old_value() {
-        let parent = std::env::temp_dir().join(format!("s4-file-keys-{}", Uuid::new_v4()));
+        let parent = std::env::temp_dir().join(format!("maskura-file-keys-{}", Uuid::new_v4()));
         let durable_parent = parent.with_extension("durable");
         std::fs::create_dir_all(&parent).unwrap();
         let path = parent.join("keys.json");
@@ -2364,7 +2365,7 @@ mod tests {
 
     #[tokio::test]
     async fn file_key_store_rolls_back_key_delete_when_persist_fails() {
-        let parent = std::env::temp_dir().join(format!("s4-file-keys-{}", Uuid::new_v4()));
+        let parent = std::env::temp_dir().join(format!("maskura-file-keys-{}", Uuid::new_v4()));
         let durable_parent = parent.with_extension("durable");
         std::fs::create_dir_all(&parent).unwrap();
         let path = parent.join("keys.json");
@@ -2400,7 +2401,7 @@ mod tests {
 
     #[tokio::test]
     async fn file_key_store_rolls_back_mcp_mutations_when_persist_fails() {
-        let parent = std::env::temp_dir().join(format!("s4-file-keys-{}", Uuid::new_v4()));
+        let parent = std::env::temp_dir().join(format!("maskura-file-keys-{}", Uuid::new_v4()));
         let durable_parent = parent.with_extension("durable");
         std::fs::create_dir_all(&parent).unwrap();
         let path = parent.join("keys.json");
@@ -2657,7 +2658,7 @@ mod tests {
     async fn postgres_create_key_propagates_insert_error() {
         let pool = sqlx::postgres::PgPoolOptions::new()
             .acquire_timeout(std::time::Duration::from_millis(50))
-            .connect_lazy("postgresql://postgres:postgres@127.0.0.1:1/s4")
+            .connect_lazy("postgresql://postgres:postgres@127.0.0.1:1/maskura")
             .unwrap();
         let store = PostgresKeyStore::new(pool);
 
@@ -2683,7 +2684,7 @@ mod tests {
     async fn postgres_set_public_key_propagates_update_error() {
         let pool = sqlx::postgres::PgPoolOptions::new()
             .acquire_timeout(std::time::Duration::from_millis(50))
-            .connect_lazy("postgresql://postgres:postgres@127.0.0.1:1/s4")
+            .connect_lazy("postgresql://postgres:postgres@127.0.0.1:1/maskura")
             .unwrap();
         let store = PostgresKeyStore::new(pool);
 
@@ -2703,7 +2704,7 @@ mod tests {
     async fn postgres_reads_lists_resolves_and_deletes_propagate_database_errors() {
         let pool = sqlx::postgres::PgPoolOptions::new()
             .acquire_timeout(std::time::Duration::from_millis(50))
-            .connect_lazy("postgresql://postgres:postgres@127.0.0.1:1/s4")
+            .connect_lazy("postgresql://postgres:postgres@127.0.0.1:1/maskura")
             .unwrap();
         let store = PostgresKeyStore::with_cipher(pool, test_cipher());
 
@@ -2777,7 +2778,7 @@ mod tests {
     async fn postgres_configured_cipher_failure_prevents_insert() {
         let pool = sqlx::postgres::PgPoolOptions::new()
             .acquire_timeout(std::time::Duration::from_millis(50))
-            .connect_lazy("postgresql://postgres:postgres@127.0.0.1:1/s4")
+            .connect_lazy("postgresql://postgres:postgres@127.0.0.1:1/maskura")
             .unwrap();
         let store = PostgresKeyStore::with_cipher(pool, failing_cipher());
 

--- a/crates/gateway/src/transaction/spool.rs
+++ b/crates/gateway/src/transaction/spool.rs
@@ -12,10 +12,10 @@ use uuid::Uuid;
 
 use super::{ObjectSinkTransaction, SinkCommitState, StoredObjectMeta, TransactionError};
 
-const FILE_PREFIX: &str = "s4-spool-";
+const FILE_PREFIX: &str = "maskura-spool-";
 /// Encrypted transformed-read staging shares the compatibility spool directory.
 /// Keep its cleanup policy and private-file handling in this module as well.
-pub(crate) const READ_FILE_PREFIX: &str = "s4-read-spool-";
+pub(crate) const READ_FILE_PREFIX: &str = "maskura-read-spool-";
 
 #[derive(Clone, Debug)]
 pub struct CompatibilitySpoolConfig {
@@ -331,7 +331,7 @@ mod tests {
 
     #[tokio::test]
     async fn quota_object_limit_abort_and_permissions_are_enforced() {
-        let directory = std::env::temp_dir().join(format!("s4-spool-test-{}", Uuid::now_v7()));
+        let directory = std::env::temp_dir().join(format!("maskura-spool-test-{}", Uuid::now_v7()));
         let quota = Arc::new(SpoolQuota::new(5));
         let uploader = Arc::new(RecordingUploader::default());
         let mut transaction = CompatibilitySpoolTransaction::begin(
@@ -365,7 +365,7 @@ mod tests {
 
     #[tokio::test]
     async fn failed_upload_retries_the_identical_immutable_file() {
-        let directory = std::env::temp_dir().join(format!("s4-spool-test-{}", Uuid::now_v7()));
+        let directory = std::env::temp_dir().join(format!("maskura-spool-test-{}", Uuid::now_v7()));
         let quota = Arc::new(SpoolQuota::new(1024));
         let uploader = Arc::new(RecordingUploader {
             attempts: Mutex::default(),
@@ -399,7 +399,7 @@ mod tests {
 
     #[tokio::test]
     async fn cleanup_removes_only_recognized_stale_regular_files() {
-        let directory = std::env::temp_dir().join(format!("s4-spool-test-{}", Uuid::now_v7()));
+        let directory = std::env::temp_dir().join(format!("maskura-spool-test-{}", Uuid::now_v7()));
         tokio::fs::create_dir_all(&directory).await.unwrap();
         let stale = directory.join(format!("{FILE_PREFIX}old.tmp"));
         let stale_read = directory.join(format!("{READ_FILE_PREFIX}old.tmp"));

--- a/crates/gateway/src/workspace_storage.rs
+++ b/crates/gateway/src/workspace_storage.rs
@@ -1409,7 +1409,7 @@ mod tests {
 
         let mut unsupported = valid_request();
         unsupported.backend_type = BackendType::AwsRole;
-        unsupported.role_arn = "arn:aws:iam::123456789012:role/s4".to_string();
+        unsupported.role_arn = "arn:aws:iam::123456789012:role/maskura".to_string();
         assert!(matches!(
             repository.put_config(&workspace, unsupported).await,
             Err(WorkspaceStorageError::UnsupportedConfig(_))

--- a/crates/gateway/static/dashboard.html
+++ b/crates/gateway/static/dashboard.html
@@ -686,12 +686,12 @@ window.toggleTheme = function() {
   var d = html.getAttribute('data-theme') === 'dark';
   html.setAttribute('data-theme', d ? 'light' : 'dark');
   document.getElementById('theme-btn').textContent = d ? 'Dark' : 'Light';
-  localStorage.setItem('s4-theme', d ? 'light' : 'dark');
+  localStorage.setItem('maskura-theme', d ? 'light' : 'dark');
   drawFlow();
 };
 
 (function initTheme() {
-  var s = localStorage.getItem('s4-theme') || 'light';
+  var s = localStorage.getItem('maskura-theme') || 'light';
   document.documentElement.setAttribute('data-theme', s);
   document.getElementById('theme-btn').textContent = s === 'dark' ? 'Light' : 'Dark';
 })();
@@ -815,9 +815,9 @@ window.createKey = function() {
       expInfo +
       '<p class="reveal-warn">Copy this secret. It will not be shown again.</p>' +
       '<div class="code-wrapper"><button class="copy-btn" onclick="copyBlock(this)">Copy</button>' +
-      '<div class="code-block">aws configure set aws_access_key_id '+r.key_id+' --profile s4\n' +
-      'aws configure set aws_secret_access_key '+r.secret+' --profile s4\n' +
-      'aws configure set region us-east-1 --profile s4</div></div></div>';
+      '<div class="code-block">aws configure set aws_access_key_id '+r.key_id+' --profile maskura\n' +
+      'aws configure set aws_secret_access_key '+r.secret+' --profile maskura\n' +
+      'aws configure set region us-east-1 --profile maskura</div></div></div>';
     loadKeys();
   });
 };

--- a/crates/gateway/tests/db_keys_test.rs
+++ b/crates/gateway/tests/db_keys_test.rs
@@ -2830,8 +2830,10 @@ async fn state_assertions_for_unknown_head_and_ambiguous_delete(
 #[test]
 fn router_staged_multipart_flow_is_durable_and_idempotent() {
     with_pool(|pool| async move {
-        let staging_dir =
-            std::env::temp_dir().join(format!("s4-multipart-staging-{}", uuid::Uuid::new_v4()));
+        let staging_dir = std::env::temp_dir().join(format!(
+            "maskura-multipart-staging-{}",
+            uuid::Uuid::new_v4()
+        ));
         tokio::fs::create_dir_all(&staging_dir).await.unwrap();
 
         let mock_state = MockS3State::default();

--- a/crates/gateway/tests/s3_frontdoor_test.rs
+++ b/crates/gateway/tests/s3_frontdoor_test.rs
@@ -661,7 +661,7 @@ async fn backend_api_requires_real_auth_rejects_unsupported_config_and_never_ret
         .header(header::AUTHORIZATION, format!("Bearer {token}"))
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(
-            r#"{"backend_type":"aws_role","role_arn":"arn:aws:iam::123456789012:role/s4"}"#,
+            r#"{"backend_type":"aws_role","role_arn":"arn:aws:iam::123456789012:role/maskura"}"#,
         ))
         .unwrap();
     assert_eq!(
@@ -739,8 +739,10 @@ async fn backend_api_requires_real_auth_rejects_unsupported_config_and_never_ret
 #[tokio::test]
 async fn create_key_persistence_failure_returns_unavailable_without_secret() {
     let mut state = test_state().await;
-    let blocking_parent =
-        std::env::temp_dir().join(format!("s4-create-key-failure-{}", uuid::Uuid::new_v4()));
+    let blocking_parent = std::env::temp_dir().join(format!(
+        "maskura-create-key-failure-{}",
+        uuid::Uuid::new_v4()
+    ));
     std::fs::create_dir_all(&blocking_parent).unwrap();
     let file_store = FileKeyStore::new(blocking_parent.join("keys.json")).unwrap();
     std::fs::remove_dir_all(&blocking_parent).unwrap();
@@ -775,8 +777,10 @@ async fn create_key_persistence_failure_returns_unavailable_without_secret() {
 #[tokio::test]
 async fn public_key_persistence_failure_returns_generic_503_and_rolls_back() {
     let mut state = test_state().await;
-    let parent =
-        std::env::temp_dir().join(format!("s4-public-key-handler-{}", uuid::Uuid::new_v4()));
+    let parent = std::env::temp_dir().join(format!(
+        "maskura-public-key-handler-{}",
+        uuid::Uuid::new_v4()
+    ));
     let durable_parent = parent.with_extension("durable");
     std::fs::create_dir_all(&parent).unwrap();
     let path = parent.join("keys.json");
@@ -1021,8 +1025,10 @@ fn test_filter_component() -> Vec<u8> {
 
 async fn unsafe_transformed_test_state(later_filter: bool) -> Arc<AppState> {
     let mut state = test_state().await;
-    let spool_dir =
-        std::env::temp_dir().join(format!("s4-read-spool-failure-{}", uuid::Uuid::now_v7()));
+    let spool_dir = std::env::temp_dir().join(format!(
+        "maskura-read-spool-failure-{}",
+        uuid::Uuid::now_v7()
+    ));
     let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
     state_mut.streaming_read_mode = StreamingReadMode::Transformed;
     state_mut.transformed_read_spool_enabled = true;
@@ -2194,7 +2200,7 @@ async fn put_with_unsupported_content_encoding_is_rejected_without_polling_body(
 #[tokio::test]
 #[ignore = "soak: run via `just soak-streaming` or the weekly workflow"]
 async fn soak_streaming_roundtrip_holds_under_repetition() {
-    let iterations = std::env::var("S4_SOAK_ITERATIONS")
+    let iterations = std::env::var("MASKURA_SOAK_ITERATIONS")
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
         .unwrap_or(200);
@@ -4171,7 +4177,7 @@ fn presigned_request(
 async fn sigv4_signed_request_accepted_and_rejected() {
     let (app, state) = router().await;
     let (ak, sk) = make_key(&state).await;
-    let uri = "http://s4.local/demo/signed.txt";
+    let uri = "http://maskura.local/demo/signed.txt";
 
     // Correct signature → 200.
     let req = signed_request(
@@ -4230,7 +4236,7 @@ async fn sigv4_wrapping_provider_failure_returns_generic_service_unavailable() {
         &created.key_id,
         &secret,
         "PUT",
-        "http://s4.local/outage/unwrap.txt",
+        "http://maskura.local/outage/unwrap.txt",
         b"sensitive",
         &[],
     );
@@ -4283,7 +4289,7 @@ async fn sigv4_signed_semantic_headers_accept_and_detect_mutation_or_removal() {
     .into_iter()
     .enumerate()
     {
-        let uri = format!("http://s4.local/semantic/signed-{index}.txt");
+        let uri = format!("http://maskura.local/semantic/signed-{index}.txt");
         let request = signed_request(
             &access_key,
             &secret_key,
@@ -4343,7 +4349,7 @@ async fn sigv4_signs_the_exact_old_or_new_semantic_header_names() {
             &access_key,
             &secret_key,
             "PUT",
-            &format!("http://s4.local/sigv4-aliases/{index}.txt"),
+            &format!("http://maskura.local/sigv4-aliases/{index}.txt"),
             b"signed alias",
             &[("content-type", "text/plain"), (name, value)],
         );
@@ -4358,7 +4364,7 @@ async fn sigv4_signs_the_exact_old_or_new_semantic_header_names() {
         &access_key,
         &secret_key,
         "PUT",
-        "http://s4.local/sigv4-aliases/equal.txt",
+        "http://maskura.local/sigv4-aliases/equal.txt",
         b"equal aliases",
         &[
             ("content-type", "text/plain"),
@@ -4375,7 +4381,7 @@ async fn sigv4_signs_the_exact_old_or_new_semantic_header_names() {
         &access_key,
         &secret_key,
         "PUT",
-        "http://s4.local/sigv4-aliases/conflict.txt",
+        "http://maskura.local/sigv4-aliases/conflict.txt",
         b"conflicting aliases",
         &[
             ("content-type", "text/plain"),
@@ -4463,7 +4469,7 @@ async fn sigv4_rejects_ambiguous_or_noncanonical_integrity_headers_before_body_p
             signed_headers.push(("content-type", "text/plain"));
         }
         signed_headers.push((name, signed_value));
-        let uri = format!("http://s4.local/semantic/shape-{index}.txt");
+        let uri = format!("http://maskura.local/semantic/shape-{index}.txt");
         let request = signed_request(
             &access_key,
             &secret_key,
@@ -4518,7 +4524,7 @@ async fn sigv4_rejects_unsigned_integrity_header_injection_before_polling_the_bo
     .into_iter()
     .enumerate()
     {
-        let uri = format!("http://s4.local/semantic/unsigned-{index}.txt");
+        let uri = format!("http://maskura.local/semantic/unsigned-{index}.txt");
         let request = signed_request(
             &access_key,
             &secret_key,
@@ -4572,7 +4578,7 @@ async fn presigned_host_only_get_accepts_but_appended_protected_headers_are_reje
         Bytes::from_static(b"presigned body"),
         "text/plain",
     );
-    let uri = "https://s4.local/presigned/object.txt";
+    let uri = "https://maskura.local/presigned/object.txt";
 
     let response = app
         .clone()
@@ -4681,7 +4687,7 @@ async fn streaming_sigv4_hash_is_checked_before_atomic_commit() {
     state_mut.dev_memory_streaming_enabled = true;
     let (access_key, secret_key) = make_key(&state).await;
     let app = build_router(state.clone());
-    let uri = "http://s4.local/stream/signed-stream.txt";
+    let uri = "http://maskura.local/stream/signed-stream.txt";
     let input = b"contact a@b.com now\n";
 
     let request = signed_request(
@@ -4713,7 +4719,7 @@ async fn streaming_sigv4_hash_is_checked_before_atomic_commit() {
         Bytes::from_static(b"contact [REDACTED_EMAIL] now\n")
     );
 
-    let bad_uri = "http://s4.local/stream/tampered-stream.txt";
+    let bad_uri = "http://maskura.local/stream/tampered-stream.txt";
     let request = signed_request(
         &access_key,
         &secret_key,
@@ -4735,7 +4741,7 @@ async fn sigv4_get_object_roundtrip() {
     let (ak, sk) = make_key(&state).await;
 
     // PUT via SigV4.
-    let uri = "http://s4.local/bkt/signed.txt";
+    let uri = "http://maskura.local/bkt/signed.txt";
     let req = signed_request(
         &ak,
         &sk,
@@ -4908,7 +4914,7 @@ async fn managed_storage_isolates_users() {
 async fn sigv4_tampered_body_rejected() {
     let (app, state) = router().await;
     let (ak, sk) = make_key(&state).await;
-    let uri = "http://s4.local/bkt/tamper.txt";
+    let uri = "http://maskura.local/bkt/tamper.txt";
 
     // Sign body A, then send body B with the A-signature -> 403.
     let req = signed_request(
@@ -4933,7 +4939,7 @@ async fn sigv4_tampered_body_rejected() {
 async fn invalid_sigv4_headers_are_rejected_without_polling_put_body() {
     let (app, state) = router().await;
     let (ak, _sk) = make_key(&state).await;
-    let uri = "http://s4.local/bkt/unpolled.txt";
+    let uri = "http://maskura.local/bkt/unpolled.txt";
     let signed = signed_request(&ak, "wrong-secret", "PUT", uri, b"sensitive body", &[]);
     let (parts, _) = signed.into_parts();
     let polls = Arc::new(AtomicUsize::new(0));
@@ -4954,7 +4960,7 @@ async fn invalid_sigv4_headers_are_rejected_without_polling_put_body() {
 async fn valid_sigv4_seed_polls_then_rejects_payload_hash_mismatch() {
     let (app, state) = router().await;
     let (ak, sk) = make_key(&state).await;
-    let uri = "http://s4.local/bkt/hash-mismatch.txt";
+    let uri = "http://maskura.local/bkt/hash-mismatch.txt";
     let signed = signed_request(
         &ak,
         &sk,
@@ -5031,7 +5037,7 @@ async fn unmodified_rust_sdk_default_put_is_accepted() {
 
 #[tokio::test]
 async fn available_aws_cli_and_boto3_interoperate() {
-    if std::env::var("S4_RUN_EXTERNAL_CLIENT_INTEROP").as_deref() != Ok("1") {
+    if std::env::var("MASKURA_RUN_EXTERNAL_CLIENT_INTEROP").as_deref() != Ok("1") {
         return;
     }
     let aws_available = tokio::time::timeout(
@@ -5054,11 +5060,11 @@ async fn available_aws_cli_and_boto3_interoperate() {
     .is_ok_and(|result| result.is_ok_and(|output| output.status.success()));
     assert!(
         aws_available,
-        "S4_RUN_EXTERNAL_CLIENT_INTEROP requires AWS CLI"
+        "MASKURA_RUN_EXTERNAL_CLIENT_INTEROP requires AWS CLI"
     );
     assert!(
         boto3_available,
-        "S4_RUN_EXTERNAL_CLIENT_INTEROP requires boto3"
+        "MASKURA_RUN_EXTERNAL_CLIENT_INTEROP requires boto3"
     );
 
     let mut state = test_state().await;
@@ -5126,7 +5132,7 @@ import boto3, os
 from botocore.config import Config
 boto3.client(
     "s3",
-    endpoint_url=os.environ["S4_TEST_ENDPOINT"],
+    endpoint_url=os.environ["MASKURA_TEST_ENDPOINT"],
     region_name="us-east-1",
     aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
     aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
@@ -5137,7 +5143,7 @@ boto3.client(
             Duration::from_secs(30),
             Command::new("python3")
                 .args(["-c", script])
-                .env("S4_TEST_ENDPOINT", &endpoint)
+                .env("MASKURA_TEST_ENDPOINT", &endpoint)
                 .env("AWS_ACCESS_KEY_ID", &access_key)
                 .env("AWS_SECRET_ACCESS_KEY", &secret)
                 .env("AWS_EC2_METADATA_DISABLED", "true")
@@ -5793,8 +5799,10 @@ async fn stable_transformed_reads_are_rejected_without_disclosure() {
 #[tokio::test]
 async fn unsafe_transformed_read_stages_then_sanitizes_source_headers() {
     let mut state = test_state().await;
-    let spool_dir =
-        std::env::temp_dir().join(format!("s4-read-spool-router-{}", uuid::Uuid::now_v7()));
+    let spool_dir = std::env::temp_dir().join(format!(
+        "maskura-read-spool-router-{}",
+        uuid::Uuid::now_v7()
+    ));
     let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
     let control = Arc::new(RecordingMeteringControl::default());
     state_mut.streaming_read_mode = StreamingReadMode::Transformed;
@@ -6307,8 +6315,10 @@ async fn nonempty_prefix_safe_reads_stream_and_settle_without_spool() {
     let mut state = test_state().await;
     let control = Arc::new(RecordingMeteringControl::default());
     let state_mut = Arc::get_mut(&mut state).expect("test state is uniquely owned");
-    let spool_dir =
-        std::env::temp_dir().join(format!("s4-direct-read-no-spool-{}", uuid::Uuid::now_v7()));
+    let spool_dir = std::env::temp_dir().join(format!(
+        "maskura-direct-read-no-spool-{}",
+        uuid::Uuid::now_v7()
+    ));
     let spool_quota = Arc::new(SpoolQuota::new(2048));
     state_mut.streaming_read_mode = StreamingReadMode::Transformed;
     state_mut.transformed_read_spool_enabled = false;

--- a/crates/s4ctl/src/main.rs
+++ b/crates/s4ctl/src/main.rs
@@ -2123,7 +2123,7 @@ mod tests {
     #[test]
     fn parse_draft_step_reads_config_file() {
         let dir = std::env::temp_dir().join(format!(
-            "s4ctl-step-{}-{}",
+            "maskura-step-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)

--- a/crates/wasm-runtime/src/executor.rs
+++ b/crates/wasm-runtime/src/executor.rs
@@ -433,7 +433,7 @@ fn panic_error(payload: Box<dyn Any + Send>) -> S4Error {
 
 fn spawn_worker(index: usize, receiver: Arc<Mutex<Receiver<Job>>>) -> Result<(), S4Error> {
     std::thread::Builder::new()
-        .name(format!("s4-wasm-{index}"))
+        .name(format!("maskura-wasm-{index}"))
         .spawn(move || {
             loop {
                 let job = receiver.lock().unwrap().recv();
@@ -480,7 +480,7 @@ mod tests {
                 std::thread::current().name().unwrap().to_string()
             })
             .unwrap();
-        assert_eq!(name, "s4-wasm-0");
+        assert_eq!(name, "maskura-wasm-0");
         assert_eq!(executor.admission().used(), 0);
     }
 

--- a/crates/wasm-runtime/src/lib.rs
+++ b/crates/wasm-runtime/src/lib.rs
@@ -857,7 +857,7 @@ impl RuntimeComponent {
     }
 }
 
-/// Registers only the WASI preview 2 interfaces that built-in S4 filters
+/// Registers only the WASI preview 2 interfaces that built-in Maskura filters
 /// require, denying sockets, terminal, and other capabilities outright.
 ///
 /// This is the hardened capability surface: guests may read the empty
@@ -958,7 +958,7 @@ fn register_epoch_engine(engine: &Arc<EpochEngine>) {
         .push(Arc::downgrade(engine));
     EPOCH_THREAD.get_or_init(|| {
         std::thread::Builder::new()
-            .name("s4-wasm-epoch".to_string())
+            .name("maskura-wasm-epoch".to_string())
             .spawn(|| {
                 loop {
                     std::thread::sleep(EPOCH_TICK);

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -1,0 +1,128 @@
+# Local end-to-end suite
+
+The gateway ships a local, no-secrets end-to-end suite that boots a real
+MinIO S3 backend plus the gateway binary and exercises public HTTP features
+against it. It runs in CI (`ci.yml`, `weekly.yml`, `nightly.yml`) and locally,
+and needs no Supabase, Postgres, cloud credentials, or signed-in users.
+
+```bash
+just e2e                  # run the full suite
+bash scripts/e2e-local.sh # same, without `just`
+```
+
+## How it is structured
+
+- `scripts/e2e-local.sh` — the orchestrator. Boots the shared environment
+  once, runs every feature script in `scripts/e2e/features/`, aggregates
+  PASS/FAIL, and exits 0 only when all features pass.
+- `scripts/e2e/lib.sh` — the shared harness contract and helpers
+  (`pass`/`fail`, HTTP-status and content assertions, JSON field extraction).
+- `scripts/e2e/features/NN-*.sh` — one discrete, independently-runnable
+  feature script per concern. Feature order is lexicographic; stateful
+  features (plugin management) run last.
+
+A feature may also be run alone against a freshly booted environment:
+
+```bash
+bash scripts/e2e-local.sh 30-keys-s3-lifecycle
+# accept a bare feature number/name or a path:
+bash scripts/e2e-local.sh 30-keys-s3-lifecycle.sh
+```
+
+## Boot contract
+
+The orchestrator starts (or reuses) one shared environment for every feature:
+
+- **MinIO on `:9000`** — if a healthy MinIO is already listening there
+  (`minioadmin`/`minioadmin`), it is reused instead of failing on the port
+  clash (common when a dev/ad MinIO is running). Otherwise `docker compose -f
+  local/docker-compose.yml up -d minio` starts one, torn down on exit.
+- **Bucket `s4-local`** is created if missing.
+- **Gateway (AUTH_DISABLED)** on `$MASKURA_E2E_GW_PORT` (default `9010`),
+  single-tenant streaming against that MinIO, an isolated `keys.json`, the
+  built `pii-default` component, and `MASKURA_STREAMING_WRITE_MODE=single` /
+  `READ_MODE=passthrough`.
+- Gateway, MinIO, and the filter/binaries are **built from the working tree**
+  each run, so the suite validates the code you have checked out.
+
+Requirements: `bash`, Docker + `docker compose`, `curl`, `python3`, and a Rust
+toolchain with the WASM/WASI targets used by `scripts/build-filters.sh`. No
+environment variables, secrets, or network access are required.
+
+> Note: with `AUTH_DISABLED=true`, unauthenticated and unresolvable-credential
+> requests are admitted as the demo user. Key expiry/revocation *rejection*
+> therefore cannot be asserted against the shared gateway; the strict-auth
+> feature (below) covers denial semantics on a second gateway instead.
+
+## Features
+
+| Script | Concern | What it proves |
+| --- | --- | --- |
+| `10-http-surface.sh` | HTTP surface | `/health`; `/` serves the dashboard HTML and is not an S3 `ListBuckets` XML response; `/openapi.json` is OpenAPI 3.1 and documents `/dashboard/api/keys` and `/dashboard/api/backend`; `/docs` serves Swagger UI (following the redirect); retired `/dashboard/api/demo/store` returns 410 for every method |
+| `15-avro-gate.sh` | Avro gate | A PUT with `Content-Type: application/avro` is rejected (501) while `MASKURA_ENABLE_AVRO` is unset, and nothing is stored |
+| `20-redaction-roundtrip.sh` | Core redaction | `maskura test upload` stores a PII fixture through the pipeline; the object read directly back from MinIO contains `[REDACTED_EMAIL]`/`[REDACTED_SSN]`/`[REDACTED_CARD]` and no plaintext |
+| `25-strict-auth-denial.sh` | Auth enforcement | Boots a second, isolated gateway on `$MASKURA_STRICT_GW_PORT` (default `9011`) **without** `AUTH_DISABLED` and an empty keystore: unauthenticated S3 PUT/GET/List are denied 403 and the dashboard key API is denied 401 — no demo fallback |
+| `30-keys-s3-lifecycle.sh` | Keys + S3 data plane | Dashboard key create / list / revoke happy paths (`s4_`/`s4s_` formats, revoke returns 204 and removes the key); header-authenticated S3 PUT → HEAD → GET byte-identical read-back → ListObjects v1 and v2 via the real MinIO backend → DELETE → 404 |
+| `40-plugin-admin-http.sh` | Plugin management | Import a real `.wasm` component (201), catalog list, enable (200 + `enabled: true`), reorder, and remove (204) over the HTTP admin routes mounted in `AUTH_DISABLED` mode. Runs last because enabling an imported component can change the write pipeline |
+
+Each feature prints `PASS:`/`FAIL:` lines and exits non-zero on failure, so a
+feature can also be executed directly against an already-booted environment.
+
+## What the suite covers beyond the old e2e
+
+The original e2e only exercised `GET /health` and one demo-mode `test upload`.
+The suite now also asserts previously untested public paths:
+
+- S3-backend `ListObjects` v1 + v2 and byte-faithful authenticated
+  PUT/HEAD/GET/DELETE against a real S3 backend (MinIO).
+- `GET`/`DELETE /dashboard/api/keys` happy paths and the dashboard key format.
+- Dashboard HTML, `/openapi.json` + `/docs` serving, and legacy tombstone 410s.
+- Plugin import / list / enable / reorder / remove across the real HTTP router.
+- Data-plane + dashboard denial on a non-`AUTH_DISABLED` boot (no demo fallback).
+- The Avro enablement gate (negative path).
+
+## Deferred scenarios (and why they are separate harnesses)
+
+The following need a different gateway boot contract or extra tooling, so they
+are deliberately not part of this suite yet. Each is a natural future
+`NN-*.sh` with its own boot:
+
+- **Positive Avro round trip and envelope/stable field encryption** —
+  need `MASKURA_ENABLE_AVRO=true`, an authenticated public key, OCF fixtures,
+  and an Avro codec (e.g. `fastavro`) on the runner to assert typed output.
+  See `docs/avro.md`.
+- **Managed service storage** — needs a multi-backend boot with
+  `S4_SERVICE_BUCKETS` and no `S3_ENDPOINT` (the two are mutually exclusive at
+  startup).
+- **Staged multipart** — needs Postgres and a durable KEK
+  (`MULTIPART_MODE=staged` + `DATABASE_URL`); covered today by the
+  Postgres-gated `db_keys_test` CI job.
+- **Key expiry/revocation rejection on the data plane** — needs an
+  auth-enabled boot that can create keys (with `AUTH_DISABLED` unset, the
+  dashboard key API requires a real user session).
+- **Presigned URL proxy** — needs a container-network harness: the host-run
+  gateway cannot deterministically reach the local MinIO loopback over IPv4 on
+  all Docker setups, and the SSRF allowlist rejects IP-literal hosts.
+- **SDK / MCP live round trips** — need the Python/TypeScript SDK or MCP
+  runtime dependencies on the runner.
+
+## Adding a feature
+
+1. Create `scripts/e2e/features/NN-short-name.sh` that sources
+   `../lib.sh`, calls `begin_feature`, asserts with `expect_status` /
+   `assert_contains` / `assert_absent`, and ends with `end_feature "<name>"`.
+2. Use unique object keys and, when mutating the gateway state, place the
+   feature last (as `40-plugin-admin-http.sh` does).
+3. If the feature needs its own gateway, boot it on its own port and keys file
+   and stop it on `EXIT` (see `25-strict-auth-denial.sh`).
+4. Keep it deterministic in CI: only `bash`, `curl`, `python3`, Docker, and
+   the artifacts the orchestrator already builds. Remember `curl
+   --data-binary` implies **POST** unless `-X PUT` is given.
+
+## Troubleshooting
+
+- If MinIO is already running on `:9000` the orchestrator reuses it; give it a
+  moment or confirm `curl http://127.0.0.1:9000/minio/health/live` succeeds.
+- The gateway log is written to the isolated run directory
+  (`$E2E_KEYS_DIR/gateway.log`) and removed on exit; run a single feature and
+  check the `FAIL:` lines for the exact assertion that broke.

--- a/examples/avro-demo.py
+++ b/examples/avro-demo.py
@@ -34,7 +34,7 @@ KEY = "customers/day=2026-08-30/part-000.avro"
 SCHEMA = {
     "type": "record",
     "name": "Customer",
-    "namespace": "s4.example",
+    "namespace": "maskura.example",
     "fields": [
         {"name": "id", "type": "long"},
         {"name": "email", "type": ["null", "string"]},

--- a/examples/b2-encrypt-demo.sh
+++ b/examples/b2-encrypt-demo.sh
@@ -24,18 +24,18 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-PORT="${S4_TEST_PORT:-9012}"
+PORT="${MASKURA_TEST_PORT:-9012}"
 GATEWAY_URL="http://127.0.0.1:${PORT}"
 INPUT="$ROOT/tests/fixtures/pii/sample1.txt"
 OBJ_KEY="demo/encrypted-sample.txt"
 CERT="$ROOT/tests/fixtures/pii/crypto/cert.pem"
 KEY="$ROOT/tests/fixtures/pii/crypto/key.pem"
-MC_CONF="s4-mc-demo"
+MC_CONF="maskura-mc-demo"
 MC_IMAGE="minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"
-GW_LOG="/tmp/s4-b2-enc-demo.log"
-RAW="/tmp/s4-b2-enc-raw.txt"
-THROUGH="/tmp/s4-b2-enc-through.txt"
-DECRYPTED="/tmp/s4-b2-decrypted.txt"
+GW_LOG="/tmp/maskura-b2-enc-demo.log"
+RAW="/tmp/maskura-b2-enc-raw.txt"
+THROUGH="/tmp/maskura-b2-enc-through.txt"
+DECRYPTED="/tmp/maskura-b2-decrypted.txt"
 
 for v in B2_S3_ENDPOINT B2_REGION B2_BUCKET B2_ACCESS_KEY_ID B2_SECRET_ACCESS_KEY; do
   [ -n "${!v:-}" ] || { echo "ERROR: $v is not set (see script header)" >&2; exit 1; }

--- a/examples/b2-redact-demo.sh
+++ b/examples/b2-redact-demo.sh
@@ -18,14 +18,14 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-PORT="${S4_TEST_PORT:-9013}"
+PORT="${MASKURA_TEST_PORT:-9013}"
 GATEWAY_URL="http://127.0.0.1:${PORT}"
 INPUT="$ROOT/tests/fixtures/pii/sample1.txt"
 OBJ_KEY="demo/redacted-sample.txt"
-MC_CONF="s4-mc-redact-demo"
+MC_CONF="maskura-mc-redact-demo"
 MC_IMAGE="minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"
-GW_LOG="/tmp/s4-b2-redact-demo.log"
-RAW="/tmp/s4-b2-redact-raw.txt"
+GW_LOG="/tmp/maskura-b2-redact-demo.log"
+RAW="/tmp/maskura-b2-redact-raw.txt"
 
 for v in B2_S3_ENDPOINT B2_REGION B2_BUCKET B2_ACCESS_KEY_ID B2_SECRET_ACCESS_KEY; do
   [ -n "${!v:-}" ] || { echo "ERROR: $v is not set (see script header)" >&2; exit 1; }

--- a/examples/local-quickstart.sh
+++ b/examples/local-quickstart.sh
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-SAMPLE="/tmp/s4-quickstart.csv"
+SAMPLE="/tmp/maskura-quickstart.csv"
 
 echo "=== Maskura local quickstart ==="
 maskura --version

--- a/justfile
+++ b/justfile
@@ -69,7 +69,7 @@ bench-rss:
 # Soak: high-case-count property tests + repeated streaming round-trips
 soak-streaming:
   PROPTEST_CASES=10000 cargo test -p s4-gateway --test property --test record_decoder
-  S4_SOAK_ITERATIONS=500 cargo test -p s4-gateway --test s3_frontdoor_test soak_streaming_roundtrip_holds_under_repetition -- --ignored
+  MASKURA_SOAK_ITERATIONS=500 cargo test -p s4-gateway --test s3_frontdoor_test soak_streaming_roundtrip_holds_under_repetition -- --ignored
 
 # Release image smoke (boot smoke against the built OCI image)
 release-smoke:

--- a/scripts/build-filters.sh
+++ b/scripts/build-filters.sh
@@ -29,7 +29,7 @@ sha256_file() {
   fi
 }
 
-ADAPTER="${S4_WASI_ADAPTER:-}"
+ADAPTER="${MASKURA_WASI_ADAPTER:-}"
 if [ -z "$ADAPTER" ]; then
   ADAPTER_DIR="$ROOT/target/wasi-preview1-adapter-v${ADAPTER_VERSION}"
   ADAPTER="$ADAPTER_DIR/wasi_snapshot_preview1.reactor.wasm"
@@ -47,7 +47,7 @@ if [ -z "$ADAPTER" ]; then
     mv "$ADAPTER_TMP" "$ADAPTER"
   fi
 elif [ ! -f "$ADAPTER" ]; then
-  echo "ERROR: S4_WASI_ADAPTER does not exist: $ADAPTER" >&2
+  echo "ERROR: MASKURA_WASI_ADAPTER does not exist: $ADAPTER" >&2
   exit 1
 fi
 

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -1,132 +1,157 @@
 #!/usr/bin/env bash
+# Maskura local end-to-end suite.
+#
+# Boots MinIO + the gateway once, then runs every discrete feature script in
+# scripts/e2e/features/ against that shared environment. Each feature is an
+# independently-runnable script; `bash scripts/e2e-local.sh <name>` runs only
+# the matching feature (after boot).
+#
+# Features covered today:
+#   10-http-surface.sh        /health, dashboard HTML, /openapi.json, /docs, legacy tombstones
+#   15-avro-gate.sh           Avro-content PUT rejected while MASKURA_ENABLE_AVRO is unset
+#   20-redaction-roundtrip.sh PII redaction on PUT -> object read-back from MinIO
+#   25-strict-auth-denial.sh  second strict gateway (no AUTH_DISABLED): unauthenticated S3/dashboard denied
+#   30-keys-s3-lifecycle.sh   dashboard key CRUD + authenticated S3 PUT/HEAD/GET/LIST/DELETE
+#   40-plugin-admin-http.sh   plugin import / list / enable / reorder / remove over HTTP
+#
+# Features that need a different gateway configuration or extra tooling are
+# intentionally separate future harnesses (each keeps its own boot contract):
+# the positive Avro round trip and envelope/stable field encryption need
+# MASKURA_ENABLE_AVRO=true plus OCF fixtures and an Avro codec to assert on;
+# managed service storage needs an S4_SERVICE_BUCKETS multi-backend boot
+# without S3_ENDPOINT; staged multipart needs Postgres + a durable KEK; key
+# expiry/revocation rejection on the data plane needs an auth-enabled boot
+# that can create keys; presigned URL proxying needs a container-network
+# harness (the host process cannot deterministically reach the local MinIO's
+# loopback over IPv4 on all Docker setups and IP literals are not allowlisted);
+# SDK/MCP live round trips need their runtimes.
+
 set -euo pipefail
 
-ROOT="$(dirname "$0")/.."
-RUN_ID="${GITHUB_RUN_ID:-$$}"
-COMPOSE_PROJECT="s4-e2e-${RUN_ID}"
-COMPOSE=(docker compose --project-name "$COMPOSE_PROJECT" -f "$ROOT/local/docker-compose.yml")
-READBACK="/tmp/s4-e2e-readback-${RUN_ID}.txt"
-GW_LOG="/tmp/s4-e2e-gateway-${RUN_ID}.log"
-# Isolate the local-mode key store from the user's real config directory so a
-# stale `~/Library/Application Support/s4/keys.json` (DEK wrapped by an earlier
-# ephemeral/secret key) can never abort gateway startup.
-KEYS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/s4-e2e-keys-${RUN_ID}.XXXXXX")"
-KEYS_FILE="$KEYS_DIR/keys.json"
-MC_CONF="${COMPOSE_PROJECT}-mc"
-MC_IMAGE="minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"
-GW_PORT="${S4_E2E_GW_PORT:-9010}"
-GW_URL="http://127.0.0.1:$GW_PORT"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=lib.sh
+source "$ROOT/scripts/e2e/lib.sh"
+
 GW_PID=""
+E2E_STARTED_MINIO=0
 
 cleanup() {
-    [ -n "$GW_PID" ] && kill "$GW_PID" 2>/dev/null || true
-    [ -n "$GW_PID" ] && wait "$GW_PID" 2>/dev/null || true
-    "${COMPOSE[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
-    rm -f "$READBACK" "$GW_LOG"
-    rm -rf "$KEYS_DIR"
-    docker volume rm "$MC_CONF" >/dev/null 2>&1 || true
+    if [ -n "$GW_PID" ]; then
+        kill "$GW_PID" 2>/dev/null || true
+        wait "$GW_PID" 2>/dev/null || true
+    fi
+    if [ "$E2E_STARTED_MINIO" -eq 1 ]; then
+        "${E2E_COMPOSE[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
+    fi
+    docker volume rm "$E2E_MC_CONF" >/dev/null 2>&1 || true
+    rm -rf "$E2E_KEYS_DIR"
 }
 trap cleanup EXIT
 
-echo "=== Maskura E2E: MinIO read/write validation ==="
+e2e_boot() {
+    echo "=== Maskura E2E: boot MinIO + gateway ==="
 
-# 1. Start MinIO
-echo "--- Starting MinIO ---"
-"${COMPOSE[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
-docker volume rm "$MC_CONF" >/dev/null 2>&1 || true
-"${COMPOSE[@]}" up -d --wait minio 2>&1
-
-# mc config lives in a shared volume so alias set and subsequent ops
-# (run as separate --rm containers) see the same configuration.
-MC_OPTS=(--rm -i --network host -v "$MC_CONF:/root/.mc" "$MC_IMAGE" --no-color)
-
-# 2. Configure MinIO client alias + create the bucket the gateway will use
-echo "--- Configuring MinIO alias ---"
-docker run "${MC_OPTS[@]}" alias set local http://localhost:9000 minioadmin minioadmin
-
-echo "--- Creating s4-local bucket ---"
-docker run "${MC_OPTS[@]}" mb local/s4-local --ignore-existing
-
-# 3. Build filters and binaries
-echo "--- Building filters and binaries ---"
-(cd "$ROOT" && bash scripts/build-filters.sh)
-(cd "$ROOT" && cargo build --locked -p s4-gateway --bin s4-gateway)
-(cd "$ROOT" && cargo build --locked -p s4ctl --bin maskura)
-
-# 4. Start the gateway against MinIO (auth disabled)
-echo "--- Starting Maskura Gateway on $GW_URL ---"
-S3_ENDPOINT=http://127.0.0.1:9000 \
-S3_ACCESS_KEY_ID=minioadmin \
-S3_SECRET_ACCESS_KEY=minioadmin \
-S3_REGION=us-east-1 \
-LISTEN_ADDR="127.0.0.1:$GW_PORT" \
-MASKURA_FILTER_COMPONENT="$ROOT/target/components/pii-default.component.wasm" \
-MASKURA_STREAMING_WRITE_MODE=single \
-MASKURA_STREAMING_READ_MODE=passthrough \
-MASKURA_STREAMING_S3_PROVIDER=minio \
-MASKURA_KEYS_FILE="$KEYS_FILE" \
-AUTH_DISABLED=true \
-"$ROOT/target/debug/s4-gateway" > "$GW_LOG" 2>&1 &
-GW_PID=$!
-
-echo "--- Waiting for gateway health ---"
-for _ in $(seq 1 30); do
-    if curl -sf "$GW_URL/health" >/dev/null 2>&1; then
-        echo "Gateway healthy"
-        break
+    # 1. MinIO on :9000: reuse a healthy instance (common when the local
+    # dev/ad MinIO is already running) or start one via docker compose.
+    if curl -fs http://127.0.0.1:9000/minio/health/live >/dev/null 2>&1; then
+        echo "--- Reusing running MinIO on :9000 ---"
+        E2E_STARTED_MINIO=0
+    else
+        echo "--- Starting MinIO ---"
+        "${E2E_COMPOSE[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
+        docker volume rm "$E2E_MC_CONF" >/dev/null 2>&1 || true
+        "${E2E_COMPOSE[@]}" up -d --wait minio 2>&1
+        E2E_STARTED_MINIO=1
     fi
-    sleep 1
-done
-curl -sf "$GW_URL/health" >/dev/null 2>&1 || {
-    echo "FAIL: gateway did not become healthy"
-    tail -5 "$GW_LOG"
-    exit 1
+
+    # mc config lives in a shared volume so alias set and the read-back steps
+    # (separate --rm containers) see the same configuration.
+    local mc_opts=(--rm -i --network host -v "$E2E_MC_CONF:/root/.mc" "$E2E_MC_IMAGE" --no-color)
+    docker run "${mc_opts[@]}" alias set local http://localhost:9000 minioadmin minioadmin
+    docker run "${mc_opts[@]}" mb "local/$E2E_BUCKET" --ignore-existing
+
+    # 2. Build the filters and the debug binaries.
+    echo "--- Building filters and binaries ---"
+    (cd "$ROOT" && bash scripts/build-filters.sh)
+    (cd "$ROOT" && cargo build --locked -p s4-gateway --bin s4-gateway)
+    (cd "$ROOT" && cargo build --locked -p s4ctl --bin maskura)
+
+    # 3. Start the gateway against MinIO (auth disabled, isolated keys file).
+    echo "--- Starting Maskura Gateway on $E2E_GW_URL ---"
+    S3_ENDPOINT=http://127.0.0.1:9000 \
+    S3_ACCESS_KEY_ID=minioadmin \
+    S3_SECRET_ACCESS_KEY=minioadmin \
+    S3_REGION=us-east-1 \
+    LISTEN_ADDR="127.0.0.1:$MASKURA_E2E_GW_PORT" \
+    MASKURA_FILTER_COMPONENT="$E2E_COMPONENT" \
+    MASKURA_STREAMING_WRITE_MODE=single \
+    MASKURA_STREAMING_READ_MODE=passthrough \
+    MASKURA_STREAMING_S3_PROVIDER=minio \
+    MASKURA_KEYS_FILE="$E2E_KEYS_FILE" \
+    AUTH_DISABLED=true \
+    "$E2E_GW_BIN" > "$E2E_GW_LOG" 2>&1 &
+    GW_PID=$!
+
+    echo "--- Waiting for gateway health ---"
+    local ok=0
+    for _ in $(seq 1 30); do
+        if curl -sf "$E2E_GW_URL/health" >/dev/null 2>&1; then
+            ok=1
+            break
+        fi
+        sleep 1
+    done
+    if [ "$ok" -ne 1 ]; then
+        echo "FAIL: gateway did not become healthy" >&2
+        tail -5 "$E2E_GW_LOG" >&2 || true
+        exit 1
+    fi
+    echo "Gateway healthy"
 }
 
-# 5. Upload PII fixture through the gateway, read it back (verifies redaction)
-echo "--- Running maskura test upload through the gateway ---"
-MASKURA_GATEWAY_URL="$GW_URL" "$ROOT/target/debug/maskura" test upload
+FEATURES_DIR="$ROOT/scripts/e2e/features"
+select_features() {
+    if [ "$#" -eq 0 ]; then
+        printf '%s\n' "$FEATURES_DIR"/*.sh | sort
+    else
+        for want in "$@"; do
+            # Accept a bare feature number/name or a path.
+            local base
+            base="$(basename "$want")"
+            case "$base" in
+                *.sh) printf '%s\n' "$want" ;;
+                *) printf '%s\n' "$FEATURES_DIR/${base}.sh" ;;
+            esac
+        done
+    fi
+}
 
-# 6. Verify the stored object in MinIO is redacted
-echo "--- Verifying object in MinIO ---"
-docker run "${MC_OPTS[@]}" cat local/s4-local/test-upload.txt > "$READBACK"
-
-echo "--- Read-back content ---"
-cat "$READBACK"
+e2e_boot
+TOTAL_FAILED=0
+FEATURES_LIST="$E2E_TMP/features.txt"
+select_features "$@" > "$FEATURES_LIST"
+while IFS= read -r feature; do
+    [ -n "$feature" ] || continue
+    if [ ! -f "$feature" ]; then
+        echo "ERROR: feature not found: $feature" >&2
+        exit 2
+    fi
+    echo ""
+    echo "######## $(basename "$feature") ########"
+    # < /dev/null keeps the child from consuming the features list via stdin
+    # (docker run -i inside a feature would otherwise eat the remaining lines).
+    if bash "$feature" < /dev/null; then
+        echo "RESULT: $(basename "$feature") passed"
+    else
+        echo "RESULT: $(basename "$feature") FAILED" >&2
+        TOTAL_FAILED=1
+    fi
+done < "$FEATURES_LIST"
 
 echo ""
-echo "=== Verification ==="
-FAIL=0
-
-for pat in "REDACTED_EMAIL" "REDACTED_SSN" "REDACTED_CARD"; do
-    if grep -q "\[$pat\]" "$READBACK"; then
-        echo "PASS: $pat present in stored object"
-    else
-        echo "FAIL: $pat missing from stored object"
-        FAIL=1
-    fi
-done
-
-if ! grep -q "jane.doe@example.com" "$READBACK"; then
-    echo "PASS: original email absent from stored object"
-else
-    echo "FAIL: original email found in stored object"
-    FAIL=1
-fi
-
-if ! grep -q "4111111111111111" "$READBACK"; then
-    echo "PASS: original card absent from stored object"
-else
-    echo "FAIL: original card found in stored object"
-    FAIL=1
-fi
-
-if [ "$FAIL" -eq 0 ]; then
-    echo ""
+if [ "$TOTAL_FAILED" -eq 0 ]; then
     echo "=== E2E VALIDATION PASSED ==="
-    echo "Filtered data is written to MinIO and read back with PII removed."
 else
-    echo ""
-    echo "=== E2E VALIDATION FAILED ==="
+    echo "=== E2E VALIDATION FAILED ===" >&2
     exit 1
 fi

--- a/scripts/e2e/features/10-http-surface.sh
+++ b/scripts/e2e/features/10-http-surface.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Feature: HTTP surface — liveness, dashboard HTML, OpenAPI spec, Swagger UI,
+# and the retired demo tombstones. No S3 credentials involved.
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
+begin_feature "HTTP surface: health / dashboard HTML / OpenAPI / Swagger UI / tombstones"
+
+# GET /health -> 200 liveness
+curl -sS -o "$E2E_TMP/10-health.txt" -w '%{http_code}' "$E2E_GW_URL/health" > "$E2E_TMP/10-health.code"
+expect_status 200 "$(cat "$E2E_TMP/10-health.code")" "GET /health"
+
+# GET / (no S3 auth headers) -> dashboard HTML, not ListBuckets XML
+curl -sS -o "$E2E_TMP/10-root.html" -w '%{http_code}' "$E2E_GW_URL/" > "$E2E_TMP/10-root.code"
+expect_status 200 "$(cat "$E2E_TMP/10-root.code")" "GET /"
+assert_contains "$E2E_TMP/10-root.html" "Maskura" "root serves the Maskura dashboard HTML"
+assert_absent "$E2E_TMP/10-root.html" "<ListBucketResult" "dashboard root is not an S3 ListBuckets response"
+
+# GET /openapi.json -> OpenAPI 3.1 with the dashboard API schemas
+curl -sS -o "$E2E_TMP/10-openapi.json" -w '%{http_code}' "$E2E_GW_URL/openapi.json" > "$E2E_TMP/10-openapi.code"
+expect_status 200 "$(cat "$E2E_TMP/10-openapi.code")" "GET /openapi.json"
+if python3 - "$E2E_TMP/10-openapi.json" <<'PY'
+import json, sys
+doc = json.load(open(sys.argv[1]))
+assert doc.get("openapi", "").startswith("3.1"), doc.get("openapi")
+paths = doc.get("paths", {})
+assert "/dashboard/api/keys" in paths, sorted(paths)
+assert "/dashboard/api/backend" in paths, sorted(paths)
+print("ok")
+PY
+then
+    pass "OpenAPI spec is 3.1 and documents the dashboard key + backend APIs"
+else
+    fail "openapi.json is not a 3.1 spec exposing /dashboard/api/keys and /dashboard/api/backend"
+fi
+
+# GET /docs -> Swagger UI (utoipa redirects /docs to /docs/)
+curl -sSL -o "$E2E_TMP/10-docs.html" -w '%{http_code}' "$E2E_GW_URL/docs" > "$E2E_TMP/10-docs.code"
+expect_status 200 "$(cat "$E2E_TMP/10-docs.code")" "GET /docs (followed redirect)"
+assert_contains "$E2E_TMP/10-docs.html" "Swagger" "GET /docs serves the Swagger UI"
+
+# Legacy demo endpoints must answer 410 for every method.
+for method in GET POST PUT DELETE; do
+    code="$(curl -sS -o /dev/null -X "$method" -w '%{http_code}' "$E2E_GW_URL/dashboard/api/demo/store")"
+    expect_status 410 "$code" "legacy $method /dashboard/api/demo/store tombstone"
+done
+
+end_feature "HTTP surface"

--- a/scripts/e2e/features/15-avro-gate.sh
+++ b/scripts/e2e/features/15-avro-gate.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Feature: Avro processing gate — with MASKURA_ENABLE_AVRO unset (the shared
+# e2e boot), an Avro-content PUT must be rejected before the body is polled.
+# The positive Avro round trip needs MASKURA_ENABLE_AVRO=true plus OCF
+# fixtures + an Avro codec to assert on, so it stays a separate future harness.
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
+begin_feature "Avro processing gate (disabled by default)"
+
+printf 'this body never needs to be a valid Avro OCF\n' > "$E2E_TMP/15-avro-input.bin"
+code="$(curl -sS -o "$E2E_TMP/15-avro.out" -w '%{http_code}' \
+    -X PUT \
+    -H 'Content-Type: application/avro' \
+    --data-binary "@$E2E_TMP/15-avro-input.bin" \
+    "$E2E_GW_URL/$E2E_BUCKET/e2e-avro-gate.avro")"
+expect_status 501 "$code" "Avro PUT is rejected while MASKURA_ENABLE_AVRO is unset"
+
+# The gate rejects before polling the body; a GET of the key must 404.
+code="$(curl -sS -o /dev/null -w '%{http_code}' "$E2E_GW_URL/$E2E_BUCKET/e2e-avro-gate.avro")"
+expect_status 404 "$code" "rejected Avro object was not stored"
+
+end_feature "Avro processing gate"

--- a/scripts/e2e/features/20-redaction-roundtrip.sh
+++ b/scripts/e2e/features/20-redaction-roundtrip.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Feature: PII redaction round trip — upload the PII fixture through the
+# gateway pipeline and verify the object stored in MinIO is redacted with no
+# plaintext leakage. This is the historical core of the MinIO e2e.
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
+begin_feature "PII redaction round trip through MinIO"
+
+# Run the CLI fixture upload (demo mode, unauthenticated local gateway).
+echo "--- Running maskura test upload ---"
+MASKURA_GATEWAY_URL="$E2E_GW_URL" "$E2E_MASKURA_BIN" test upload
+
+# Read the stored object straight out of MinIO (bypassing the gateway).
+echo "--- Reading stored object from MinIO ---"
+docker run --rm -i --network host -v "$E2E_MC_CONF:/root/.mc" "$E2E_MC_IMAGE" --no-color \
+    alias set local http://localhost:9000 minioadmin minioadmin >/dev/null
+docker run --rm -i --network host -v "$E2E_MC_CONF:/root/.mc" "$E2E_MC_IMAGE" --no-color \
+    cat "local/$E2E_BUCKET/test-upload.txt" > "$E2E_TMP/20-readback.txt" 2>"$E2E_TMP/20-readback.err" || {
+    cat "$E2E_TMP/20-readback.err" >&2
+    fail "mc cat could not read local/$E2E_BUCKET/test-upload.txt from MinIO"
+}
+
+for marker in "REDACTED_EMAIL" "REDACTED_SSN" "REDACTED_CARD"; do
+    if grep -q "\[$marker\]" "$E2E_TMP/20-readback.txt"; then
+        pass "[$marker] present in the stored object"
+    else
+        fail "[$marker] missing from the stored object"
+    fi
+done
+
+assert_absent "$E2E_TMP/20-readback.txt" "jane.doe@example.com" "original email absent from the stored object"
+assert_absent "$E2E_TMP/20-readback.txt" "4111111111111111" "original card absent from the stored object"
+
+end_feature "PII redaction round trip"

--- a/scripts/e2e/features/25-strict-auth-denial.sh
+++ b/scripts/e2e/features/25-strict-auth-denial.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Feature: strict auth enforcement (no demo fallback).
+#
+# The shared e2e gateway runs AUTH_DISABLED=true, where unauthenticated and
+# unresolvable-credential requests are allowed as the demo user — so key
+# expiry/revocation rejection cannot be observed there. This feature boots a
+# second, isolated gateway WITHOUT AUTH_DISABLED against an empty in-memory
+# keystore and proves the data plane and dashboard refuse unauthenticated
+# access (HTTP 403/401) instead of silently falling back. It is still fully
+# local/CI: no Supabase, no Postgres, no secrets.
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
+begin_feature "Strict auth enforcement (no demo fallback)"
+
+if [ -z "${MASKURA_STRICT_GW_PORT:-}" ]; then
+    MASKURA_STRICT_GW_PORT=9011
+fi
+STRICT_URL="http://127.0.0.1:$MASKURA_STRICT_GW_PORT"
+STRICT_TMP="$(mktemp -d "${TMPDIR:-/tmp}/maskura-e2e-strict-${E2E_RUN_ID}.XXXXXX")"
+STRICT_LOG="$STRICT_TMP/gateway.log"
+STRICT_PID=""
+
+cleanup_strict() {
+    if [ -n "$STRICT_PID" ]; then
+        kill "$STRICT_PID" 2>/dev/null || true
+        wait "$STRICT_PID" 2>/dev/null || true
+    fi
+    rm -rf "$STRICT_TMP"
+}
+trap cleanup_strict EXIT
+
+echo "--- Starting strict gateway (AUTH_DISABLED unset, empty in-memory keystore) on :$MASKURA_STRICT_GW_PORT ---"
+S3_ENDPOINT=http://127.0.0.1:9000 \
+S3_ACCESS_KEY_ID=minioadmin \
+S3_SECRET_ACCESS_KEY=minioadmin \
+S3_REGION=us-east-1 \
+MASKURA_SINGLE_TENANT=true \
+LISTEN_ADDR="127.0.0.1:$MASKURA_STRICT_GW_PORT" \
+MASKURA_FILTER_COMPONENT="$E2E_COMPONENT" \
+"$E2E_GW_BIN" > "$STRICT_LOG" 2>&1 &
+STRICT_PID=$!
+
+ok=0
+for _ in $(seq 1 30); do
+    if curl -sf "$STRICT_URL/health" >/dev/null 2>&1; then
+        ok=1
+        break
+    fi
+    sleep 1
+done
+if [ "$ok" -ne 1 ]; then
+    tail -20 "$STRICT_LOG" >&2 || true
+    fail "strict gateway did not become healthy"
+    end_feature "Strict auth enforcement"
+fi
+pass "strict gateway is healthy (booted without AUTH_DISABLED)"
+
+# Dashboard key API requires a real user identity.
+code="$(curl -sS -o "$E2E_TMP/25-keys.json" -w '%{http_code}' "$STRICT_URL/dashboard/api/keys")"
+expect_status 401 "$code" "GET /dashboard/api/keys without a session"
+
+# Data-plane S3 requests without credentials are denied, not demo-user.
+code="$(curl -sS -o "$E2E_TMP/25-put.out" -w '%{http_code}' \
+    -X PUT -H 'Content-Type: text/plain' \
+    --data-binary 'deny me' \
+    "$STRICT_URL/$E2E_BUCKET/denied.txt")"
+expect_status 403 "$code" "unauthenticated S3 PUT is denied"
+
+code="$(curl -sS -o "$E2E_TMP/25-list.out" -w '%{http_code}' "$STRICT_URL/$E2E_BUCKET")"
+expect_status 403 "$code" "unauthenticated S3 bucket listing is denied"
+
+code="$(curl -sS -o "$E2E_TMP/25-get.out" -w '%{http_code}' "$STRICT_URL/$E2E_BUCKET/denied.txt")"
+expect_status 403 "$code" "unauthenticated S3 GET is denied"
+
+end_feature "Strict auth enforcement"

--- a/scripts/e2e/features/30-keys-s3-lifecycle.sh
+++ b/scripts/e2e/features/30-keys-s3-lifecycle.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Feature: API-key lifecycle + authenticated S3 data plane.
+#
+# Exercises previously untested public paths: GET/DELETE /dashboard/api/keys
+# happy paths, header-authenticated PUT/HEAD/GET/DELETE on the S3 data plane,
+# and ListObjects v1 + v2 forwarded to a real S3 backend (MinIO).
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
+begin_feature "API-key CRUD + authenticated S3 object lifecycle against MinIO"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    fail "python3 is required to parse dashboard API responses"
+    end_feature "API-key CRUD + S3 lifecycle"
+fi
+
+OBJECT_KEY="e2e-lifecycle/object.txt"
+PAYLOAD="hello from the maskura e2e lifecycle
+"
+printf '%s' "$PAYLOAD" > "$E2E_TMP/30-payload.txt"
+
+# 1. Create an API key through the dashboard API (demo user in local mode).
+code="$(curl -sS -o "$E2E_TMP/30-key.json" -w '%{http_code}' \
+    -X POST -H 'Content-Type: application/json' \
+    -d '{"label":"e2e-lifecycle"}' \
+    "$E2E_GW_URL/dashboard/api/keys")"
+expect_status 200 "$code" "POST /dashboard/api/keys"
+KEY_ID="$(json_field "$E2E_TMP/30-key.json" '["key_id"]')"
+SECRET="$(json_field "$E2E_TMP/30-key.json" '["secret"]')"
+case "$KEY_ID" in
+    s4_*) pass "created key id uses the s4_ prefix ($KEY_ID)" ;;
+    *) fail "created key id '$KEY_ID' does not start with s4_" ;;
+esac
+case "$SECRET" in
+    s4s_*) pass "created key secret uses the s4s_ prefix" ;;
+    *) fail "created key secret does not start with s4s_" ;;
+esac
+
+# 2. GET /dashboard/api/keys lists the new key (without the secret).
+code="$(curl -sS -o "$E2E_TMP/30-keys.json" -w '%{http_code}' "$E2E_GW_URL/dashboard/api/keys")"
+expect_status 200 "$code" "GET /dashboard/api/keys"
+assert_contains "$E2E_TMP/30-keys.json" "$KEY_ID" "created key appears in the key list"
+
+# 3. Authenticated PUT through the S3 data plane.
+code="$(curl -sS -o "$E2E_TMP/30-put.out" -w '%{http_code}' \
+    -X PUT \
+    -H "x-maskura-access-key: $KEY_ID" \
+    -H "x-maskura-secret-key: $SECRET" \
+    -H 'Content-Type: text/plain' \
+    --data-binary "@$E2E_TMP/30-payload.txt" \
+    "$E2E_GW_URL/$E2E_BUCKET/$OBJECT_KEY")"
+expect_status 200 "$code" "authenticated PUT /$E2E_BUCKET/$OBJECT_KEY"
+
+# 4. HEAD returns the object metadata.
+code="$(curl -sS -o /dev/null -I -w '%{http_code}' \
+    -H "x-maskura-access-key: $KEY_ID" \
+    -H "x-maskura-secret-key: $SECRET" \
+    "$E2E_GW_URL/$E2E_BUCKET/$OBJECT_KEY")"
+expect_status 200 "$code" "HEAD /$E2E_BUCKET/$OBJECT_KEY"
+
+# 5. GET returns the exact stored bytes.
+code="$(curl -sS -o "$E2E_TMP/30-get.out" -w '%{http_code}' \
+    -H "x-maskura-access-key: $KEY_ID" \
+    -H "x-maskura-secret-key: $SECRET" \
+    "$E2E_GW_URL/$E2E_BUCKET/$OBJECT_KEY")"
+expect_status 200 "$code" "GET /$E2E_BUCKET/$OBJECT_KEY"
+if cmp -s "$E2E_TMP/30-payload.txt" "$E2E_TMP/30-get.out"; then
+    pass "GET body is byte-identical to the uploaded payload"
+else
+    fail "GET body differs from the uploaded payload"
+fi
+
+# 6. ListObjects v2 + v1 forwarded to the MinIO backend exposes the object.
+code="$(curl -sS -o "$E2E_TMP/30-list-v2.xml" -w '%{http_code}' \
+    -H "x-maskura-access-key: $KEY_ID" \
+    -H "x-maskura-secret-key: $SECRET" \
+    "$E2E_GW_URL/$E2E_BUCKET?list-type=2")"
+expect_status 200 "$code" "ListObjectsV2 via the S3 backend"
+assert_contains "$E2E_TMP/30-list-v2.xml" "<Key>$OBJECT_KEY</Key>" "ListObjectsV2 lists the uploaded object"
+
+code="$(curl -sS -o "$E2E_TMP/30-list-v1.xml" -w '%{http_code}' \
+    -H "x-maskura-access-key: $KEY_ID" \
+    -H "x-maskura-secret-key: $SECRET" \
+    "$E2E_GW_URL/$E2E_BUCKET")"
+expect_status 200 "$code" "ListObjectsV1 via the S3 backend"
+assert_contains "$E2E_TMP/30-list-v1.xml" "<Key>$OBJECT_KEY</Key>" "ListObjectsV1 lists the uploaded object"
+
+# 7. DELETE the object, then confirm it is gone.
+code="$(curl -sS -o /dev/null -X DELETE -w '%{http_code}' \
+    -H "x-maskura-access-key: $KEY_ID" \
+    -H "x-maskura-secret-key: $SECRET" \
+    "$E2E_GW_URL/$E2E_BUCKET/$OBJECT_KEY")"
+expect_status 204 "$code" "DELETE /$E2E_BUCKET/$OBJECT_KEY"
+
+code="$(curl -sS -o "$E2E_TMP/30-gone.out" -w '%{http_code}' \
+    -H "x-maskura-access-key: $KEY_ID" \
+    -H "x-maskura-secret-key: $SECRET" \
+    "$E2E_GW_URL/$E2E_BUCKET/$OBJECT_KEY")"
+expect_status 404 "$code" "GET of deleted object returns 404"
+
+# 8. Revoke the key (204), then confirm it no longer appears in the list.
+code="$(curl -sS -o /dev/null -X DELETE -w '%{http_code}' \
+    -H 'Content-Type: application/json' \
+    -d "{\"key_id\":\"$KEY_ID\"}" \
+    "$E2E_GW_URL/dashboard/api/keys")"
+expect_status 204 "$code" "DELETE /dashboard/api/keys (revoke)"
+
+code="$(curl -sS -o "$E2E_TMP/30-keys-after.json" -w '%{http_code}' "$E2E_GW_URL/dashboard/api/keys")"
+expect_status 200 "$code" "GET /dashboard/api/keys after revoke"
+assert_absent "$E2E_TMP/30-keys-after.json" "$KEY_ID" "revoked key is absent from the key list"
+
+end_feature "API-key CRUD + S3 lifecycle"

--- a/scripts/e2e/features/40-plugin-admin-http.sh
+++ b/scripts/e2e/features/40-plugin-admin-http.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Feature: plugin-management HTTP surface (local admin mode, AUTH_DISABLED).
+#
+# Previously only mounted-without-assertion: imports a real .wasm component,
+# lists it, enables it, reorders the catalog, and removes it. Runs last in the
+# suite because enabling an imported component can change the write pipeline
+# for subsequent features.
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib.sh"
+begin_feature "Plugin import / list / enable / reorder / remove over HTTP"
+
+if [ ! -f "$E2E_NOOP_COMPONENT" ]; then
+    fail "noop component missing at $E2E_NOOP_COMPONENT (run scripts/build-filters.sh first)"
+    end_feature "Plugin management over HTTP"
+fi
+
+PLUGIN_NAME="e2e-noop-http"
+
+# 1. Import a real component (noop) under a plugin name.
+code="$(curl -sS -o "$E2E_TMP/40-import.json" -w '%{http_code}' \
+    -X POST \
+    -H "x-maskura-plugin-name: $PLUGIN_NAME" \
+    --data-binary "@$E2E_NOOP_COMPONENT" \
+    "$E2E_GW_URL/dashboard/api/plugins")"
+expect_status 201 "$code" "POST /dashboard/api/plugins (import $PLUGIN_NAME)"
+PLUGIN_ID="$(json_field "$E2E_TMP/40-import.json" '["id"]')"
+assert_contains "$E2E_TMP/40-import.json" "$PLUGIN_NAME" "import response reports the plugin name"
+
+# 2. The catalog lists the imported plugin.
+code="$(curl -sS -o "$E2E_TMP/40-plugins.json" -w '%{http_code}' "$E2E_GW_URL/dashboard/api/plugins")"
+expect_status 200 "$code" "GET /dashboard/api/plugins"
+assert_contains "$E2E_TMP/40-plugins.json" "$PLUGIN_ID" "imported plugin appears in the catalog"
+
+# 3. Enable it.
+code="$(curl -sS -o "$E2E_TMP/40-enabled.json" -w '%{http_code}' \
+    -X PUT -H 'Content-Type: application/json' \
+    -d '{"enabled":true}' \
+    "$E2E_GW_URL/dashboard/api/plugins/$PLUGIN_ID")"
+expect_status 200 "$code" "PUT /dashboard/api/plugins/$PLUGIN_ID (enable)"
+code="$(curl -sS -o "$E2E_TMP/40-plugins-after-enable.json" -w '%{http_code}' "$E2E_GW_URL/dashboard/api/plugins")"
+expect_status 200 "$code" "GET /dashboard/api/plugins after enable"
+if [ "$(python3 - "$E2E_TMP/40-plugins-after-enable.json" "$PLUGIN_ID" <<'PY'
+import json, sys
+plugins = json.load(open(sys.argv[1]))
+print("True" if any(p.get("id") == sys.argv[2] and p.get("enabled") for p in plugins) else "False")
+PY
+)" = "True" ]
+then
+    pass "imported plugin is enabled"
+else
+    fail "imported plugin is not enabled after PUT"
+fi
+
+# 4. Reorder the catalog to the current id order (no semantic change).
+python3 - "$E2E_TMP/40-plugins-after-enable.json" > "$E2E_TMP/40-order.json" <<'PY'
+import json, sys
+plugins = json.load(open(sys.argv[1]))
+print(json.dumps({"order": [p["id"] for p in plugins]}))
+PY
+code="$(curl -sS -o /dev/null -w '%{http_code}' \
+    -X PUT -H 'Content-Type: application/json' \
+    --data-binary "@$E2E_TMP/40-order.json" \
+    "$E2E_GW_URL/dashboard/api/plugins/reorder")"
+expect_status 200 "$code" "PUT /dashboard/api/plugins/reorder"
+
+# 5. Remove the imported plugin.
+code="$(curl -sS -o /dev/null -X DELETE -w '%{http_code}' \
+    "$E2E_GW_URL/dashboard/api/plugins/$PLUGIN_ID")"
+expect_status 204 "$code" "DELETE /dashboard/api/plugins/$PLUGIN_ID"
+code="$(curl -sS -o "$E2E_TMP/40-plugins-after-delete.json" -w '%{http_code}' "$E2E_GW_URL/dashboard/api/plugins")"
+expect_status 200 "$code" "GET /dashboard/api/plugins after delete"
+assert_absent "$E2E_TMP/40-plugins-after-delete.json" "$PLUGIN_ID" "removed plugin is absent from the catalog"
+
+end_feature "Plugin management over HTTP"

--- a/scripts/e2e/lib.sh
+++ b/scripts/e2e/lib.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Shared harness for the Maskura local e2e.
+#
+# Sourced by scripts/e2e-local.sh (the orchestrator that owns infrastructure
+# lifecycle) and by each scripts/e2e/features/*.sh feature script. This file
+# only defines the booted-gateway contract and assertion helpers — it never
+# boots or tears down infrastructure by itself.
+#
+# A feature script may be run directly against an already-booted gateway
+# (same contract: AUTH_DISABLED=true, MinIO on :9000, isolated keys file);
+# the orchestrator boots that environment and then runs every feature.
+
+set -euo pipefail
+
+E2E_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+if [ -z "${E2E_RUN_ID:-}" ]; then
+    E2E_RUN_ID="${GITHUB_RUN_ID:-$$}"
+    export E2E_RUN_ID
+fi
+export E2E_ROOT
+
+# Booted-gateway contract (exported so feature subprocesses inherit it).
+: "${MASKURA_E2E_GW_PORT:=9010}"
+export MASKURA_E2E_GW_PORT
+E2E_GW_URL="http://127.0.0.1:$MASKURA_E2E_GW_PORT"
+E2E_BUCKET="s4-local"
+E2E_GW_BIN="$E2E_ROOT/target/debug/s4-gateway"
+E2E_MASKURA_BIN="$E2E_ROOT/target/debug/maskura"
+E2E_COMPONENT="$E2E_ROOT/target/components/pii-default.component.wasm"
+E2E_NOOP_COMPONENT="$E2E_ROOT/target/components/noop.component.wasm"
+E2E_COMPOSE_PROJECT="maskura-e2e-${E2E_RUN_ID}"
+E2E_COMPOSE=(docker compose --project-name "$E2E_COMPOSE_PROJECT" -f "$E2E_ROOT/local/docker-compose.yml")
+E2E_MC_IMAGE="minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"
+E2E_MC_CONF="${E2E_COMPOSE_PROJECT}-mc"
+export E2E_GW_URL E2E_BUCKET E2E_GW_BIN E2E_MASKURA_BIN E2E_COMPONENT E2E_NOOP_COMPONENT
+export E2E_COMPOSE_PROJECT E2E_MC_IMAGE E2E_MC_CONF
+
+# One scratch area shared by the orchestrator and every feature so nothing
+# is left behind; the orchestrator's EXIT trap removes it.
+if [ -z "${E2E_KEYS_DIR:-}" ]; then
+    E2E_KEYS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/maskura-e2e-keys-${E2E_RUN_ID}.XXXXXX")"
+    export E2E_KEYS_DIR
+fi
+E2E_KEYS_FILE="$E2E_KEYS_DIR/keys.json"
+E2E_GW_LOG="$E2E_KEYS_DIR/gateway.log"
+E2E_TMP="$E2E_KEYS_DIR/http"
+mkdir -p "$E2E_TMP"
+export E2E_KEYS_FILE E2E_GW_LOG E2E_TMP
+
+pass() {
+    printf '    PASS: %s\n' "$1"
+}
+
+fail() {
+    printf '    FAIL: %s\n' "$1" >&2
+    E2E_FEATURE_FAILED=1
+}
+
+begin_feature() {
+    E2E_FEATURE_FAILED=0
+    echo "=== $1 ==="
+}
+
+end_feature() {
+    local name="$1"
+    if [ "${E2E_FEATURE_FAILED:-0}" -eq 0 ]; then
+        echo "--- $name: passed ---"
+    else
+        echo "--- $name: FAILED ---" >&2
+    fi
+    exit "${E2E_FEATURE_FAILED:-0}"
+}
+
+# Require an expected HTTP status; body of the response is left on stdin's file.
+expect_status() { # expected_code actual_code label
+    if [ "$1" = "$2" ]; then
+        pass "$3 -> HTTP $2"
+    else
+        fail "$3 -> expected HTTP $1, got $2"
+    fi
+}
+
+# assert_contains FILE NEEDLE LABEL
+assert_contains() {
+    if grep -qF -- "$2" "$1"; then
+        pass "$3"
+    else
+        fail "$3 (did not find '$2' in $1)"
+    fi
+}
+
+# assert_absent FILE NEEDLE LABEL
+assert_absent() {
+    if grep -qF -- "$2" "$1"; then
+        fail "$3 (found forbidden '$2' in $1)"
+    else
+        pass "$3"
+    fi
+}
+
+# json_field FILE <python-suffix> — print a JSON field, e.g.:
+#   json_field "$f" '["key_id"]'
+json_field() {
+    python3 - "$1" "$2" <<'PY'
+import json, sys
+with open(sys.argv[1]) as fh:
+    doc = json.load(fh)
+print(eval("doc" + sys.argv[2]))
+PY
+}

--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -12,7 +12,7 @@ GATEWAY_PID=""
 # Isolate the local-mode key store from the user's real config directory so a
 # stale `~/Library/Application Support/s4/keys.json` (DEK wrapped by an earlier
 # ephemeral/secret key) can never abort gateway startup.
-KEYS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/s4-sdkgen-keys.XXXXXX")"
+KEYS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/maskura-sdkgen-keys.XXXXXX")"
 KEYS_FILE="$KEYS_DIR/keys.json"
 
 cleanup() {

--- a/scripts/release-image-smoke.sh
+++ b/scripts/release-image-smoke.sh
@@ -8,15 +8,15 @@ fi
 
 IMAGE_REF="$1"
 RUN_ID="${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-0}-${RANDOM}"
-NETWORK="s4-release-smoke-${RUN_ID}"
-MINIO_NAME="s4-minio-${RUN_ID}"
-POSTGRES_NAME="s4-postgres-${RUN_ID}"
-GATEWAY_NAME="s4-gateway-${RUN_ID}"
+NETWORK="maskura-release-smoke-${RUN_ID}"
+MINIO_NAME="maskura-minio-${RUN_ID}"
+POSTGRES_NAME="maskura-postgres-${RUN_ID}"
+GATEWAY_NAME="maskura-gateway-${RUN_ID}"
 MINIO_IMAGE="minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
 POSTGRES_IMAGE="postgres:17-trixie@sha256:e38411452a464af89e5adadb8d223bf53b898d47d6ef918b2d58c08707350449"
 MC_IMAGE="minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"
-MC_CONF="s4-release-smoke-mc-${RUN_ID}"
-GATEWAY_PORT="${S4_RELEASE_SMOKE_PORT:-18080}"
+MC_CONF="maskura-release-smoke-mc-${RUN_ID}"
+GATEWAY_PORT="${MASKURA_RELEASE_SMOKE_PORT:-18080}"
 
 cleanup() {
   docker rm -f "$GATEWAY_NAME" "$MINIO_NAME" "$POSTGRES_NAME" >/dev/null 2>&1 || true
@@ -50,11 +50,11 @@ fi
 # Release builds have no in-memory operation journal, so the gateway needs a
 # Postgres for the durable journal the streaming S3 sink requires.
 docker run -d --name "$POSTGRES_NAME" --network "$NETWORK" \
-  -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=s4 \
+  -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=maskura \
   "$POSTGRES_IMAGE" >/dev/null
 pg_ready=0
 for _ in $(seq 1 30); do
-  if docker exec "$POSTGRES_NAME" pg_isready -U postgres -d s4 >/dev/null 2>&1; then
+  if docker exec "$POSTGRES_NAME" pg_isready -U postgres -d maskura >/dev/null 2>&1; then
     pg_ready=1
     break
   fi
@@ -69,14 +69,14 @@ fi
 docker run --rm --network "$NETWORK" -v "$MC_CONF:/root/.mc" "$MC_IMAGE" --no-color \
   alias set local "http://${MINIO_NAME}:9000" minioadmin minioadmin >/dev/null
 docker run --rm --network "$NETWORK" -v "$MC_CONF:/root/.mc" "$MC_IMAGE" --no-color \
-  mb "local/s4-release-smoke" --ignore-existing >/dev/null
+  mb "local/maskura-release-smoke" --ignore-existing >/dev/null
 
 docker run -d --name "$GATEWAY_NAME" --network "$NETWORK" \
   -p "127.0.0.1:${GATEWAY_PORT}:8080" \
   -e AUTH_DISABLED=true \
   -e MASKURA_STREAMING_WRITE_MODE=all \
   -e MASKURA_STREAMING_S3_PROVIDER=minio \
-  -e DATABASE_URL="postgres://postgres:postgres@${POSTGRES_NAME}:5432/s4" \
+  -e DATABASE_URL="postgres://postgres:postgres@${POSTGRES_NAME}:5432/maskura" \
   -e MASKURA_KEYS_FILE=/tmp/keys.json \
   -e S3_ENDPOINT="http://${MINIO_NAME}:9000" \
   -e S3_ACCESS_KEY_ID=minioadmin \
@@ -106,10 +106,10 @@ curl --fail --silent --show-error \
   -X PUT \
   -H 'Content-Type: text/plain' \
   --data-binary "$INPUT" \
-  "http://127.0.0.1:${GATEWAY_PORT}/s4-release-smoke/object.txt" >/dev/null
+  "http://127.0.0.1:${GATEWAY_PORT}/maskura-release-smoke/object.txt" >/dev/null
 
 READBACK="$(docker run --rm --network "$NETWORK" -v "$MC_CONF:/root/.mc" "$MC_IMAGE" --no-color \
-  cat 'local/s4-release-smoke/object.txt')"
+  cat 'local/maskura-release-smoke/object.txt')"
 case "$READBACK" in
   *'[REDACTED_EMAIL]'*'[REDACTED_CARD]'*) ;;
   *)


### PR DESCRIPTION
## Summary

Restructures the MinIO local e2e into a shared harness plus one script per discrete feature, and applies the feasible internal `s4` → `maskura` renames. CI entry point and semantics are unchanged (`just e2e` / `ci.yml` call the same `scripts/e2e-local.sh`; exit 0 only when every feature passes).

### E2E restructure

- `scripts/e2e/lib.sh` — shared boot contract and assertion helpers (`expect_status`, `assert_contains`, JSON extraction).
- `scripts/e2e-local.sh` — thin orchestrator: boots MinIO + gateway once (reuses a healthy MinIO already on `:9000`), runs every feature script, aggregates PASS/FAIL, cleans up on exit.
- `scripts/e2e/features/` — one discrete feature per script:
  - `10-http-surface` — `/health`, dashboard HTML vs S3 `ListBuckets` branch, `/openapi.json` (3.1 + dashboard schemas), `/docs` Swagger UI, legacy 410 tombstones
  - `15-avro-gate` — Avro-content PUT rejected while `MASKURA_ENABLE_AVRO` is unset
  - `20-redaction-roundtrip` — the historic core: PII redaction verified by reading the stored object back from MinIO
  - `25-strict-auth-denial` — second, strict gateway (no `AUTH_DISABLED`, empty keystore): unauthenticated S3/dashboard requests denied (403/401), no demo fallback
  - `30-keys-s3-lifecycle` — dashboard key CRUD happy paths + authenticated S3 PUT/HEAD/GET/ListObjects v1+v2/DELETE against MinIO
  - `40-plugin-admin-http` — plugin import/list/enable/reorder/remove over the HTTP admin routes
- `docs/e2e.md` documents the suite, each feature, CI usage, how to add features, and the scenarios intentionally deferred to separate harnesses.

This adds coverage for previously untested public paths (S3-backend listing, dashboard key list/delete happy paths, plugin HTTP CRUD, OpenAPI/docs serving, strict auth denial, Avro gate).

### Naming

Internal/cosmetic `s4` → `maskura` renames only: Wasm thread names, AWS credential-provider labels, spool/temp prefixes, test-only env vars (`MASKURA_SOAK_ITERATIONS`, `MASKURA_RUN_EXTERNAL_CLIENT_INTEROP`, `MASKURA_WASI_ADAPTER`, etc.), dashboard localStorage/theme tokens, script/CI container and Postgres DB names, test hosts/fixtures, and code doc comments.

All documented compatibility contracts are preserved unchanged: API-key prefixes (`s4_`/`s4s_`/`s4m_`), `S4_*`/`x-s4-*` aliases, WIT `s4:*` worlds, `~/.config/s4` paths, SDK `s4_client`/`S4Client`, crate/binary names (`s4-gateway`, `s4ctl`, `s4-mcp`), stored `x-amz-meta-s4-*` metadata, repo URLs, and persistence/derivation domains.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` green (filters built via `scripts/build-filters.sh`)
- Full local e2e suite (`bash scripts/e2e-local.sh`) passes all six features; CI workflows still invoke the same script
