### PR TITLE
test: add local MCP smoke coverage and examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "card-detect"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "email-detect"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-encrypt"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -3052,7 +3052,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "serde",
  "winapi",
 ]
@@ -3076,14 +3076,14 @@ dependencies = [
 
 [[package]]
 name = "maskura-customer-config"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "maskura-mcp-protocol"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "quick-xml",
  "schemars",
@@ -3231,6 +3231,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3242,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "noop"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]
@@ -3538,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "pii-default"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -3546,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "pii-shared"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "pin-project-lite"
@@ -3705,6 +3717,20 @@ dependencies = [
  "syn 2.0.119",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix 0.31.3",
+ "tokio",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -4234,12 +4260,14 @@ dependencies = [
  "indexmap",
  "pastey",
  "pin-project-lite",
+ "process-wrap",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "uuid",
@@ -4481,14 +4509,14 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s4-error"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "s4-gateway"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aes-gcm",
  "aes-siv",
@@ -4555,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "s4-mcp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4567,6 +4595,7 @@ dependencies = [
  "rmcp",
  "s4-gateway",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4576,7 +4605,7 @@ dependencies = [
 
 [[package]]
 name = "s4-policy"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ciborium",
  "ed25519-dalek",
@@ -4589,7 +4618,7 @@ dependencies = [
 
 [[package]]
 name = "s4-wasm-runtime"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -4604,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "s4ctl"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -5306,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "ssn-detect"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "pii-shared",
  "wit-bindgen 0.60.0",
@@ -5314,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "stable-encrypt"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aes-siv",
  "base64 0.22.1",
@@ -5494,21 +5523,21 @@ dependencies = [
 
 [[package]]
 name = "test-binary-reductor"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]
 
 [[package]]
 name = "test-filter"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]
 
 [[package]]
 name = "test-filter-v02"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "wit-bindgen 0.60.0",
 ]
@@ -6706,6 +6735,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6716,6 +6766,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -6745,6 +6806,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -6831,6 +6902,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/231self/S4"

--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ documented in [docs/avro.md](docs/avro.md). A runnable PUT/read example is in
 
 The local stdio MCP server exposes put, get, list, and delete tools to agent
 clients while preserving the gateway's normal auth, pipeline, and metering path.
-See [docs/mcp.md](docs/mcp.md).
+See [docs/mcp.md](docs/mcp.md) for Claude Desktop, Cursor, and Kilo setup, plus
+the runnable [`examples/mcp-client.py`](examples/mcp-client.py) lifecycle.
 
 ## Usage examples
 

--- a/crates/s4-mcp/Cargo.toml
+++ b/crates/s4-mcp/Cargo.toml
@@ -32,4 +32,6 @@ url = "2"
 s4-gateway = { path = "../gateway" }
 axum.workspace = true
 http-body-util = "0.1"
+rmcp = { version = "3.1", features = ["client", "transport-child-process"] }
+tempfile = "3"
 uuid.workspace = true

--- a/crates/s4-mcp/src/main.rs
+++ b/crates/s4-mcp/src/main.rs
@@ -13,10 +13,10 @@ use maskura_mcp_protocol::{
 };
 use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, ContentBlock};
+use rmcp::model::{CallToolResult, ContentBlock, Implementation, ServerCapabilities, ServerInfo};
 use rmcp::tool;
 use rmcp::transport::stdio;
-use rmcp::{ErrorData as McpError, ServiceExt, tool_router};
+use rmcp::{ErrorData as McpError, ServerHandler, ServiceExt, tool_handler, tool_router};
 use url::Url;
 
 const DEFAULT_GATEWAY_URL: &str = "http://localhost:8080";
@@ -148,7 +148,7 @@ impl MaskuraServer {
     }
 }
 
