### PR TITLE
fix(managed): avoid erroring when re-recording an existing placement policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "card-detect"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "email-detect"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-encrypt"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "maskura-customer-config"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "thiserror 2.0.20",
 ]
@@ -3231,7 +3231,7 @@ dependencies = [
 
 [[package]]
 name = "noop"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "pii-default"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "pii-shared"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "pin-project-lite"
@@ -4470,14 +4470,14 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s4-error"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "s4-gateway"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes-gcm",
  "aes-siv",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "s4-mcp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4565,7 +4565,7 @@ dependencies = [
 
 [[package]]
 name = "s4-policy"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ciborium",
  "ed25519-dalek",
@@ -4578,7 +4578,7 @@ dependencies = [
 
 [[package]]
 name = "s4-wasm-runtime"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -4593,7 +4593,7 @@ dependencies = [
 
 [[package]]
 name = "s4ctl"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -5295,7 +5295,7 @@ dependencies = [
 
 [[package]]
 name = "ssn-detect"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -5303,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "stable-encrypt"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes-siv",
  "base64 0.22.1",
@@ -5483,21 +5483,21 @@ dependencies = [
 
 [[package]]
 name = "test-binary-reductor"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]
 
 [[package]]
 name = "test-filter"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]
 
 [[package]]
 name = "test-filter-v02"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/231self/S4"

--- a/crates/gateway/src/managed.rs
+++ b/crates/gateway/src/managed.rs
@@ -4363,7 +4363,7 @@ impl ManagedRepository for PostgresManagedRepository {
                 .do_nothing()
                 .to_owned(),
         )
-        .exec(&self.db)
+        .exec_without_returning(&self.db)
         .await
         .map_err(persistence)?;
         let existing = managed_placement_policy_version::Entity::find_by_id(version)


### PR DESCRIPTION
## Why

`s4-control` crash-loops on its second deploy with `managed authority persistence failed: None of the records are inserted`. At startup the gateway records the durable placement policy; the first deploy inserts the row, and the second deploy's `INSERT … ON CONFLICT DO NOTHING` conflicts (0 rows), which SeaORM's `Insert::exec` surfaces as an error.

## What

Use `exec_without_returning` on the conflict insert — the pattern already used by every other `on_conflict` insert in this file — so re-recording an existing version is a no-op, followed by the existing `find_by_id` fingerprint check.

Bump workspace 0.4.0 → 0.4.1.