### PR TITLE
bench: add gateway filter performance benchmark

### DIFF
--- a/crates/wasm-runtime/examples/bench_filters.rs
+++ b/crates/wasm-runtime/examples/bench_filters.rs
@@ -1,0 +1,350 @@
+//! Tier-1 micro-benchmark for the `s4:filter` pipeline components.
+//!
+//! Measures per-object Wasm fuel, wall-clock time, and output expansion for
+//! every built-in component across a record-size / PII-density sweep. Run
+//! with `just bench-filters` (builds the components first) or directly with
+//! `cargo run --release -p s4-wasm-runtime --example bench_filters`.
+
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use s4_wasm_runtime::{FilterEngine, Operation, RuntimeLimits, Session, TransformOutcome};
+
+const PUBLIC_KEY_PEM: &str = "-----BEGIN PUBLIC KEY-----\n\
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmO5zDMFH3Ka2TpgJ1NSr\n\
+yOYHyn4l7r+yTnOc5AGe4bEQmErHrAmalqYbSJkO8yHH3M0TKojjCIK0v0zxJHdW\n\
+uFXLIwD9XpPBUAGPhDrcG1ljvEystFX/kIqJp8mUXLb5oLBkTJa7s7J0DO+P6lNb\n\
+hl0YNUajEQTqFpXvRG/sFeVyvIte6K+dsLCw3JBVnfNG7dJyRXuT6y0McoWdq2Wg\n\
+Nw5XL4h23bp2dvZjljUxJ3I43BZLQpymQjcvY2gCxFPb+n9Gix6x98WG3LzD8lwG\n\
+G/PyrV2DNfpRmgm2z62yoorRnZie7XC47Q1ecIyWEIVuVEzHIMMOwlfjFALVlZn/\n\
+MwIDAQAB\n\
+-----END PUBLIC KEY-----";
+
+const PII_EMAIL: &str = "alice@example.com";
+const PII_SSN: &str = "123-45-6789";
+const PII_CARD: &str = "4111111111111111";
+
+const FILLER: &str =
+    "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ";
+
+const BENCH_FUEL: u64 = 10_000_000_000;
+
+const SIZES: [usize; 3] = [1_000, 64_000, 1_000_000];
+const PII_COUNTS: [usize; 4] = [0, 1, 10, 100];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Format {
+    Text,
+    Jsonl,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Component {
+    name: &'static str,
+    file: &'static str,
+    format: Format,
+    needs_public_key: bool,
+    needs_stable: bool,
+}
+
+const COMPONENTS: [Component; 7] = [
+    Component {
+        name: "noop",
+        file: "noop",
+        format: Format::Text,
+        needs_public_key: false,
+        needs_stable: false,
+    },
+    Component {
+        name: "pii-default",
+        file: "pii-default",
+        format: Format::Text,
+        needs_public_key: false,
+        needs_stable: false,
+    },
+    Component {
+        name: "email-detect",
+        file: "email-detect",
+        format: Format::Text,
+        needs_public_key: false,
+        needs_stable: false,
+    },
+    Component {
+        name: "ssn-detect",
+        file: "ssn-detect",
+        format: Format::Text,
+        needs_public_key: false,
+        needs_stable: false,
+    },
+    Component {
+        name: "card-detect",
+        file: "card-detect",
+        format: Format::Text,
+        needs_public_key: false,
+        needs_stable: false,
+    },
+    Component {
+        name: "envelope-encrypt",
+        file: "envelope-encrypt",
+        format: Format::Text,
+        needs_public_key: true,
+        needs_stable: false,
+    },
+    Component {
+        name: "stable-encrypt",
+        file: "stable-encrypt",
+        format: Format::Jsonl,
+        needs_public_key: false,
+        needs_stable: true,
+    },
+];
+
+struct Record {
+    bytes: Vec<u8>,
+    stable_fields: String,
+}
+
+fn components_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("target")
+        .join("components")
+}
+
+fn read_component(name: &str) -> Vec<u8> {
+    let path = components_dir().join(format!("{name}.component.wasm"));
+    std::fs::read(&path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read {}: {error}; run `just build-filters` first",
+            path.display()
+        )
+    })
+}
+
+fn make_record(size: usize, pii: usize, format: Format) -> Record {
+    match format {
+        Format::Text => make_text(size, pii),
+        Format::Jsonl => make_jsonl(size, pii),
+    }
+}
+
+fn make_text(size: usize, pii: usize) -> Record {
+    let mut body = String::with_capacity(size + pii * 64);
+    for _ in 0..pii {
+        body.push_str("Contact ");
+        body.push_str(PII_EMAIL);
+        body.push_str(" SSN ");
+        body.push_str(PII_SSN);
+        body.push_str(" card ");
+        body.push_str(PII_CARD);
+        body.push_str(". ");
+    }
+    while body.len() < size {
+        body.push_str(FILLER);
+    }
+    body.truncate(size);
+    Record {
+        bytes: body.into_bytes(),
+        stable_fields: String::new(),
+    }
+}
+
+fn make_jsonl(size: usize, pii: usize) -> Record {
+    let mut fields = Vec::with_capacity(pii);
+    for i in 0..pii {
+        fields.push((format!("f{i}"), PII_EMAIL));
+    }
+
+    let mut note = String::new();
+    while note.len() < size.saturating_sub(pii * 40 + 64) {
+        note.push_str(FILLER);
+    }
+
+    let mut body = String::with_capacity(size + 128);
+    body.push('{');
+    for (i, (key, value)) in fields.iter().enumerate() {
+        if i > 0 {
+            body.push(',');
+        }
+        body.push('"');
+        body.push_str(key);
+        body.push_str("\":\"");
+        body.push_str(value);
+        body.push('"');
+    }
+    if !fields.is_empty() {
+        body.push(',');
+    }
+    body.push_str("\"note\":\"");
+    body.push_str(&note);
+    body.push_str("\"}");
+
+    let stable_fields = fields
+        .iter()
+        .map(|(key, _)| key.as_str())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    Record {
+        bytes: body.into_bytes(),
+        stable_fields,
+    }
+}
+
+fn make_session(component: Component, format: Format, stable_fields: &str) -> Session {
+    Session {
+        format: match format {
+            Format::Text => "text".to_string(),
+            Format::Jsonl => "jsonl".to_string(),
+        },
+        content_type: match format {
+            Format::Text => "text/plain".to_string(),
+            Format::Jsonl => "application/x-ndjson".to_string(),
+        },
+        policy_version: 1,
+        operation: Operation::Write,
+        config_json: None,
+        public_key_pem: component
+            .needs_public_key
+            .then(|| PUBLIC_KEY_PEM.to_string()),
+        stable_key: component.needs_stable.then(|| vec![0x5a; 64]),
+        stable_fields: component.needs_stable.then(|| stable_fields.to_string()),
+    }
+}
+
+fn engine(component: Component) -> FilterEngine {
+    FilterEngine::with_limits(
+        &read_component(component.file),
+        RuntimeLimits {
+            cumulative_fuel: BENCH_FUEL,
+            per_call_fuel: BENCH_FUEL,
+            ..RuntimeLimits::default()
+        },
+    )
+    .expect("component compiles")
+}
+
+struct Outcome {
+    fuel: u64,
+    output_bytes: usize,
+}
+
+fn run_once(engine: &FilterEngine, session: &Session, record: &[u8]) -> Outcome {
+    let mut filter = engine.start_session(session).expect("start_session");
+    let output = match filter.transform(record).expect("transform") {
+        TransformOutcome::Emit(bytes) => bytes,
+        TransformOutcome::Drop => Vec::new(),
+    };
+    let (tail, fuel) = filter.finish_with_fuel_limit(u64::MAX).expect("finish");
+    Outcome {
+        fuel,
+        output_bytes: output.len() + tail.len(),
+    }
+}
+
+fn median_duration(mut durations: Vec<Duration>) -> Duration {
+    durations.sort_unstable();
+    durations[durations.len() / 2]
+}
+
+fn bench(engine: &FilterEngine, session: &Session, record: &[u8]) -> (Outcome, Duration) {
+    for _ in 0..2 {
+        let _ = run_once(engine, session, record);
+    }
+
+    let (single_duration, outcome) = {
+        let start = Instant::now();
+        let outcome = run_once(engine, session, record);
+        (start.elapsed(), outcome)
+    };
+
+    let target = Duration::from_millis(200).as_nanos().max(1);
+    let iters = ((target / single_duration.as_nanos().max(1)) as usize).clamp(3, 5_000);
+
+    let mut durations = Vec::with_capacity(iters);
+    for _ in 0..iters {
+        let start = Instant::now();
+        let outcome = run_once(engine, session, record);
+        black_box(outcome.output_bytes);
+        durations.push(start.elapsed());
+    }
+
+    (outcome, median_duration(durations))
+}
+
+struct Row {
+    plugin: &'static str,
+    bytes: usize,
+    pii: usize,
+    fuel: u64,
+    output_bytes: usize,
+    median: Duration,
+}
+
+fn main() {
+    let mut rows: Vec<Row> = Vec::new();
+
+    for component in COMPONENTS.iter() {
+        let component_engine = engine(*component);
+        for &pii in &PII_COUNTS {
+            for &size in &SIZES {
+                let record = make_record(size, pii, component.format);
+                let session = make_session(*component, component.format, &record.stable_fields);
+                let (outcome, median) = bench(&component_engine, &session, &record.bytes);
+                rows.push(Row {
+                    plugin: component.name,
+                    bytes: record.bytes.len(),
+                    pii,
+                    fuel: outcome.fuel,
+                    output_bytes: outcome.output_bytes,
+                    median,
+                });
+            }
+        }
+    }
+
+    print_report(&rows);
+    write_csv(&rows);
+}
+
+fn print_report(rows: &[Row]) {
+    println!(
+        "{:<16} {:>9} {:>5} {:>14} {:>12} {:>12} {:>10} {:>10}",
+        "plugin", "bytes", "pii", "fuel", "fuel/byte", "ms/object", "MiB/s", "expansion"
+    );
+    for row in rows {
+        let fuel_per_byte = row.fuel as f64 / row.bytes.max(1) as f64;
+        let secs = row.median.as_secs_f64().max(1e-9);
+        let mib_s = (row.bytes as f64 / (1024.0 * 1024.0)) / secs;
+        let expansion = row.output_bytes as f64 / row.bytes.max(1) as f64;
+        println!(
+            "{:<16} {:>9} {:>5} {:>14} {:>12.4} {:>12.3} {:>10.2} {:>10.3}",
+            row.plugin,
+            row.bytes,
+            row.pii,
+            row.fuel,
+            fuel_per_byte,
+            secs * 1000.0,
+            mib_s,
+            expansion
+        );
+    }
+}
+
+fn write_csv(rows: &[Row]) {
+    let path = components_dir().parent().unwrap().join("benchmarks.csv");
+    let mut csv = String::from("plugin,bytes,pii,fuel,fuel_per_byte,ms_per_object,expansion\n");
+    for row in rows {
+        let fuel_per_byte = row.fuel as f64 / row.bytes.max(1) as f64;
+        let ms = row.median.as_secs_f64() * 1000.0;
+        let expansion = row.output_bytes as f64 / row.bytes.max(1) as f64;
+        csv.push_str(&format!(
+            "{},{},{},{},{:.4},{:.3},{:.3}\n",
+            row.plugin, row.bytes, row.pii, row.fuel, fuel_per_byte, ms, expansion
+        ));
+    }
+    std::fs::write(&path, csv).expect("write benchmarks.csv");
+    eprintln!("wrote {}", path.display());
+}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,101 @@
+# Gateway Filter Pipeline Benchmarks
+
+Measured per-object cost of routing writes through the `s4:filter` plugin
+pipeline. Each number below is the median over a self-tuned run on the Wasm
+runtime micro-benchmark; **fuel** is Wasmtime's deterministic instruction
+counter (the reproducible cross-machine metric), and wall-clock time is
+indicative for one Apple Silicon machine.
+
+## Run it
+
+```bash
+just bench-filters
+```
+
+This builds the filter components and prints the full sweep plus a CSV at
+`target/benchmarks.csv`. It drives `FilterEngine` directly (no network, no
+storage), so it isolates pure plugin cost. The sweep is 7 components x 3 record
+sizes (1 KB / 64 KB / 1 MB) x 4 PII counts (0 / 1 / 10 / 100).
+
+## What each metric means
+
+- **fuel** — Wasmtime fuel consumed per object (Wasm instruction count proxy).
+  Deterministic across machines for the same component and payload.
+- **fuel/byte** — marginal scan cost; the fixed per-object overhead is small
+  relative to 1 MB records, so large records expose the true per-byte cost.
+- **ms/object** — median wall-clock per object (machine-dependent).
+- **MiB/s** — effective single-object throughput.
+- **expansion** — output bytes / input bytes (crypto envelopes inflate output).
+
+## Results
+
+### 1. Fixed per-object overhead (`noop`)
+
+A `noop` filter still pays one fresh Wasm store, `begin`, one `transform`, and
+`finish` per object. Fuel is flat regardless of size:
+
+| size | fuel | ms/object | MiB/s |
+|------|-----:|----------:|------:|
+| 1 KB | 18,396 | 0.062 | 15 |
+| 64 KB | 18,592 | 0.109 | 560 |
+| 1 MB | 18,592 | 0.772 | 1236 |
+
+### 2. PII scan cost (redaction filters, 1 MB, 0 PII)
+
+Detection/redaction scans every byte; cost is linear in size:
+
+| plugin | fuel/byte | ms/object | MiB/s |
+|--------|----------:|----------:|------:|
+| pii-default (email+card+ssn) | 49.5 | 3.37 | 283 |
+| email-detect | 41.5 | 2.76 | 346 |
+| ssn-detect | 45.5 | 3.23 | 295 |
+| card-detect | 45.5 | 3.14 | 303 |
+
+### 3. Envelope encryption (RSA-2048 OAEP + AES-256-GCM)
+
+Cost is dominated by one RSA-OAEP wrap per detected field, ~52M fuel per field:
+
+| record | fields | fuel | ms/object | MiB/s | expansion |
+|--------|-------:|-----:|----------:|------:|----------:|
+| 1 KB | 1 | 52.3M | 2.27 | 0.4 | 2.38x |
+| 1 MB | 100 | 5.24G | 178.6 | 5.3 | 1.14x |
+
+### 4. Stable (deterministic) encryption (AES-SIV)
+
+This filter parses and re-serializes the whole JSON record (serde), so cost
+scales with record size, plus ~170K fuel per encrypted field:
+
+| record | fields | fuel | ms/object | MiB/s |
+|--------|-------:|-----:|----------:|------:|
+| 1 MB | 0 | 1.02M | 0.93 | 1023 |
+| 1 MB | 1 | 29.6M | 2.27 | 420 |
+| 1 MB | 100 | 46.8M | 2.76 | 345 |
+
+## Cost summary (multiplier vs. `noop`, 1 MB)
+
+| plugin | fuel/byte | vs noop (fuel) | MiB/s |
+|--------|----------:|---------------:|------:|
+| noop | ~0.02 | 1x | 1236 |
+| stable-encrypt (0 fields) | ~1.0 | ~55x | 1023 |
+| envelope-encrypt (0 fields) | 27.7 | ~1490x | 275 |
+| email-detect | 41.5 | ~2230x | 346 |
+| ssn-detect | 45.5 | ~2450x | 295 |
+| card-detect | 45.5 | ~2450x | 303 |
+| pii-default | 49.5 | ~2660x | 283 |
+
+The `vs noop` column is absolute fuel; for a fixed per-object budget the
+marginal per-byte figure (`fuel/byte`) is the number to plan capacity against.
+
+## Caveats
+
+- Built with the production `release` profile (`opt-level = "s"`, `lto`, 1 CU).
+  A speed-optimized profile would lower wall-clock times; fuel is unaffected.
+- Fuel budget for this sweep was raised to 1e10 to measure crypto work rather
+  than the production 1e9 ceiling. At the default budget, `envelope-encrypt`
+  exhausts fuel at roughly 19 encrypted fields per object.
+- A text record is padded/truncated to the target size; a small record with a
+  high requested PII count therefore carries fewer actual tokens (see the CSV
+  for exact input bytes).
+- `envelope-encrypt` numbers assume a valid RSA-2048 public key in the session
+  context and host-generated entropy; `stable-encrypt` uses a fixed 64-byte key
+  and tagged fields.

