### PR TITLE
docs: publish mdBook docs site and refresh README quickstart

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+name: Docs
+
+# Build the mdBook site in docs/ and publish it to GitHub Pages.
+# Note: Pages must be enabled with "Source: GitHub Actions" in the repo
+# settings before the deploy job can succeed.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: latest
+      - name: Build docs
+        run: mdbook build docs
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/output
+
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 *.swo
 .DS_Store
 *.proptest-regressions
+/docs/output/

--- a/README.md
+++ b/README.md
@@ -32,12 +32,55 @@ emails / SSNs / credit cards), `email-detect`, `ssn-detect`, `card-detect`,
 `envelope-encrypt` (per-field RSA-OAEP / AES-256-GCM), `stable-encrypt`
 (deterministic encryption).
 
-## Quickstart (local-only)
+## Contents
 
-No cloud account, no database, no repo clone — everything runs on your machine:
+- [Try it in 60 seconds](#try-it-in-60-seconds)
+- [Install the CLI (optional)](#install-the-cli-optional)
+- [Compatibility](#compatibility)
+- [Run your own plugin](#run-your-own-plugin)
+- [Usage examples](#usage-examples)
+- [How it works](#how-it-works)
+- [Development](#development)
+- [Security](#security)
+- [Documentation](#documentation)
+- [LLM agents](#llm-agents)
+- [License](#license)
+
+## Try it in 60 seconds
+
+No cloud account, no database, no repo clone — run the published image and open
+the demo dashboard:
 
 ```bash
-cargo install --git https://github.com/231self/S4 --bin maskura s4ctl
+docker run --rm -p 127.0.0.1:8791:8080 -e AUTH_DISABLED=true \
+  ghcr.io/231self/maskura/maskura:latest
+# open http://localhost:8791 → demo dashboard (no sign-up)
+
+# Grab an API key from the dashboard's "API Keys" tab, then either follow its
+# "Quick Start" (the snippets auto-fill your port) or run:
+echo "jane.doe@example.com 4111111111111111" > data.jsonl
+curl -X PUT http://localhost:8791/ingest/data.jsonl \
+  -H "x-maskura-access-key: YOUR_KEY_ID" \
+  -H "x-maskura-secret-key: YOUR_SECRET" \
+  --data-binary @data.jsonl
+curl http://localhost:8791/ingest/data.jsonl \
+  -H "x-maskura-access-key: YOUR_KEY_ID" \
+  -H "x-maskura-secret-key: YOUR_SECRET"
+```
+
+The container listens on `8080`; `8791` is just the uncommon host port this
+example maps it to, so nothing already on `8080` collides. Dashboard snippets
+rewrite themselves to whatever `host:port` you open, so copy-paste works for any
+mapping.
+
+## Install the CLI (optional)
+
+Prefer the CLI? Install it with `cargo install`, or grab the prebuilt Linux
+(amd64/arm64) binaries attached to each
+[GitHub Release](https://github.com/231self/maskura/releases):
+
+```bash
+cargo install --git https://github.com/231self/maskura --bin maskura s4ctl
 maskura local init                  # runs the published gateway image (Docker)
 maskura plugin list                 # the pii-default plugin is preloaded
 
@@ -52,11 +95,11 @@ maskura get ingest/data.csv --bucket s4-local
 ```
 
 `maskura local init` pulls the gateway image tagged with the CLI version
-(`ghcr.io/231self/maskura/maskura:v0.3.3` for `maskura` 0.3.3; CLI and gateway always match,
-never `:latest`) and runs it in local mode (`AUTH_DISABLED=true`, keys persisted on a
-volume, in-memory storage); it picks a free port (8080+) and binds the loopback
-interface only. `maskura local down` stops it. For durable local storage (MinIO),
-clone the repo and use `just dev-up`.
+(`ghcr.io/231self/maskura/maskura:v0.3.3` for `maskura` 0.3.3; CLI and gateway always
+match, never `:latest`) and runs it in local mode (`AUTH_DISABLED=true`, keys
+persisted on a volume, in-memory storage); it picks a free port (8080+) and binds
+the loopback interface only. `maskura local down` stops it. For durable local
+storage (MinIO), clone the repo and use `just dev-up`.
 
 ## Compatibility
 
@@ -241,14 +284,16 @@ fail-closed guarantees on the streaming data plane (see
 responsibilities and non-guarantees).
 
 Found a vulnerability? Report it **privately** — via
-[Maskura private vulnerability reporting](https://github.com/231self/S4/security/advisories/new)
+[Maskura private vulnerability reporting](https://github.com/231self/maskura/security/advisories/new)
 or security@231self.com — and never through a
-[public issue](https://github.com/231self/S4/issues/new/choose). See
+[public issue](https://github.com/231self/maskura/issues/new/choose). See
 [SECURITY.md](SECURITY.md) for the supported-version policy,
 response timeline, and what to include in a report.
 
 ## Documentation
 
+- **Docs site** — the same docs, rendered:
+  <https://231self.github.io/maskura/>.
 - `examples/` — runnable end-to-end demos (B2 encryption round-trip).
 - `docs/plugins.md` — create and consume your own plugins.
 - `docs/security.md` — the security model of the gateway.

--- a/crates/gateway/static/dashboard.html
+++ b/crates/gateway/static/dashboard.html
@@ -1237,6 +1237,10 @@ if (document.getElementById('flowCanvas')) {
   startFlow();
 }
 
+document.querySelectorAll('.code-block').forEach(function(el) {
+  el.textContent = el.textContent.replaceAll('http://localhost:9000', window.location.origin);
+});
+
 // Boot
 (function() {
   /*BOOT*/

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,19 @@
+# Summary
+
+- [Home](index.md)
+- [Plugins](plugins.md)
+- [Avro gate](avro.md)
+- [Binary adapters](binary-adapters.md)
+- [MCP](mcp.md)
+- [End-to-end suite](e2e.md)
+- [Security](security.md)
+
+# Architecture Decision Records
+
+- [ADR 0001: Component Model and WIT](adr/0001-component-model-wit.md)
+- [ADR 0002: Nitro Enclaves and TLS](adr/0002-nitro-enclaves.md)
+- [ADR 0003: Policy Manifests](adr/0003-canonical-policy-manifests.md)
+- [ADR 0004: Postgres as Source of Truth](adr/0004-postgres-relational-source-of-truth.md)
+- [ADR 0005: Record Boundaries vs Chunks](adr/0005-record-boundaries-vs-transport-chunks.md)
+- [ADR 0006: Dev Attestation](adr/0006-dev-attestation-never-production.md)
+- [ADR 0007: Fresh Store Per Object](adr/0007-fresh-store-per-object.md)

--- a/docs/binary-adapters.md
+++ b/docs/binary-adapters.md
@@ -7,7 +7,7 @@ format-specific logical type must be converted to a Maskura-supported type befor
 typed transform, then reconstructed for output.
 
 The contract is `s4:binary-reductor@0.1.0` in
-[`wit/s4-binary-reductor/world.wit`](../wit/s4-binary-reductor/world.wit).
+[`wit/s4-binary-reductor/world.wit`](https://github.com/231self/maskura/blob/main/wit/s4-binary-reductor/world.wit).
 
 ## Lifecycle
 
@@ -30,7 +30,7 @@ do not reuse plans across component versions.
 
 Schema and value inputs are canonical JSON representations of the bounded Maskura
 IR. The definitive Rust types and validators are in
-[`crates/gateway/src/binary_ir.rs`](../crates/gateway/src/binary_ir.rs).
+[`crates/gateway/src/binary_ir.rs`](https://github.com/231self/maskura/blob/main/crates/gateway/src/binary_ir.rs).
 
 - A nullable Avro-like field is represented by `"nullable": true`, not an
   arbitrary union.
@@ -41,7 +41,7 @@ IR. The definitive Rust types and validators are in
   best-effort result.
 
 The test fixture in
-[`filters/test-binary-reductor/src/lib.rs`](../filters/test-binary-reductor/src/lib.rs)
+[`filters/test-binary-reductor/src/lib.rs`](https://github.com/231self/maskura/blob/main/filters/test-binary-reductor/src/lib.rs)
 is the smallest complete example. It reduces `vendor.money` from a custom value
 to a string and restores it after the typed transform.
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,11 @@
+[book]
+title = "Maskura"
+authors = ["231self"]
+language = "en"
+src = "."
+
+[build]
+build-dir = "output"
+
+[output.html]
+git-repository-url = "https://github.com/231self/maskura"

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -89,8 +89,8 @@ are deliberately not part of this suite yet. Each is a natural future
 
 - **Positive Avro round trip and envelope/stable field encryption** —
   need `MASKURA_ENABLE_AVRO=true`, an authenticated public key, OCF fixtures,
-  and an Avro codec (e.g. `fastavro`) on the runner to assert typed output.
-  See `docs/avro.md`.
+   and an Avro codec (e.g. `fastavro`) on the runner to assert typed output.
+   See [Avro OCF support](avro.md).
 - **Managed service storage** — needs a multi-backend boot with
   `S4_SERVICE_BUCKETS` and no `S3_ENDPOINT` (the two are mutually exclusive at
   startup).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+# Maskura docs
+
+Maskura is an S3-compatible gateway that runs your WebAssembly plugins over every
+object in transit. Point any S3 SDK, CLI, or tool at Maskura; each object passes
+through your plugin pipeline — filter, redact, encrypt, convert, validate, route —
+and the result is forwarded to any S3-compatible storage backend.
+
+The quickest way to see it working is the README's
+[60-second Docker demo](https://github.com/231self/maskura#try-it-in-60-seconds):
+run the published image with `AUTH_DISABLED=true`, open the demo dashboard, and
+push a file through the pipeline. This site is the deeper documentation:
+
+- **[Plugins](plugins.md)** — write, load, and compose your own Wasm filters.
+- **[Avro gate](avro.md)** — the typed Avro OCF processing path.
+- **[Binary adapters](binary-adapters.md)** — schema-aware binary reductors for
+  typed formats.
+- **[MCP](mcp.md)** — the local stdio MCP server for agent clients.
+- **[End-to-end suite](e2e.md)** — the no-secrets local e2e harness.
+- **[Security](security.md)** — the security model, trust boundaries, and
+  deployment responsibilities.
+- **[Architecture Decision Records](adr/0001-component-model-wit.md)** — the
+  decisions behind the design.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -18,11 +18,11 @@ apply.
 Build and install from the public source:
 
 ```bash
-cargo install --git https://github.com/231self/S4 --bin maskura-mcp s4-mcp
+cargo install --git https://github.com/231self/maskura --bin maskura-mcp s4-mcp
 ```
 
 Linux x86_64 and arm64 binaries are also attached to each
-[Maskura GitHub release](https://github.com/231self/S4/releases) as
+[Maskura GitHub release](https://github.com/231self/maskura/releases) as
 `maskura-mcp-linux-amd64` and `maskura-mcp-linux-arm64`. The `s4-mcp` binary
 and `s4_*` tools remain permanent compatibility aliases.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -8,7 +8,7 @@ filter, then encrypt, then convert.
 ## The interface
 
 Plugins implement one world, `s4:filter`
-([wit/s4-filter/world.wit](../wit/s4-filter/world.wit)):
+([`wit/s4-filter/world.wit`](https://github.com/231self/maskura/blob/main/wit/s4-filter/world.wit)):
 
 | Function | Called | Purpose |
 |---|---|---|
@@ -110,7 +110,8 @@ The default local setup preloads `pii-default` via `MASKURA_FILTER_COMPONENT`.
   [Binary adapters](binary-adapters.md).
 - Filters shipped in-tree: `noop` (pass-through baseline), `pii-default`,
   `email-detect`, `ssn-detect`, `card-detect`, `envelope-encrypt`, `stable-encrypt`.
-- The original WIT design is recorded in `docs/adr/0001-component-model-wit.md`.
+- The original WIT design is recorded in
+  [ADR-0001: component model and WIT](adr/0001-component-model-wit.md).
 
 ## Hosted workspaces (`maskura hosted`)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,7 +7,8 @@ what the trust boundaries are, what a production deployment must configure, and
 what Maskura explicitly does **not** guarantee. Anything not described here is not a
 guarantee.
 
-For the vulnerability reporting process, see [SECURITY.md](../SECURITY.md).
+For the vulnerability reporting process, see
+[SECURITY.md](https://github.com/231self/maskura/blob/main/SECURITY.md).
 
 ---
 


### PR DESCRIPTION
## What

- **README**: Docker demo becomes the headline quickstart (`127.0.0.1:8791:8080`,
  demo dashboard with `AUTH_DISABLED=true`), adds a Contents TOC, and moves
  `cargo install` / prebuilt binaries into an optional "Install the CLI" section.
  Remaining `github.com/231self/S4` URLs normalized to `maskura`.
- **Dashboard demo-port fix**: the Quick Start and connect/SDK snippets hardcoded
  `http://localhost:9000` (the MinIO port) while the gateway listens on `8080`.
  The page now rewrites every `.code-block` snippet to `window.location.origin`,
  so copy-paste always matches whatever host:port the user actually mapped.
- **Docs site**: adds mdBook under `docs/` (`book.toml`, `SUMMARY.md`,
  `index.md`) covering the existing plugins/avro/binary-adapters/mcp/e2e/security
  chapters plus all seven ADRs. Out-of-tree links now point at blob URLs on
  `main` so they render on the site.
- **CI**: new `.github/workflows/docs.yml` builds the book and deploys it to
  GitHub Pages; `/docs/output/` is gitignored.

## After merge (manual step required)

Enable **Settings → Pages → Source: GitHub Actions** (owner action). The
`deploy` job will fail until Pages is configured that way. The site will be at
`https://231self.github.io/maskura/`.

## Validation

- `mdbook build docs` succeeds locally; `docs/output/index.html` and every
  SUMMARY chapter/ADR render.
- `cargo check -p s4-gateway` passes (dashboard is embedded via `include_str!`).
- Local demo run of the built gateway on port 8791:
  - `GET /` serves the new substitution JS; simulated browser rewrite turns the
    Quick Start curl into `http://127.0.0.1:8791/ingest/...`.
  - PUT/GET round trip returns `[REDACTED_EMAIL] [REDACTED_CARD]`.
- `cargo fmt --check` clean.
