### PR TITLE
docs: formalize ADR conventions and add how-to guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,13 @@ owner after an explicit, documented decision.
 - No functionality is added without extensive unit tests.
 - Prefer specialized libraries over raw regex for PII detection (email, card validation).
 
+- **Architecture decisions belong in the public repo's ADRs.** When work
+  changes a lasting choice (interfaces, trust boundaries, storage, security,
+  deployment), create a new `docs/adr/NNNN-*.md` or update/supersede the
+  affected record in the same change, following the template and rules in
+  `OWNERS.md` ("Architecture Decision Records"). Never silently let an ADR go
+  stale relative to the code.
+
 ## Database
 
 - Relational modeling with normalized Postgres relations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,10 @@ Thanks for considering a contribution to Maskura.
   imports.
 - Match the surrounding code style; do not add comments unless they earn their place.
 
+- Architectural changes (interfaces, trust boundaries, storage, security,
+  deployment) create or update an ADR in `docs/adr/` — see the rules in
+  `OWNERS.md` under "Architecture Decision Records".
+
 ## Commit messages
 
 - Concise, imperative summary line (≤ ~72 chars), then a body explaining the *why*.

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -19,6 +19,37 @@ here, extend `CODEOWNERS`, and then enable required CODEOWNERS reviews on
   GitHub Releases with prebuilt binaries and the canonical/legacy container
   images.
 
+## Architecture Decision Records
+
+ADRs live in `docs/adr/NNNN-short-name.md` and render as a chapter on the
+docs site. Write one when a change is architectural — a lasting choice about
+interfaces, trust boundaries, storage, security, or deployment — not for
+routine bug fixes or refactors.
+
+Structure each ADR as:
+
+```markdown
+# ADR NNNN: Title
+
+- Status: Accepted | Superseded by ADR-XXXX | Proposed
+- Date: YYYY-MM-DD
+
+## Context     -- the problem and options considered
+## Decision    -- what was chosen and why
+## Consequences -- what it costs and enables
+```
+
+Rules:
+
+- Number sequentially; use the next free `NNNN` when adding a record.
+- Keep `Status` honest: flip it to `Superseded by ADR-XXXX` (linking the
+  replacement) when a later decision changes the earlier one — never rewrite
+  or delete a superseded ADR's history.
+- ADRs are written by the humans and agents making the decision, in the same
+  PR/change as the work they describe.
+- If an ADR no longer matches the code, updating or superseding it is part of
+  the architectural change — not a separate docs chore.
+
 ## Commit identity policy
 
 - Every commit is authored by a real human with their **GitHub identity**

--- a/docs/adr/0001-component-model-wit.md
+++ b/docs/adr/0001-component-model-wit.md
@@ -1,7 +1,7 @@
 # ADR 0001: WebAssembly Component Model and WIT Contract
 
-Date: 2026-08-09
-Status: Accepted
+- Status: Accepted
+- Date: 2026-08-09
 
 ## Context
 

--- a/docs/adr/0002-nitro-enclaves.md
+++ b/docs/adr/0002-nitro-enclaves.md
@@ -1,7 +1,7 @@
 # ADR 0002: AWS Nitro Enclaves, TLS-in-Enclave, us-east-1
 
-Date: 2026-08-09
-Status: Accepted
+- Status: Accepted
+- Date: 2026-08-09
 
 ## Context
 

--- a/docs/adr/0003-canonical-policy-manifests.md
+++ b/docs/adr/0003-canonical-policy-manifests.md
@@ -1,7 +1,7 @@
 # ADR 0003: Canonical CBOR and Ed25519 Policy Manifests
 
-Date: 2026-08-09
-Status: Accepted
+- Status: Accepted
+- Date: 2026-08-09
 
 ## Context
 

--- a/docs/adr/0004-postgres-relational-source-of-truth.md
+++ b/docs/adr/0004-postgres-relational-source-of-truth.md
@@ -1,7 +1,7 @@
 # ADR 0004: Postgres Relational Source of Truth
 
-Date: 2026-08-09
-Status: Accepted
+- Status: Accepted
+- Date: 2026-08-09
 
 ## Context
 

--- a/docs/adr/0005-record-boundaries-vs-transport-chunks.md
+++ b/docs/adr/0005-record-boundaries-vs-transport-chunks.md
@@ -1,7 +1,7 @@
 # ADR 0005: Record Boundaries vs Transport Chunks
 
-Date: 2026-08-09
-Status: Accepted
+- Status: Accepted
+- Date: 2026-08-09
 
 ## Context
 

--- a/docs/adr/0006-dev-attestation-never-production.md
+++ b/docs/adr/0006-dev-attestation-never-production.md
@@ -1,7 +1,7 @@
 # ADR 0006: Dev Attestation Never Production-Valid
 
-Date: 2026-08-09
-Status: Accepted
+- Status: Accepted
+- Date: 2026-08-09
 
 ## Context
 

--- a/docs/adr/0007-fresh-store-per-object.md
+++ b/docs/adr/0007-fresh-store-per-object.md
@@ -1,7 +1,7 @@
 # ADR 0007: Fresh Wasmtime Store Per Object
 
-Date: 2026-08-09
-Status: Accepted
+- Status: Accepted
+- Date: 2026-08-09
 
 ## Context
 


### PR DESCRIPTION
## What

Formalize how Maskura records architecture decisions so ADRs stay current:

- **ADR metadata**: standardized each of the seven `docs/adr/*.md` headers to
  a consistent `- Status: Accepted` / `- Date: ...` block (they previously
  mixed `Date:`/`Status:` prose).
- **`OWNERS.md`**: new "Architecture Decision Records" section — when to write
  one, the `Context / Decision / Consequences` template, sequential numbering,
  and supersession rules (flip status to `Superseded by ADR-XXXX` instead of
  rewriting history).
- **`AGENTS.md`**: agents are instructed to create, update, or supersede an
  ADR in the public repo as part of any architectural change, and never let an
  ADR silently go stale.
- **`CONTRIBUTING.md`**: contributors are told architecture changes ship with
  an ADR.

## Test plan

Docs-only change. `mdbook build docs` passes locally; no code paths touched.

## Checklist

- [x] Committed with a real author identity (no AI trailers)
- [x] Behavior changes ship with tests (N/A — docs/config only)
- [x] `docs/` or `AGENTS.md` updated when behavior/architecture changed