--- a/docs/plans/2026-09-07-gateway-filter-benchmark.md
+++ b/docs/plans/2026-09-07-gateway-filter-benchmark.md
@@ -1,0 +1,152 @@
+# Gateway Filter Pipeline Performance Benchmark
+
+Status: planned
+Scope: self-hosted OSS `s4:filter` plugin pipeline only
+Repositories: public `231self/maskura` (gateway + Wasm runtime + filters)
+
+## Objective
+
+Measure the performance cost of writing objects through the Maskura gateway so
+the overhead of each Wasm filter plugin — and of the pipeline itself — is a
+published, reproducible number rather than an anecdote. Concretely, answer:
+
+- What is the fixed cost of routing an object through the pipeline at all
+  (explicit pass-through vs. a single `noop` filter, which isolates the cost of
+  the fresh per-object Wasm store + executor scheduling)?
+- What is the marginal per-byte and per-record cost of each built-in filter
+  (`pii-default`, `email-detect`, `ssn-detect`, `card-detect`,
+  `envelope-encrypt`, `stable-encrypt`), individually and as ordered chains?
+- How much do the crypto filters cost per detected field (RSA-OAEP wrap +
+  AES-256-GCM for `envelope-encrypt`, AES-SIV for `stable-encrypt`), and how
+  much do they expand the object?
+- What is the end-to-end throughput/latency penalty of writing through Maskura
+  versus writing directly to the storage backend?
+
+The result is a benchmark harness plus a `docs/benchmarks.md` with tables whose
+headline is a "cost multiplier vs. noop" per plugin.
+
+## Current-State Findings
+
+- The write path is `server.rs` `PUT` → resolve pipeline → `snapshot_for` →
+  `streaming_single_put`. The pipeline itself is executed by
+  `PipelineSession::route_from` in `crates/gateway/src/plugin_registry.rs:1254`,
+  one `transform` call per enabled plugin per record.
+- Each object gets a fresh per-object pipeline on a dedicated `WasmExecutor`
+  (`crates/wasm-runtime/src/executor.rs`), whose default worker count is
+  `min(available_parallelism, 4)`. Throughput is worker-bound.
+- The registry already instruments execution: `control.rs` emits
+  `PipelineEvidence { revision, fingerprint, components, fuel_consumed,
+  duration_ms, spool_mode }` per operation (`crates/gateway/src/control.rs:259`),
+  and `PipelineSession` exposes `fuel_consumed()`, `input_bytes()`, and
+  `output_bytes()`. Wasmtime fuel is a deterministic, hardware-independent proxy
+  for guest CPU, so it is the primary cross-machine metric.
+- `scripts/build-filters.sh` builds seven components into
+  `target/components/*.component.wasm`: `noop`, `pii-default`, `email-detect`,
+  `ssn-detect`, `card-detect`, `envelope-encrypt`, `stable-encrypt`.
+- The self-hosted plugin set is controlled by `MASKURA_PLUGINS_DIR` (legacy
+  `S4_PLUGINS_DIR`), loaded at startup (`server.rs:725`); an empty directory is
+  the operator's explicit pass-through choice.
+- `just bench-rss` already runs `tests/streaming_rss.rs`, which asserts a 1 GiB
+  source grows peak RSS by at most 128 MiB — the memory-bound harness to reuse.
+- The release profile is size-optimized (`opt-level = "s"`), and the pipeline
+  comment notes one RSA-2048 OAEP wrap costs ~25M wasm instructions against a
+  `DEFAULT_PIPELINE_FUEL` of 1e9 (`plugin_registry.rs:26`). Both facts shape
+  what the harness must measure and how.
+
+## Decisions
+
+1. Benchmark at two tiers: a deterministic in-process micro-benchmark (isolates
+   per-plugin cost, no I/O) and an end-to-end harness against local MinIO
+   (measures the full "through Maskura" cost).
+2. Use Wasmtime **fuel** as the primary cost metric (fuel/byte, fuel/detected
+   field), reported alongside wall-clock latency, throughput, output expansion,
+   and peak RSS. Duration alone is not reproducible across machines.
+3. `noop` is a mandatory distinct row from explicit pass-through, because it
+   isolates the fixed per-object store/executor overhead.
+4. Sweep PII density (0/1/10/100%), record size (1 KB / 64 KB / 1 MB), and format
+   (`text/plain`, `jsonl`, `csv`), and — e2e only — executor concurrency.
+5. Add a dedicated release-like benchmark profile with `opt-level = 3` (the
+   production `release` profile is `opt-level = "s"`); benchmark Wasm guests are
+   built with the production `build-filters.sh` path unchanged so numbers reflect
+   shipped artifacts.
+6. Report fuel-exhaustion and memory/expansion limits as first-class results for
+   high-density `envelope-encrypt` payloads, not as afterthoughts.
+7. Keep the harness self-contained: it must not require a cloud account, Supabase,
+   or the private control plane. Local MinIO via `local/docker-compose.yml` and
+   `s4ctl` are the only infra.
+
+## Ordered Implementation
+
+### 1. Add the micro-benchmark harness
+
+**Files:** `crates/wasm-runtime/benches/` (or `crates/gateway/benches/`), with a
+criterion bench; a shared payload generator module.
+
+- Load each `target/components/*.component.wasm`, build a `PipelineSnapshot`, and
+  drive `PipelineSession::process` with synthetic records across the density/size/
+  format sweep.
+- Record per-configuration: `fuel_consumed()`, wall time, `input_bytes()`,
+  `output_bytes()`, and derive fuel/byte, fuel/detected-field, ns/record, and
+  expansion factor.
+- Include pass-through (empty chain) and `noop` rows, plus the
+  `pii-default` → `envelope-encrypt` two-stage chain.
+
+**Verify:** numbers are stable across repeated runs on the same machine; fuel/byte
+is identical across machines for the same component and payload; the noop row
+isolates a measurable fixed cost.
+
+### 2. Add the end-to-end harness and load generator
+
+**Files:** `scripts/bench-e2e.sh` (or similar), a generator script, and a small
+table-rendering step.
+
+- Reuse `local/docker-compose.yml` MinIO + gateway (`just dev-up`). Switch the
+  plugin set by pointing `MASKURA_PLUGINS_DIR` at a directory containing the
+  chosen `target/components/*.component.wasm` subset.
+- Baseline runs: direct-to-MinIO (no gateway), gateway pass-through, and gateway
+  `noop`. Then each real filter and the two-stage chain.
+- Generate payloads with configurable PII density/format/size; drive uploads with
+  `s4ctl` (or curl + SigV4) at fixed concurrency, timing each object.
+- Collect the gateway's emitted `PipelineEvidence` (fuel + duration) from usage
+  events/logs and emit CSV + markdown tables.
+
+**Verify:** the e2e latency/throughput for `noop` minus pass-through is consistent
+with the micro-benchmark fixed cost; expansion and fuel numbers reconcile with
+Tier 1; peak RSS stays within the `streaming_rss.rs` bound under the sweep.
+
+### 3. Publish the results
+
+**Files:** `docs/benchmarks.md` (and a `just bench` entry if a single command
+emerges).
+
+- Document methodology, environment, and how to reproduce.
+- Publish the tables with the "cost multiplier vs. noop" headline per plugin,
+  plus fixed-overhead, expansion, and fuel-exhaustion notes.
+
+**Verify:** a reviewer can reproduce the tables from a clean checkout with
+`just build-filters` + the benchmark commands, with no cloud credentials.
+
+## Verification Gates
+
+- `just check` stays green (harness compiles under `-D warnings`).
+- The micro-benchmark runs deterministically and its fuel/byte figure is
+  reproducible across machines.
+- The e2e harness runs against local MinIO only and requires no secrets.
+- `envelope-encrypt` high-density results include a documented fuel-exhaustion
+  outcome (or a raised `MASKURA_WASM_FUEL` with the rationale).
+- Reported expansion for `envelope-encrypt` matches the measured
+  `output_bytes`/`input_bytes` ratio.
+
+## Success Criteria
+
+- A table exists that quotes, per plugin, the cost multiplier versus `noop` for
+  CPU (fuel), latency, throughput, and output expansion.
+- The fixed cost of running the pipeline is separately quantified (pass-through
+  vs. `noop`).
+- Anyone can reproduce every number from a clean checkout with local tooling
+  only.
+
+## Open Decisions
+
+None. Selecting `criterion` versus a lighter custom timer, and the exact benchmark
+crate location, are implementation details to settle when the harness lands.

