### PR TITLE
fix(ci): make image-publicity failure non-blocking in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
           python3 sdks/package-release.py --output-dir dist
 
       - name: Make canonical and legacy images public
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
The 'Make canonical and legacy images public' step 404s with GITHUB_TOKEN for org-scoped container packages, which failed the v0.3.8 release job and skipped the GitHub Release step.

Make it best-effort (continue-on-error) so the release job always proceeds to create the GitHub Release. Image visibility can be fixed separately with an appropriately scoped token.