### PR TITLE
chore: add OSS contribution tooling and governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/231self/maskura/security/advisories/new
+    about: Report security issues privately, not as a public issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+# Pull request template
+
+Thank you for contributing to Maskura. Fill in what applies; delete the
+sections that do not.
+
+## Summary
+
+<!-- What this PR changes and why, in a few sentences. -->
+
+## Motivation / related issue
+
+<!-- "Closes #NN" when an issue exists. -->
+
+## Test plan
+
+- [ ] `just check` (fmt + clippy + build filters + tests)
+- [ ] `just e2e` (if gateway/data-plane behavior changed)
+- [ ] `cargo check -p s4-gateway` (dashboard/HTML changes — embedded via include_str!)
+- [ ] `mdbook build docs` (if `docs/` chapters changed)
+
+## Docs & UI
+
+<!-- README/docs changes, dashboard snippets affected, screenshots if any. -->
+
+## Checklist
+
+- [ ] Committed with a real author identity (no AI `Co-Authored-By` trailers)
+- [ ] Behavior changes ship with tests
+- [ ] `docs/` or `AGENTS.md` updated when behavior/architecture changed

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+# .mailmap — canonical author identity
+
+# All commits are authored by the maintainer; unify the historical name
+# spellings so `git log`/`git shortlog` and stats show one identity.
+Amit Mor <amit@231self.com> amit231self <amit@231self.com>
+Amit Mor <amit@231self.com> Amit <amit@231self.com>
+Amit Mor <amit@231self.com> Amit Mor <amit@231self.com>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,12 @@ jj git fetch         # fetch from origin
 All commits require a description (-m). Avoid interactive flags.
 Verify with `jj st` and `jj log` after each mutation.
 
+Author identity: commit as `amit231self <amit@231self.com>` (jj user config).
+Never append AI `Co-Authored-By` / `Generated with <tool>` trailers (Claude,
+Codex, etc.) to commit messages — they pollute GitHub's contributors graph.
+`main` history is shared and must never be force-rewritten except by the
+owner after an explicit, documented decision.
+
 ## Build
 
 - `just check` — format, lint, test

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+# Default code owners (declarative; not enforced as a required review yet).
+# Expand with teams/reviewers as the maintainer group grows.
+* @amit231self
+
+# Areas that benefit from a domain-focused reviewer once available.
+# /filters/  @amit231self
+# /crates/   @amit231self
+# /docs/     @amit231self
+# /sdks/     @amit231self
+# /.github/  @amit231self

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,12 @@ Thanks for considering a contribution to Maskura.
 
 - Target `main`. CI runs format, clippy, tests, filter builds, and a MinIO
   end-to-end pass on every PR.
+- Use the PR template (`.github/pull_request_template.md`): summary, linked
+  issue, and a test plan.
 - Keep changes scoped; split unrelated work into separate PRs.
 - Update `docs/` or `AGENTS.md` when behavior or architecture changes.
+- `main` is protected: the aggregate `check` CI status must pass and the
+  branch must be up to date.
 
 ## Testing
 
@@ -44,6 +48,31 @@ cargo test --workspace
 
 Integration tests that need `DATABASE_URL` skip themselves when it is unset. CI provides
 Postgres and requires these tests to run successfully.