--- a/justfile
+++ b/justfile
@@ -66,6 +66,10 @@ fault-streaming:
 bench-rss:
   cargo test -p s4-gateway --test streaming_rss -- --nocapture
 
+# Micro-benchmark: per-plugin Wasm fuel, latency, and expansion (Tier 1)
+bench-filters: build-filters
+  cargo run --release -p s4-wasm-runtime --example bench_filters
+
 # Soak: high-case-count property tests + repeated streaming round-trips
 soak-streaming:
   PROPTEST_CASES=10000 cargo test -p s4-gateway --test property --test record_decoder


### PR DESCRIPTION
Adds a reproducible benchmark for the `s4:filter` plugin pipeline, plus the measured results.

## What's included
- `crates/wasm-runtime/examples/bench_filters.rs` — in-process micro-benchmark driving `FilterEngine` directly; measures per-object Wasm fuel, wall-clock, and output expansion across all 7 components x 3 object sizes x 4 PII densities.
- `just bench-filters` — reproducible entry point (builds the filter components, then runs the sweep; emits a table and `target/benchmarks.csv`).
- `docs/benchmarks.md` — methodology + results.
- `docs/plans/2026-09-07-gateway-filter-benchmark.md` — the plan.

## Why fuel
Wasmtime fuel is a deterministic instruction counter (like gas): same component + input always burns the same amount, independent of machine speed or load. It's the reproducible cost metric; wall-clock is machine-dependent and reported only as an indication.

## Headline numbers
- Fixed per-object overhead (`noop`): ~18.5K fuel, ~0.06 ms.
- PII scan: `pii-default` ~49.5 fuel/byte (~283 MiB/s); single-kind detectors ~41–45 fuel/byte.
- `envelope-encrypt`: ~52M fuel per encrypted field (RSA-2048 OAEP + AES-256-GCM), up to 22x expansion at 1 KB.
- `stable-encrypt`: ~170K fuel per encrypted field after the JSON round-trip.

Tier 2 (end-to-end wall-clock vs MinIO) is deferred: the release gateway's streaming write path requires managed storage (`S4_SERVICE_BUCKETS`) + a durable journal (Postgres), so the fuel micro-benchmark is the authoritative cost measure for now.
