### PR TITLE
feat(managed): expose placement reconciliation and repair-state aggregates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "card-detect"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "email-detect"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-encrypt"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "maskura-customer-config"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "thiserror 2.0.20",
 ]
@@ -3231,7 +3231,7 @@ dependencies = [
 
 [[package]]
 name = "noop"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "pii-default"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "pii-shared"
-version = "0.3.6"
+version = "0.3.7"
 
 [[package]]
 name = "pin-project-lite"
@@ -4470,14 +4470,14 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s4-error"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "s4-gateway"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aes-gcm",
  "aes-siv",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "s4-mcp"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -4565,7 +4565,7 @@ dependencies = [
 
 [[package]]
 name = "s4-policy"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "ciborium",
  "ed25519-dalek",
@@ -4578,7 +4578,7 @@ dependencies = [
 
 [[package]]
 name = "s4-wasm-runtime"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "hex",
@@ -4593,7 +4593,7 @@ dependencies = [
 
 [[package]]
 name = "s4ctl"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -5295,7 +5295,7 @@ dependencies = [
 
 [[package]]
 name = "ssn-detect"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -5303,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "stable-encrypt"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aes-siv",
  "base64 0.22.1",
@@ -5483,21 +5483,21 @@ dependencies = [
 
 [[package]]
 name = "test-binary-reductor"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]
 
 [[package]]
 name = "test-filter"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]
 
 [[package]]
 name = "test-filter-v02"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/231self/S4"

--- a/crates/gateway/src/managed.rs
+++ b/crates/gateway/src/managed.rs
@@ -688,6 +688,21 @@ pub struct AuthorityPlacementPage {
     pub next_after: Option<AuthorityPlacementCursor>,
 }
 
+/// Aggregate view of authorities still below the target placement version.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct AuthorityPlacementStats {
+    pub remaining: u64,
+    pub oldest_updated_at_ms: Option<i64>,
+}
+
+/// Counts of repair records grouped by their lifecycle state.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct RepairStateCounts {
+    pub pending: u64,
+    pub leased: u64,
+    pub dead: u64,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ManagedListVersion {
     V1,
@@ -975,6 +990,10 @@ pub trait ManagedRepository: Send + Sync {
         &self,
         query: AuthorityPlacementPageQuery,
     ) -> Result<AuthorityPlacementPage, ManagedError>;
+    async fn authority_placement_stats(
+        &self,
+        target_placement_version: u32,
+    ) -> Result<AuthorityPlacementStats, ManagedError>;
 
     async fn create_list_cursor(
         &self,
@@ -1087,6 +1106,7 @@ pub trait ManagedRepository: Send + Sync {
     ) -> Result<(), ManagedError>;
     async fn complete_repair(&self, repair: &RepairRecord) -> Result<bool, ManagedError>;
     async fn fail_repair(&self, lease_token: Uuid, error: &str) -> Result<(), ManagedError>;
+    async fn repair_state_counts(&self) -> Result<RepairStateCounts, ManagedError>;
 
     /// Persist a write intent before any provider operation can create a
     /// physical version. Implementations must reject a fenced namespace.
@@ -3684,6 +3704,39 @@ impl ManagedRepository for PostgresManagedRepository {
         })
     }
 
+    async fn authority_placement_stats(
+        &self,
+        target_placement_version: u32,
+    ) -> Result<AuthorityPlacementStats, ManagedError> {
+        if target_placement_version == 0 {
+            return Err(ManagedError::Conflict);
+        }
+        let remaining = managed_object_authority::Entity::find()
+            .filter(managed_object_authority::Column::Tombstone.eq(false))
+            .filter(
+                managed_object_authority::Column::PlacementVersion
+                    .lt(i64::from(target_placement_version)),
+            )
+            .count(&self.db)
+            .await
+            .map_err(persistence)?;
+        let oldest_updated_at_ms = managed_object_authority::Entity::find()
+            .filter(managed_object_authority::Column::Tombstone.eq(false))
+            .filter(
+                managed_object_authority::Column::PlacementVersion
+                    .lt(i64::from(target_placement_version)),
+            )
+            .order_by_asc(managed_object_authority::Column::UpdatedAtMs)
+            .one(&self.db)
+            .await
+            .map_err(persistence)?
+            .map(|model| model.updated_at_ms);
+        Ok(AuthorityPlacementStats {
+            remaining,
+            oldest_updated_at_ms,
+        })
+    }
+
     async fn create_list_cursor(
         &self,
         request: ManagedListCursorRequest,
@@ -4786,6 +4839,29 @@ impl ManagedRepository for PostgresManagedRepository {
             .await
             .map_err(persistence)?;
         txn.commit().await.map_err(persistence)
+    }
+
+    async fn repair_state_counts(&self) -> Result<RepairStateCounts, ManagedError> {
+        let pending = managed_object_repair::Entity::find()
+            .filter(managed_object_repair::Column::State.eq("PENDING"))
+            .count(&self.db)
+            .await
+            .map_err(persistence)?;
+        let leased = managed_object_repair::Entity::find()
+            .filter(managed_object_repair::Column::State.eq("LEASED"))
+            .count(&self.db)
+            .await
+            .map_err(persistence)?;
+        let dead = managed_object_repair::Entity::find()
+            .filter(managed_object_repair::Column::State.eq("DEAD"))
+            .count(&self.db)
+            .await
+            .map_err(persistence)?;
+        Ok(RepairStateCounts {
+            pending,
+            leased,
+            dead,
+        })
     }
 
     async fn begin_physical_write(
@@ -6730,6 +6806,32 @@ impl ManagedRepository for InMemoryManagedRepository {
         })
     }
 
+    async fn authority_placement_stats(
+        &self,
+        target_placement_version: u32,
+    ) -> Result<AuthorityPlacementStats, ManagedError> {
+        if target_placement_version == 0 {
+            return Err(ManagedError::Conflict);
+        }
+        let state = self.state.lock().await;
+        let mut remaining = 0_u64;
+        let mut oldest_updated_at_ms: Option<i64> = None;
+        for authority in state.authorities.values() {
+            if !authority.tombstone && authority.placement_version < target_placement_version {
+                remaining = remaining.saturating_add(1);
+                oldest_updated_at_ms = Some(
+                    oldest_updated_at_ms.map_or(authority.updated_at_ms, |oldest| {
+                        oldest.min(authority.updated_at_ms)
+                    }),
+                );
+            }
+        }
+        Ok(AuthorityPlacementStats {
+            remaining,
+            oldest_updated_at_ms,
+        })
+    }
+
     async fn create_list_cursor(
         &self,
         request: ManagedListCursorRequest,
@@ -7315,6 +7417,19 @@ impl ManagedRepository for InMemoryManagedRepository {
             repair.not_before_ms = now.saturating_add(repair_backoff_ms(repair.attempts));
         }
         Ok(())
+    }
+
+    async fn repair_state_counts(&self) -> Result<RepairStateCounts, ManagedError> {
+        let state = self.state.lock().await;
+        let mut counts = RepairStateCounts::default();
+        for (_, status) in state.repairs.values() {
+            match status.as_str() {
+                "LEASED" => counts.leased = counts.leased.saturating_add(1),
+                "DEAD" => counts.dead = counts.dead.saturating_add(1),
+                _ => counts.pending = counts.pending.saturating_add(1),
+            }
+        }
+        Ok(counts)
     }
 
     async fn begin_physical_write(
@@ -9846,5 +9961,96 @@ mod tests {
                 .await,
             Err(ManagedError::Conflict)
         ));
+    }
+
+    #[tokio::test]
+    async fn authority_placement_stats_counts_stale_and_reports_oldest() {
+        let repository = InMemoryManagedRepository::new();
+        for (key, version, tombstone) in [
+            ("stale", 1, false),
+            ("oldest", 1, false),
+            ("current", 2, false),
+            ("tombstone", 1, true),
+        ] {
+            let mut object = authority(
+                LogicalObjectKey::new("stats", "bucket", key),
+                Uuid::now_v7(),
+            );
+            object.placement_version = version;
+            object.tombstone = tombstone;
+            object.replica_status = CopyStatus::Ready;
+            repository.publish(object, None).await.unwrap();
+        }
+        {
+            let mut state = repository.state.lock().await;
+            state
+                .authorities
+                .get_mut(&LogicalObjectKey::new("stats", "bucket", "stale"))
+                .unwrap()
+                .updated_at_ms = 100;
+            state
+                .authorities
+                .get_mut(&LogicalObjectKey::new("stats", "bucket", "oldest"))
+                .unwrap()
+                .updated_at_ms = 40;
+            state
+                .authorities
+                .get_mut(&LogicalObjectKey::new("stats", "bucket", "current"))
+                .unwrap()
+                .updated_at_ms = 5;
+            state
+                .authorities
+                .get_mut(&LogicalObjectKey::new("stats", "bucket", "tombstone"))
+                .unwrap()
+                .updated_at_ms = 1;
+        }
+
+        let stats = repository.authority_placement_stats(2).await.unwrap();
+        assert_eq!(stats.remaining, 2);
+        assert_eq!(stats.oldest_updated_at_ms, Some(40));
+        assert!(matches!(
+            repository.authority_placement_stats(0).await,
+            Err(ManagedError::Conflict)
+        ));
+    }
+
+    #[tokio::test]
+    async fn repair_state_counts_groups_pending_leased_and_dead() {
+        let repository = InMemoryManagedRepository::new();
+        let mut object = authority(
+            LogicalObjectKey::new("repair-counts", "bucket", "key"),
+            Uuid::now_v7(),
+        );
+        object.replica_status = CopyStatus::Ready;
+        let published = repository.publish(object, None).await.unwrap();
+
+        {
+            let mut state = repository.state.lock().await;
+            for target in ["a", "b", "c"] {
+                let mut repair = RepairRecord::copy(
+                    RepairKind::Replica,
+                    &published,
+                    Some(published.primary_backend_id.clone()),
+                    target.to_string(),
+                    RepairTargetRole::Replica,
+                    published.placement_version,
+                );
+                repair.generation = Uuid::now_v7();
+                insert_memory_repair(&mut state, repair);
+            }
+            let statuses = ["PENDING", "LEASED", "DEAD"];
+            for ((_, status), wanted) in state.repairs.values_mut().zip(statuses) {
+                *status = wanted.to_string();
+            }
+        }
+
+        assert_eq!(
+            repository.repair_state_counts().await.unwrap(),
+            RepairStateCounts {
+                pending: 1,
+                leased: 1,
+                dead: 1
+            }
+        );
     }
 }

--- a/crates/gateway/src/service_storage.rs
+++ b/crates/gateway/src/service_storage.rs
@@ -11,13 +11,13 @@ use tracing::{info, warn};
 use crate::control::{RequestKind, UsageEvent, UsageRoute};
 use crate::managed::{
     AuthorityListPage, AuthorityListQuery, AuthorityPlacementCursor, AuthorityPlacementPage,
-    AuthorityPlacementPageQuery, BackendVersioningCapability, BackendVersioningMode, CopyStatus,
-    DurablePhysicalWriteIntent, LogicalObjectKey, ManagedError, ManagedLogicalOperationIntent,
-    ManagedLogicalOperationState, ManagedMutationKind, ManagedRepository, ManagedStreamingMode,
-    ManagedUsageEvidence, NamespacePurgeRequest, NamespacePurgeStatus, ObjectAuthority,
-    PLACEMENT_VERSION_V1, PhysicalVersionTarget, PhysicalWriteIntent, Placement,
-    ProviderStorageIdentity, RepairKind, RepairRecord, RepairTargetRole, generation_physical_key,
-    weighted_rendezvous_placement,
+    AuthorityPlacementPageQuery, AuthorityPlacementStats, BackendVersioningCapability,
+    BackendVersioningMode, CopyStatus, DurablePhysicalWriteIntent, LogicalObjectKey, ManagedError,
+    ManagedLogicalOperationIntent, ManagedLogicalOperationState, ManagedMutationKind,
+    ManagedRepository, ManagedStreamingMode, ManagedUsageEvidence, NamespacePurgeRequest,
+    NamespacePurgeStatus, ObjectAuthority, PLACEMENT_VERSION_V1, PhysicalVersionTarget,
+    PhysicalWriteIntent, Placement, ProviderStorageIdentity, RepairKind, RepairRecord,
+    RepairStateCounts, RepairTargetRole, generation_physical_key, weighted_rendezvous_placement,
 };
 use crate::s3_safety::{
     record_s3_body_failure, record_s3_failure, s3_retry_config, s3_timeout_config,
@@ -213,6 +213,10 @@ impl ServiceStorage {
         self.managed_mode
     }
 
+    pub fn placement_version(&self) -> u32 {
+        self.placement_version
+    }
+
     pub fn authority_repository(&self) -> Option<&Arc<dyn ManagedRepository>> {
         self.authority.as_ref()
     }
@@ -329,6 +333,20 @@ impl ServiceStorage {
                 .await?;
         }
         Ok(page)
+    }
+
+    /// Aggregate of authorities still below the target placement version.
+    pub async fn authority_placement_stats(&self) -> Result<AuthorityPlacementStats, ManagedError> {
+        self.authority_repository_required()?
+            .authority_placement_stats(self.placement_version)
+            .await
+    }
+
+    /// Counts of repair records grouped by lifecycle state.
+    pub async fn repair_state_counts(&self) -> Result<RepairStateCounts, ManagedError> {
+        self.authority_repository_required()?
+            .repair_state_counts()
+            .await
     }
 
     /// Validate the launch topology before enabling transactional managed


### PR DESCRIPTION
## Why

The control-plane deadman (S7b item 6) needs to report migration progress and repair health, but the engine exposes no aggregate view over authorities or repairs. The private `s4-control` currently can only page authorities and enqueue/claim repairs, so it cannot count remaining stale authorities, compute oldest migration age, or break repairs down by state.

## What

- Add `ServiceStorage::placement_version()` getter.
- Add `ManagedRepository::authority_placement_stats(target)` returning `AuthorityPlacementStats { remaining, oldest_updated_at_ms }` for non-tombstone authorities below the target placement version.
- Add `ManagedRepository::repair_state_counts()` returning `RepairStateCounts { pending, leased, dead }`.
- Implement both for the Postgres and in-memory repositories, plus `ServiceStorage` wrappers.

## Notes

- Read-only aggregate queries only; no behavior change to placement or repair.
- Bump workspace version 0.3.6 → 0.3.7.