-#[tool_router(server_handler)]
+#[tool_router]
 impl MaskuraServer {
     #[tool(description = "Store a UTF-8 object through the configured Maskura pipeline")]
     async fn maskura_put_object(
@@ -323,6 +323,20 @@ impl MaskuraServer {
         params: Parameters<DeleteObjectParams>,
     ) -> Result<CallToolResult, McpError> {
         self.maskura_delete_object(params).await
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for MaskuraServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new(
+                "maskura-mcp",
+                env!("CARGO_PKG_VERSION"),
+            ))
+            .with_instructions(
+                "Use Maskura tools to store, filter, read, list, and delete text objects.",
+            )
     }
 }
 

--- a/crates/s4-mcp/tests/stdio_e2e.rs
+++ b/crates/s4-mcp/tests/stdio_e2e.rs
@@ -1,0 +1,281 @@
+use std::{collections::BTreeMap, ffi::OsString, process::Stdio, sync::Arc};
+
+use maskura_mcp_protocol::tool_definitions;
+use rmcp::{
+    ServiceExt,
+    model::{CallToolRequestParams, CallToolResult},
+    transport::{ConfigureCommandExt, TokioChildProcess},
+};
+use s4_gateway::{
+    control::NoopControlPlane,
+    key_cipher::default_wrapping,
+    server::{build_router, build_state},
+    workspace_storage::{InMemoryWorkspaceStorageRepository, WorkspaceStorageRepository},
+};
+
+struct EnvironmentGuard {
+    previous: BTreeMap<&'static str, Option<OsString>>,
+}
+
+impl EnvironmentGuard {
+    fn apply(values: &[(&'static str, Option<&str>)]) -> Self {
+        let previous = values
+            .iter()
+            .map(|(name, _)| (*name, std::env::var_os(name)))
+            .collect();
+        for (name, value) in values {
+            // This integration test is its own process and is the only test in
+            // this binary, so no other thread observes these startup settings.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+        Self { previous }
+    }
+}
+
+impl Drop for EnvironmentGuard {
+    fn drop(&mut self) {
+        for (name, value) in &self.previous {
+            // See EnvironmentGuard::apply: this test binary owns these values.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+}
+
+fn arguments(value: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+    value
+        .as_object()
+        .expect("tool arguments are an object")
+        .clone()
+}
+
+fn result_text(result: &CallToolResult) -> &str {
+    result
+        .content
+        .first()
+        .and_then(|content| content.as_text())
+        .map(|text| text.text.as_str())
+        .expect("tool returned text content")
+}
+
+#[tokio::test]
+async fn stdio_client_round_trips_through_the_real_gateway() -> anyhow::Result<()> {
+    let temporary = tempfile::tempdir()?;
+    let component = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../target/components/pii-default.component.wasm");
+    assert!(
+        component.is_file(),
+        "missing {}; run `just build-filters`",
+        component.display()
+    );
+    let keys_file = temporary.path().join("keys.json");
+    let _environment = EnvironmentGuard::apply(&[
+        ("AUTH_DISABLED", None),
+        ("MASKURA_SINGLE_TENANT", Some("true")),
+        (
+            "MASKURA_FILTER_COMPONENT",
+            Some(component.to_str().expect("component path is UTF-8")),
+        ),
+        (
+            "MASKURA_KEYS_FILE",
+            Some(keys_file.to_str().expect("keys path is UTF-8")),
+        ),
+        ("MASKURA_DEV_MEMORY_STREAMING", Some("true")),
+        ("MASKURA_STREAMING_READ_MODE", Some("passthrough")),
+        ("S4_FILTER_COMPONENT", None),
+        ("S4_KEYS_FILE", None),
+        ("S4_SINGLE_TENANT", None),
+        ("S4_DEV_MEMORY_STREAMING", None),
+        ("S4_STREAMING_READ_MODE", None),
+        ("DATABASE_URL", None),
+        ("S3_ENDPOINT", None),
+        ("S4_SERVICE_BUCKETS", None),
+    ]);
+
+    let workspaces = Arc::new(InMemoryWorkspaceStorageRepository::new());
+    let state = build_state(
+        Arc::new(NoopControlPlane),
+        default_wrapping()?,
+        workspaces.clone(),
+    )
+    .await?;
+    let workspace = workspaces.resolve_workspace("mcp-e2e-user").await?;
+    let (token, _) = state
+        .keys
+        .create_mcp_token("mcp-e2e-user", &workspace, "stdio-e2e", 300)
+        .await?;
+
+    let app = build_router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let gateway_url = format!("http://{}", listener.local_addr()?);
+    let gateway = tokio::spawn(async move { axum::serve(listener, app).await });
+
+    let (transport, _) = TokioChildProcess::builder(
+        tokio::process::Command::new(env!("CARGO_BIN_EXE_maskura-mcp")).configure(|command| {
+            command
+                .env("MASKURA_GATEWAY_URL", &gateway_url)
+                .env("MASKURA_MCP_TOKEN", &token)
+                .env_remove("S4_GATEWAY_URL")
+                .env_remove("S4_MCP_TOKEN")
+                .env_remove("MASKURA_ACCESS_KEY")
+                .env_remove("MASKURA_SECRET_KEY")
+                .env_remove("S4_ACCESS_KEY")
+                .env_remove("S4_SECRET_KEY");
+        }),
+    )
+    .stderr(Stdio::null())
+    .spawn()?;
+    let client = ().serve(transport).await?;
+
+    let mut names = client
+        .list_all_tools()
+        .await?
+        .into_iter()
+        .map(|tool| tool.name.into_owned())
+        .collect::<Vec<_>>();
+    names.sort();
+    let mut expected = tool_definitions()
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect::<Vec<_>>();
+    expected.sort();
+    assert_eq!(names, expected);
+
+    let put = client
+        .call_tool(
+            CallToolRequestParams::new("maskura_put_object").with_arguments(arguments(
+                serde_json::json!({
+                    "bucket": "agent-data",
+                    "key": "runs/first.txt",
+                    "body": "email alice@example.com",
+                    "content_type": "text/plain; charset=utf-8"
+                }),
+            )),
+        )
+        .await?;
+    assert_eq!(put.is_error, Some(false));
+    assert!(result_text(&put).contains("stored agent-data/runs/first.txt"));
+
+    let get = client
+        .call_tool(
+            CallToolRequestParams::new("maskura_get_object").with_arguments(arguments(
+                serde_json::json!({
+                    "bucket": "agent-data",
+                    "key": "runs/first.txt"
+                }),
+            )),
+        )
+        .await?;
+    assert_eq!(get.is_error, Some(false));
+    assert_eq!(result_text(&get), "email [REDACTED_EMAIL]");
+
+    let list = client
+        .call_tool(
+            CallToolRequestParams::new("maskura_list_objects").with_arguments(arguments(
+                serde_json::json!({
+                    "bucket": "agent-data",
+                    "prefix": "runs/",
+                    "max_keys": 1
+                }),
+            )),
+        )
+        .await?;
+    assert_eq!(list.is_error, Some(false));
+    assert_eq!(result_text(&list), "runs/first.txt");
+
+    let delete = client
+        .call_tool(
+            CallToolRequestParams::new("maskura_delete_object").with_arguments(arguments(
+                serde_json::json!({
+                    "bucket": "agent-data",
+                    "key": "runs/first.txt"
+                }),
+            )),
+        )
+        .await?;
+    assert_eq!(delete.is_error, Some(false));
+    assert!(result_text(&delete).contains("deleted agent-data/runs/first.txt"));
+
+    let missing = client
+        .call_tool(
+            CallToolRequestParams::new("maskura_get_object").with_arguments(arguments(
+                serde_json::json!({
+                    "bucket": "agent-data",
+                    "key": "runs/first.txt"
+                }),
+            )),
+        )
+        .await?;
+    assert_eq!(missing.is_error, Some(true));
+    assert!(result_text(&missing).contains("NoSuchKey"));
+
+    client.cancel().await?;
+    gateway.abort();
+    let _ = gateway.await;
+
+    // Exercise the exact local-init contract documented for desktop clients:
+    // an auth-disabled loopback gateway plus an explicit placeholder key pair.
+    unsafe {
+        std::env::set_var("AUTH_DISABLED", "true");
+    }
+    let local_workspaces = Arc::new(InMemoryWorkspaceStorageRepository::new());
+    let local_state = build_state(
+        Arc::new(NoopControlPlane),
+        default_wrapping()?,
+        local_workspaces,
+    )
+    .await?;
+    let local_app = build_router(local_state);
+    let local_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let local_gateway_url = format!("http://{}", local_listener.local_addr()?);
+    let local_gateway = tokio::spawn(async move { axum::serve(local_listener, local_app).await });
+
+    let example =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/mcp-client.py");
+    let output = tokio::process::Command::new("python3")
+        .arg(example)
+        .env("MASKURA_GATEWAY_URL", &local_gateway_url)
+        .env_remove("MASKURA_MCP_TOKEN")
+        .env("MASKURA_ACCESS_KEY", "local")
+        .env("MASKURA_SECRET_KEY", "local")
+        .env("MASKURA_MCP_COMMAND", env!("CARGO_BIN_EXE_maskura-mcp"))
+        .env("MCP_EXAMPLE_RUN_MUTATIONS", "1")
+        .env("MCP_EXAMPLE_BUCKET", "agent-data")
+        .env("MCP_EXAMPLE_KEY", "examples/python-client.txt")
+        .output()
+        .await?;
+    assert!(
+        output.status.success(),
+        "example failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(
+        stdout.contains("Connected to maskura-mcp"),
+        "unexpected stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Read: Contact [REDACTED_EMAIL]"),
+        "unexpected stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("List: examples/python-client.txt"),
+        "unexpected stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Deleted agent-data/examples/python-client.txt"),
+        "unexpected stdout: {stdout}"
+    );
+
+    local_gateway.abort();
+    Ok(())
+}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -31,9 +31,75 @@ gateway does provide the foundation used by a hosted transport: shared typed
 contracts in `maskura-mcp-protocol` (re-exported as `s4_gateway::mcp`) and trusted in-process execution through
 `s4_gateway::server::invoke_mcp`.
 
-## Configure
+## Run locally
 
-Create an MCP token in the Maskura dashboard, then configure the local server:
+Start the published gateway image and copy the loopback URL printed by the CLI:
+
+```bash
+maskura local init
+# Gateway: http://127.0.0.1:8080 (the selected port may differ)
+```
+
+The local gateway runs with `AUTH_DISABLED=true`. `maskura-mcp` still requires
+an explicit credential shape so a configuration cannot accidentally become
+credential-free when pointed at production. Use local-only placeholder values:
+
+```json
+{
+  "mcpServers": {
+    "maskura-local": {
+      "command": "maskura-mcp",
+      "env": {
+        "MASKURA_GATEWAY_URL": "http://127.0.0.1:8080",
+        "MASKURA_ACCESS_KEY": "local",
+        "MASKURA_SECRET_KEY": "local"
+      }
+    }
+  }
+}
+```
+
+Use the exact port printed by `maskura local init`. These placeholder
+credentials are accepted only because that loopback gateway explicitly disables
+authentication; never use `AUTH_DISABLED` on a network-accessible deployment.
+
+For Kilo, the equivalent local entry in `kilo.json` is:
+
+```json
+{
+  "mcp": {
+    "maskura-local": {
+      "type": "local",
+      "command": ["maskura-mcp"],
+      "environment": {
+        "MASKURA_GATEWAY_URL": "http://127.0.0.1:8080",
+        "MASKURA_ACCESS_KEY": "local",
+        "MASKURA_SECRET_KEY": "local"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+## Connect to a hosted gateway
+
+Create an MCP token in the Maskura dashboard, or through the dashboard API with
+a signed-in session JWT:
+
+```bash
+curl --fail-with-body \
+  --request POST "$MASKURA_GATEWAY_URL/dashboard/api/mcp-tokens" \
+  --header "Authorization: Bearer $MASKURA_SESSION_JWT" \
+  --header "Content-Type: application/json" \
+  --data '{"label":"desktop-agent","expires_in":2592000}'
+```
+
+The response reveals the `s4m_...` token once. Store it in a secret manager,
+not in source control. The token remains bound to the workspace selected when
+it was created.
+
+Claude Desktop and Cursor use the standard `mcpServers` shape:
 
 ```json
 {
@@ -49,6 +115,32 @@ Create an MCP token in the Maskura dashboard, then configure the local server:
 }
 ```
 
+For Claude Desktop on macOS, place this under the `mcpServers` key in
+`~/Library/Application Support/Claude/claude_desktop_config.json`. Cursor uses
+`.cursor/mcp.json` in a project or its equivalent global MCP settings.
+
+Kilo uses its local-process MCP configuration shape in `kilo.json`:
+
+```json
+{
+  "mcp": {
+    "maskura": {
+      "type": "local",
+      "command": ["maskura-mcp"],
+      "environment": {
+        "MASKURA_GATEWAY_URL": "https://api.s4.231self.com",
+        "MASKURA_MCP_TOKEN": "s4m_your_token"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+Restart the client after changing its MCP configuration. Desktop applications
+often do not inherit shell environment variables, so use the client's secret
+storage or a restricted configuration file when literal values are required.
+
 A Maskura API key pair can be used instead:
 
 ```json
@@ -63,6 +155,37 @@ A Maskura API key pair can be used instead:
 values are validated at startup and are omitted from debug output.
 Legacy `S4_*` names remain accepted. If both forms are set, their values must
 match exactly, including empty values, or startup fails closed.
+
+## Try it locally
+
+The stdlib-only example connects over MCP stdio and lists the available tools:
+
+```bash
+export MASKURA_GATEWAY_URL="http://127.0.0.1:8080" # use the printed port
+export MASKURA_ACCESS_KEY="local"
+export MASKURA_SECRET_KEY="local"
+python3 examples/mcp-client.py
+```
+
+Run a complete put, filtered get, paged list, and delete lifecycle:
+
+```bash
+MCP_EXAMPLE_RUN_MUTATIONS=1 \
+MCP_EXAMPLE_BUCKET=agent-data \
+python3 examples/mcp-client.py
+```
+
+The upload contains `alice@example.com`; the read result should contain
+`[REDACTED_EMAIL]`, proving the MCP call used the normal gateway filter path.
+
+Equivalent requests from an MCP-enabled agent are:
+
+```text
+Store "Contact alice@example.com" at agent-data/examples/mcp.txt with Maskura.
+Read agent-data/examples/mcp.txt and show me the stored value.
+List up to 10 keys under examples/ in agent-data.
+Delete agent-data/examples/mcp.txt.
+```
 
 ## Tool behavior
 

--- a/examples/mcp-client.py
+++ b/examples/mcp-client.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Small stdlib-only MCP client for the local maskura-mcp stdio server."""
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+
+
+def require(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"{name} is required")
+    return value
+
+
+def send(process: subprocess.Popen[str], message: dict) -> None:
+    assert process.stdin is not None
+    process.stdin.write(json.dumps(message, separators=(",", ":")) + "\n")
+    process.stdin.flush()
+
+
+def receive(process: subprocess.Popen[str], request_id: int) -> dict:
+    assert process.stdout is not None
+    for line in process.stdout:
+        message = json.loads(line)
+        if message.get("id") == request_id:
+            if "error" in message:
+                raise RuntimeError(message["error"].get("message", "MCP request failed"))
+            return message["result"]
+    raise RuntimeError("maskura-mcp closed before returning a response")
+
+
+def request(process: subprocess.Popen[str], request_id: int, method: str, params=None):
+    message = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params is not None:
+        message["params"] = params
+    send(process, message)
+    return receive(process, request_id)
+
+
+def call_tool(process: subprocess.Popen[str], request_id: int, name: str, arguments: dict):
+    result = request(
+        process,
+        request_id,
+        "tools/call",
+        {"name": name, "arguments": arguments},
+    )
+    if result.get("isError"):
+        text = result.get("content", [{}])[0].get("text", "tool call failed")
+        raise RuntimeError(text)
+    return result
+
+
+def main() -> None:
+    gateway_url = require("MASKURA_GATEWAY_URL")
+    command = shlex.split(os.environ.get("MASKURA_MCP_COMMAND", "maskura-mcp"))
+    environment = os.environ.copy()
+    environment["MASKURA_GATEWAY_URL"] = gateway_url
+    token = os.environ.get("MASKURA_MCP_TOKEN")
+    access_key = os.environ.get("MASKURA_ACCESS_KEY")
+    secret_key = os.environ.get("MASKURA_SECRET_KEY")
+    if token:
+        environment["MASKURA_MCP_TOKEN"] = token
+    elif access_key and secret_key:
+        environment.pop("MASKURA_MCP_TOKEN", None)
+        environment["MASKURA_ACCESS_KEY"] = access_key
+        environment["MASKURA_SECRET_KEY"] = secret_key
+    else:
+        raise SystemExit(
+            "set MASKURA_MCP_TOKEN, or both MASKURA_ACCESS_KEY and "
+            "MASKURA_SECRET_KEY"
+        )
+
+    process = subprocess.Popen(
+        command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=environment,
+    )
+    try:
+        initialize = request(
+            process,
+            1,
+            "initialize",
+            {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "maskura-example", "version": "1"},
+            },
+        )
+        send(process, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+        tools = request(process, 2, "tools/list")
+        print(f"Connected to {initialize['serverInfo']['name']}")
+        print("Tools:", ", ".join(tool["name"] for tool in tools["tools"]))
+
+        if os.environ.get("MCP_EXAMPLE_RUN_MUTATIONS") != "1":
+            print("Set MCP_EXAMPLE_RUN_MUTATIONS=1 to run put/get/list/delete.")
+            return
+
+        bucket = os.environ.get("MCP_EXAMPLE_BUCKET", "agent-data")
+        key = os.environ.get("MCP_EXAMPLE_KEY", "examples/mcp.txt")
+        call_tool(
+            process,
+            3,
+            "maskura_put_object",
+            {
+                "bucket": bucket,
+                "key": key,
+                "body": "Contact alice@example.com",
+                "content_type": "text/plain; charset=utf-8",
+            },
+        )
+        read = call_tool(
+            process, 4, "maskura_get_object", {"bucket": bucket, "key": key}
+        )
+        print("Read:", read["content"][0]["text"])
+        listed = call_tool(
+            process,
+            5,
+            "maskura_list_objects",
+            {"bucket": bucket, "prefix": "examples/", "max_keys": 10},
+        )
+        print("List:", listed["content"][0]["text"])
+        call_tool(
+            process, 6, "maskura_delete_object", {"bucket": bucket, "key": key}
+        )
+        print(f"Deleted {bucket}/{key}")
+    finally:
+        if process.stdin is not None:
+            process.stdin.close()
+        try:
+            process.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, RuntimeError, json.JSONDecodeError) as error:
+        print(f"MCP example failed: {error}", file=sys.stderr)
+        raise SystemExit(1) from error


### PR DESCRIPTION
## Summary
- add a process-boundary MCP E2E that launches the real `maskura-mcp` binary and gateway
- verify workspace-bound token auth plus put, redacted get, paged list, delete, and missing-object behavior
- execute the documented Python client against the exact `maskura local init` auth-disabled loopback contract
- document local-first Claude Desktop, Cursor, and Kilo configuration, with hosted token usage separately
- advertise the server as `maskura-mcp` during MCP initialization
- bump the workspace to 0.5.1

## Validation
- `just check`
- `cargo test --locked -p s4-mcp --test stdio_e2e`
- `mdbook build docs`
- Python example syntax and executable lifecycle

## Local safety
The `local` placeholder key pair is documented only for the loopback gateway started by `maskura local init`, where `AUTH_DISABLED=true`; production and hosted examples remain credentialed.