+
+## Author identity
+
+- Commit with your real GitHub identity (for the maintainer:
+  `amit231self <amit@231self.com>`). The repo keeps a `.mailmap` so `git log`
+  and stats show one canonical author.
+- Do **not** append AI `Co-Authored-By` / `Generated with <tool>` trailers
+  (Claude, Codex, and similar) to commit messages. They create phantom entries
+  on GitHub's contributors graph. If you want to credit assistance, say it in
+  the PR description instead.
+- If you ever commit with the wrong email, say so in the PR — the maintainers
+  prefer correcting attribution before merge over rewriting history later.
+
+## Docs site
+
+The docs are an mdBook site in `docs/` (chapters listed in `docs/SUMMARY.md`,
+config in `docs/book.toml`), published to GitHub Pages from `main`. When you
+change a chapter, run `mdbook build docs` locally (`brew install mdbook`) and
+keep out-of-tree links as `https://github.com/231self/maskura/blob/main/...`
+URLs rather than relative `../` paths.
+
+## Maintainers and ownership
+
+See `OWNERS.md` for the maintainer list, decision process, and branch
+protection notes.
 
 ## Security
 

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,39 @@
+# Owners
+
+## Maintainers
+
+| Role | GitHub | Scope |
+| --- | --- | --- |
+| Owner / maintainer | [@amit231self](https://github.com/amit231self) | all areas, releases, CI, Pages/docs |
+
+The single-owner status is intentional today. As contributors join, add them
+here, extend `CODEOWNERS`, and then enable required CODEOWNERS reviews on
+`main` (see the "Branch protection" notes below).
+
+## Decision process
+
+- Proposals start as a GitHub issue or discussion.
+- Substantive architecture or security decisions are recorded as
+  Architecture Decision Records in `docs/adr/` and merged with their change.
+- Releases are cut from `main` by the release workflow and published as
+  GitHub Releases with prebuilt binaries and the canonical/legacy container
+  images.
+
+## Commit identity policy
+
+- Every commit is authored by a real human with their **GitHub identity**
+  (for the maintainer: `amit231self <amit@231self.com>`).
+- Do **not** append AI `Co-Authored-By` / `Generated with` trailers
+  (Claude, Codex, etc.) to commit messages — they create phantom entries on
+  the contributors graph. See `CONTRIBUTING.md`.
+
+## Branch protection (admin)
+
+`main` currently uses classic branch protection:
+
+- required status check: `check` (aggregate CI), strict, admin-enforced
+- required linear history / force pushes / deletions: off
+
+Keep force-pushes to `main` an exceptional, coordinated action. History has
+been rewritten once to remove a wrong author email and AI co-author trailers;
+do not rewrite again without a documented reason.

--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ response timeline, and what to include in a report.
 - `docs/security.md` — the security model of the gateway.
 - `docs/adr/` — architecture decision records.
 - `AGENTS.md` — development conventions.
+- `CONTRIBUTING.md` — contribution guide, tests, and author identity policy.
+- `OWNERS.md` — maintainers and decision process.
 
 ## LLM agents
 


### PR DESCRIPTION
## What

Common GitHub OSS tooling and governance for Maskura:

- **`.github/pull_request_template.md`** — standard PR template (summary, linked
  issue, test plan incl. `just check` / `just e2e` / `cargo check -p s4-gateway` /
  `mdbook build docs`).
- **`.github/ISSUE_TEMPLATE/config.yml`** — disables blank issues and points
  security reporters at private advisories (bug/feature forms already exist).
- **`CODEOWNERS`** — declarative ownership (single maintainer today, commented
  area breakdown for when reviewers exist).
- **`OWNERS.md`** — maintainer list, decision process (issues + ADRs), commit
  identity policy, and branch-protection notes.
- **`CONTRIBUTING.md`** — new sections: PR expectations, **author identity**
  (real GitHub identity; no AI `Co-Authored-By`/`Generated with` trailers),
  the docs-site (mdBook) workflow, and a maintainers pointer.
- **`.mailmap`** — canonical author display for `git log`/shortlog.
- **`AGENTS.md` / `README.md`** — surface the author-identity rules and link
  `CONTRIBUTING.md`/`OWNERS.md`.

## Why now

This follows the history cleanup that removed the wrong Trustmi author email
and AI co-author trailers from `main`; these rules make the fix stick for
future commits.

## Test plan

Docs/CI-config only — no code paths change. CI `check` covers the repo;
`mdbook build docs` unaffected (no `docs/` chapters changed).

## Checklist

- [x] Committed with a real author identity (no AI trailers)
- [x] Behavior changes ship with tests (N/A — docs/config only)
- [x] `docs/` or `AGENTS.md` updated when behavior/architecture changed
