### PR TITLE
docs: add post-quantum encryption and SQL proxy roadmap chapters

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -9,6 +9,11 @@
 - [End-to-end suite](e2e.md)
 - [Security](security.md)
 
+# Roadmap (planned, not shipped)
+
+- [Post-quantum encryption](post-quantum-crypto.md)
+- [SQL proxy](sql-proxy.md)
+
 # Architecture Decision Records
 
 - [ADR 0001: Component Model and WIT](adr/0001-component-model-wit.md)

--- a/docs/post-quantum-crypto.md
+++ b/docs/post-quantum-crypto.md
@@ -1,0 +1,38 @@
+# Post-quantum encryption
+
+> **Status: planned.** This page describes an upcoming feature, not shipped
+> behavior. Current builds use RSA-OAEP key wrapping.
+
+## What it is
+
+Maskura's encryption filters protect fields with envelope encryption: a fresh
+AES-256-GCM key per field, wrapped with a public key so only the key holder can
+decrypt. Today that wrap is RSA-OAEP, which a quantum computer can break.
+
+The post-quantum feature replaces the RSA-OAEP wrap with a **hybrid X25519 +
+ML-KEM-768** key encapsulation:
+
+- **ML-KEM-768** (NIST FIPS 203) protects against a cryptographically relevant
+  quantum computer (harvest-now-decrypt-later).
+- **X25519** protects against the risk of an undiscovered weakness in a young
+  post-quantum scheme.
+
+The data cipher stays AES-256-GCM, which is already post-quantum-safe.
+
+## What changes
+
+- New envelope `alg`: `X25519+ML-KEM-768/AES-256-GCM`.
+- New client key format (hybrid public/private keys).
+- Existing `RSA-OAEP` envelopes remain decryptable (dual-alg read).
+
+## What does not change
+
+- The plugin model, the `transform`/`finish` interface, and the sandbox are
+  untouched — this is a new filter implementation, not a new runtime.
+- API-key secrets (`KeyWrapping`) and KMS/Vault wrapping are symmetric and already
+  safe.
+
+## See also
+
+- [Plugins](plugins.md)
+- [Security](security.md)

--- a/docs/sql-proxy.md
+++ b/docs/sql-proxy.md
@@ -1,0 +1,40 @@
+# SQL proxy
+
+> **Status: planned.** This page describes an upcoming feature, not shipped
+> behavior.
+
+## What it is
+
+A SQL-over-HTTP proxy in front of a customer's own Postgres (Supabase, Neon, RDS,
+self-hosted). The client sends a query; Maskura executes it against the backing
+database, runs the result set through the privacy layer, and returns masked JSON
+rows.
+
+It is the same promise Maskura makes for objects, applied to rows:
+
+> raw in Postgres, scrubbed in the JSON response.
+
+## Why
+
+AI agents already reach production databases. Fine-grained access control is the
+blocker, and Postgres's native answer — roles, column grants, RLS, views — does not
+scale to many agents.
+
+Maskura takes the opposite approach: the agent can run whatever `SELECT` it wants,
+but the only thing it can ever *observe* is the masked projection. Masking is
+post-query and server-side, so the raw column never leaves Maskura.
+
+## Scope (day one)
+
+- **Read-only** — writes are rejected.
+- **BYO Postgres** — Maskura fronts the customer's database using the same
+  encrypted-credential + routing machinery as the S3 backend.
+- **Schema-aware masking** — column-level policy (`users.email` is always masked),
+  with type-aware transforms (bucketing numbers, coarse-graining dates).
+- **Reuse** — masking runs through the same sandboxed wasm pipeline and
+  `binary_reductor` claim model.
+
+## See also
+
+- [Binary adapters](binary-adapters.md)
+- [MCP](mcp.md)


### PR DESCRIPTION
Adds roadmap pages for two planned features:

- **Post-quantum encryption** — hybrid X25519 + ML-KEM-768 key wrapping, replacing RSA-OAEP.
- **SQL proxy** — SQL-over-HTTP read-path masking in front of a customer's own Postgres.

Both pages are marked `Status: planned` so the book does not misrepresent shipped behavior. Tracked against private plans in `231self/S4-private`.