### PR TITLE
docs: post-quantum benchmark results, encryption guide, and RSA-OAEP cleanup

### DIFF
--- a/crates/gateway/src/plugin_registry.rs
+++ b/crates/gateway/src/plugin_registry.rs
@@ -22,7 +22,8 @@ use crate::pipeline::{
 use crate::record::{OutputValidator, Record};
 
 /// Default per-session fuel budget for the plugin pipeline. Set high enough
-/// for crypto filters (one RSA-2048 OAEP wrap costs ~25M wasm instructions).
+/// for crypto filters (one hybrid X25519 + ML-KEM-768 envelope field costs
+/// ~34M wasm instructions).
 pub const DEFAULT_PIPELINE_FUEL: u64 = 1_000_000_000;
 
 /// Default bound for the digest-keyed compiled-component cache. Weight is the

--- a/crates/gateway/static/dashboard.html
+++ b/crates/gateway/static/dashboard.html
@@ -608,7 +608,7 @@ client.send(httpReq, HttpResponse.BodyHandlers.ofString());</div>
 <div class="section">
   <div class="section-label">Client SDKs</div>
   <div class="section-title">Envelope encryption built in</div>
-  <div class="section-subtitle">Python and TypeScript SDKs ship a high-level client. Generate a keypair, hand Maskura the public half once, and every PUT is envelope-encrypted server-side (RSA-OAEP + AES-256-GCM). Read back and decrypt with your private key; Maskura never sees it.</div>
+  <div class="section-subtitle">Python and TypeScript SDKs ship a high-level client. Generate a keypair, hand Maskura the public half once, and every PUT is envelope-encrypted server-side (hybrid X25519 + ML-KEM-768 + AES-256-GCM). Read back and decrypt with your private key; Maskura never sees it.</div>
 
   <div class="tab-bar">
     <button class="tab-btn active" onclick="switchTab('sdk-python', this)">Python</button>
@@ -629,7 +629,7 @@ client = MaskuraClient("http://localhost:9000", "s4_KEY_ID", "s4s_SECRET")
 private_pem, public_pem = MaskuraClient.generate_keypair()
 client.attach_public_key(public_pem)
 
-# Write — PII envelope-encrypted server-side (RSA-OAEP + AES-256-GCM)
+# Write — PII envelope-encrypted server-side (hybrid X25519 + ML-KEM-768 + AES-256-GCM)
 client.put_object("my-bucket", "ingest/data.jsonl", open("data.jsonl", "rb").read())
 
 # Read — decrypt the envelopes back to plaintext with your private key
@@ -655,7 +655,7 @@ const client = new MaskuraClient({
 const { privateKeyPem, publicKeyPem } = await MaskuraClient.generateKeypair();
 await client.attachPublicKey(publicKeyPem);
 
-// Write — PII encrypted server-side (RSA-OAEP + AES-256-GCM)
+// Write — PII encrypted server-side (hybrid X25519 + ML-KEM-768 + AES-256-GCM)
 await client.putObject("my-bucket", "ingest/data.jsonl",
   new TextEncoder().encode(JSON.stringify(records)));
 

--- a/crates/wasm-runtime/examples/bench_filters.rs
+++ b/crates/wasm-runtime/examples/bench_filters.rs
@@ -11,15 +11,7 @@ use std::time::{Duration, Instant};
 
 use s4_wasm_runtime::{FilterEngine, Operation, RuntimeLimits, Session, TransformOutcome};
 
-const PUBLIC_KEY_PEM: &str = "-----BEGIN PUBLIC KEY-----\n\
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmO5zDMFH3Ka2TpgJ1NSr\n\
-yOYHyn4l7r+yTnOc5AGe4bEQmErHrAmalqYbSJkO8yHH3M0TKojjCIK0v0zxJHdW\n\
-uFXLIwD9XpPBUAGPhDrcG1ljvEystFX/kIqJp8mUXLb5oLBkTJa7s7J0DO+P6lNb\n\
-hl0YNUajEQTqFpXvRG/sFeVyvIte6K+dsLCw3JBVnfNG7dJyRXuT6y0McoWdq2Wg\n\
-Nw5XL4h23bp2dvZjljUxJ3I43BZLQpymQjcvY2gCxFPb+n9Gix6x98WG3LzD8lwG\n\
-G/PyrV2DNfpRmgm2z62yoorRnZie7XC47Q1ecIyWEIVuVEzHIMMOwlfjFALVlZn/\n\
-MwIDAQAB\n\
------END PUBLIC KEY-----";
+const PUBLIC_KEY_PEM: &str = include_str!("../../../tests/fixtures/pii/crypto/hybrid-public.pem");
 
 const PII_EMAIL: &str = "alice@example.com";
 const PII_SSN: &str = "123-45-6789";

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,15 +3,13 @@
 - [Home](index.md)
 - [Demo](demo.md)
 - [Plugins](plugins.md)
+- [Encryption](encryption.md)
+- [Post-quantum encryption](post-quantum-crypto.md)
 - [Avro gate](avro.md)
 - [Binary adapters](binary-adapters.md)
 - [MCP](mcp.md)
 - [End-to-end suite](e2e.md)
 - [Security](security.md)
-
-# Roadmap (planned, not shipped)
-
-- [Post-quantum encryption](post-quantum-crypto.md)
 
 # Architecture Decision Records
 

--- a/docs/avro.md
+++ b/docs/avro.md
@@ -46,7 +46,7 @@ bytes and cannot declare an output schema.
 
 `x-maskura-encrypt-fields` selects comma-separated string schema paths, for example
 `email` or `contacts[*].email`. With an authenticated public key, selected
-fields become `RSA-OAEP/AES-256-GCM` envelope records and the Avro schema is
+fields become `X25519+ML-KEM-768/AES-256-GCM` envelope records and the Avro schema is
 evolved before encoding. Without a public key, selected fields are redacted to
 `[REDACTED]` while the string schema is preserved. Overlapping or invalid paths
 are rejected. Multipart completion uses identity processing; field selection

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -51,14 +51,17 @@ Detection/redaction scans every byte; cost is linear in size:
 | ssn-detect | 45.5 | 3.23 | 295 |
 | card-detect | 45.5 | 3.14 | 303 |
 
-### 3. Envelope encryption (RSA-2048 OAEP + AES-256-GCM)
+### 3. Envelope encryption (hybrid X25519 + ML-KEM-768 + AES-256-GCM)
 
-Cost is dominated by one RSA-OAEP wrap per detected field, ~52M fuel per field:
+Cost is dominated by one hybrid key encapsulation per detected field, ~35M fuel
+per field (down from ~52M for the RSA-2048 OAEP wrap it replaced). The
+encapsulation is larger — 1120 B per field vs 256 B — so expansion grows for
+dense records:
 
 | record | fields | fuel | ms/object | MiB/s | expansion |
 |--------|-------:|-----:|----------:|------:|----------:|
-| 1 KB | 1 | 52.3M | 2.27 | 0.4 | 2.38x |
-| 1 MB | 100 | 5.24G | 178.6 | 5.3 | 1.14x |
+| 1 KB | 1 | 35.1M | 0.97 | 1.0 | 5.86x |
+| 1 MB | 100 | 3.42G | 89.6 | 10.6 | 1.49x |
 
 ### 4. Stable (deterministic) encryption (AES-SIV)
 
@@ -77,7 +80,7 @@ scales with record size, plus ~170K fuel per encrypted field:
 |--------|----------:|---------------:|------:|
 | noop | ~0.02 | 1x | 1236 |
 | stable-encrypt (0 fields) | ~1.0 | ~55x | 1023 |
-| envelope-encrypt (0 fields) | 27.7 | ~1490x | 275 |
+| envelope-encrypt (0 fields) | 28.6 | ~1540x | 520 |
 | email-detect | 41.5 | ~2230x | 346 |
 | ssn-detect | 45.5 | ~2450x | 295 |
 | card-detect | 45.5 | ~2450x | 303 |
@@ -92,10 +95,10 @@ marginal per-byte figure (`fuel/byte`) is the number to plan capacity against.
   A speed-optimized profile would lower wall-clock times; fuel is unaffected.
 - Fuel budget for this sweep was raised to 1e10 to measure crypto work rather
   than the production 1e9 ceiling. At the default budget, `envelope-encrypt`
-  exhausts fuel at roughly 19 encrypted fields per object.
+  exhausts fuel at roughly 27 encrypted fields per object.
 - A text record is padded/truncated to the target size; a small record with a
   high requested PII count therefore carries fewer actual tokens (see the CSV
   for exact input bytes).
-- `envelope-encrypt` numbers assume a valid RSA-2048 public key in the session
-  context and host-generated entropy; `stable-encrypt` uses a fixed 64-byte key
-  and tagged fields.
+- `envelope-encrypt` numbers assume a valid hybrid X25519 + ML-KEM-768 public
+  key in the session context and host-generated entropy; `stable-encrypt` uses a
+  fixed 64-byte key and tagged fields.

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,0 +1,132 @@
+# Encryption
+
+This page explains how Maskura's envelope encryption works, from the key you
+hand the gateway to the bytes that leave your writer. It is the long-form
+companion to the [post-quantum](post-quantum-crypto.md) feature page and
+[ADR 0011](adr/0011-post-quantum-hybrid-envelope.md).
+
+## The model
+
+Encryption is **envelope encryption** with a fresh data key per field:
+
+1. The gateway generates a random 256-bit **data encryption key (DEK)** and
+   encrypts the field with **AES-256-GCM**.
+2. The DEK is then **key-encapsulated** to your public key, so only the holder
+   of the matching private key can recover it.
+3. Both the ciphertext and the encapsulated DEK are written to storage.
+
+Maskura never sees a plaintext field, never sees the DEK after it is wrapped,
+and never holds your private key. Decryption happens entirely on the client.
+
+## The primitives
+
+| Role | Primitive | Why |
+|------|-----------|-----|
+| Data cipher | AES-256-GCM | Authenticated encryption; 256-bit keys resist Grover (~2^128) |
+| Classical KEM | X25519 (ECDH) | Protects against an undiscovered weakness in a young PQ scheme |
+| Post-quantum KEM | ML-KEM-768 (FIPS 203) | Protects against a cryptographically relevant quantum computer |
+| Combiner | HKDF-SHA256 | Folds the two shared secrets into one DEK |
+
+The construction is a **hybrid KEM**: the DEK is secure unless *both* X25519 and
+ML-KEM-768 are broken. This is the consensus position of the IETF hybrid
+key-exchange draft, NSA CNSA 2.0, and BSI.
+
+The data path contains no signatures, so ML-DSA and SLH-DSA are out of scope —
+KEM-only.
+
+## Encapsulation (encrypt)
+
+For each detected field the gateway:
+
+```text
+m            = 32 random bytes from a CSPRNG
+(mlkem_ss, mlkem_ct) = ML-KEM-768.Encaps(ek, m)        # ek = your ML-KEM public key
+x25519_sk    = 32 random bytes
+x25519_epk   = X25519(x25519_sk, basepoint)
+x25519_ss    = X25519(x25519_sk, your_x25519_pk)
+dek          = HKDF-SHA256(ikm = x25519_ss ‖ mlkem_ss,
+                           salt = "",
+                           info = "maskura/hybrid/envelope-dek/v1",
+                           L = 32)
+enc_dek      = x25519_epk ‖ mlkem_ct                  # 1120 bytes
+field        = AES-256-GCM(dek, iv, plaintext)
+```
+
+The wrapped key material (`enc_dek`) carries everything you need to decrypt:
+your X25519 ephemeral public key and the ML-KEM-768 ciphertext. The DEK itself
+is never stored — it is derived from the two shared secrets on both sides.
+
+## Decapsulation (decrypt, client-side)
+
+```text
+(x25519_epk, mlkem_ct) = split(enc_dek)
+x25519_ss = X25519(your_x25519_sk, x25519_epk)
+mlkem_ss  = ML-KEM-768.Decaps(your_mlkem_dk, mlkem_ct)
+dek       = HKDF-SHA256(same construction as above)
+plaintext = AES-256-GCM.Decrypt(dek, iv, ct ‖ tag)
+```
+
+## The envelope
+
+Each encrypted field becomes a JSON object with five fields:
+
+```json
+{"alg":"X25519+ML-KEM-768/AES-256-GCM","iv":"<b64>","enc_dek":"<b64>","ct":"<b64>","tag":"<b64>"}
+```
+
+- `alg` identifies the construction. Existing `RSA-OAEP/AES-256-GCM` envelopes
+  remain decryptable (dual-alg read); new writes are hybrid-only.
+- `iv` is the 12-byte AES-GCM nonce.
+- `enc_dek` is the 1120-byte hybrid encapsulation (base64).
+- `ct` / `tag` are the AES-256-GCM ciphertext and authentication tag.
+
+## Key format
+
+Keys are a single base64 blob of fixed-length concatenation, wrapped in PEM:
+
+```text
+-----BEGIN MASKURA HYBRID PUBLIC KEY-----
+base64( x25519_pk ‖ mlkem_ek )        # 32 + 1184 = 1216 bytes
+-----END MASKURA HYBRID PUBLIC KEY-----
+
+-----BEGIN MASKURA HYBRID PRIVATE KEY-----
+base64( x25519_sk ‖ mlkem_seed )      # 32 + 64 = 96 bytes
+-----END MASKURA HYBRID PRIVATE KEY-----
+```
+
+| Component | Size |
+|-----------|------|
+| X25519 public key / shared secret | 32 B |
+| ML-KEM-768 encapsulation key (public) | 1184 B |
+| ML-KEM-768 ciphertext | 1088 B |
+| ML-KEM-768 shared secret | 32 B |
+| ML-KEM-768 seed (private key serialization) | 64 B |
+| Hybrid public key | 1216 B |
+| Hybrid private key | 96 B |
+| `enc_dek` | 1120 B |
+
+The gateway's `public-key-pem` config field is unchanged: it is still a string.
+The private key never touches the gateway.
+
+## Security properties
+
+- **IND-CCA2.** Both KEMs are CCA-secure; the HKDF combiner produces an
+  indistinguishable DEK unless both are broken.
+- **Per-field keys.** A fresh DEK per field means a compromise of one DEK does
+  not expose any other field.
+- **Authenticated encryption.** AES-GCM binds the ciphertext to its tag; any
+  tampering fails decryption.
+- **Fail closed.** If key encapsulation or encryption fails, the field is
+  redacted rather than emitted as plaintext.
+- **Single-alg write.** New writes are hybrid-only; legacy RSA keys are rejected
+  for new writes and remain only for decrypting previously written objects.
+
+## Cost
+
+The hybrid wrap trades a slightly larger key encapsulation for materially
+cheaper CPU than the RSA-OAEP wrap it replaces:
+
+- ~34M Wasm fuel per encrypted field (vs ~52M for RSA-2048 OAEP).
+- `enc_dek` grows from 256 B (RSA-2048) to 1120 B per field.
+
+Measured numbers and methodology are in [Benchmarks](benchmarks.md).

--- a/docs/post-quantum-crypto.md
+++ b/docs/post-quantum-crypto.md
@@ -1,13 +1,15 @@
 # Post-quantum encryption
 
-> **Status: planned.** This page describes an upcoming feature, not shipped
-> behavior. Current builds use RSA-OAEP key wrapping.
+> **Status: shipped.** Current builds wrap the data key with a hybrid X25519 +
+> ML-KEM-768 key encapsulation. See [Encryption](encryption.md) for the details
+> and [ADR 0011](adr/0011-post-quantum-hybrid-envelope.md) for the decision.
 
 ## What it is
 
 Maskura's encryption filters protect fields with envelope encryption: a fresh
 AES-256-GCM key per field, wrapped with a public key so only the key holder can
-decrypt. Today that wrap is RSA-OAEP, which a quantum computer can break.
+decrypt. Before this change that wrap was RSA-OAEP, which a quantum computer can
+break.
 
 The post-quantum feature replaces the RSA-OAEP wrap with a **hybrid X25519 +
 ML-KEM-768** key encapsulation:
@@ -34,5 +36,6 @@ The data cipher stays AES-256-GCM, which is already post-quantum-safe.
 
 ## See also
 
+- [Encryption](encryption.md)
 - [Plugins](plugins.md)
 - [Security](security.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -142,10 +142,10 @@ persisted.
 Credential mutations are bounded before persistence. API-key and MCP labels are
 trimmed, non-empty, free of control characters, and at most 128 UTF-8 bytes.
 Non-zero API-key and MCP lifetimes are at most one year (`0` means no expiry).
-Encryption public keys are at most 16 KiB and must be an SPKI public-key PEM or
-X.509 certificate carrying an RSA key between 2048 and 4096 bits, matching the
-formats consumed by the envelope-encryption filter. Credential JSON endpoints
-also have route-specific body limits; oversized requests receive `413`.
+Encryption public keys are at most 16 KiB and must be a `MASKURA HYBRID PUBLIC
+KEY` PEM carrying an X25519 public key and an ML-KEM-768 encapsulation key,
+matching the format consumed by the envelope-encryption filter. Credential JSON
+endpoints also have route-specific body limits; oversized requests receive `413`.
 
 Credential creation returns plaintext only after the repository has committed
 the new credential. File-backed mutations remain hidden from concurrent readers
@@ -209,8 +209,9 @@ signatures — regenerate them if you need native S3 tools.
   a capped queue and a guest-memory budget (`MemoryAdmission`); admission
   failure surfaces as `SlowDown` rather than unbounded parallelism.
 - The pipeline is deterministic and runs **before** data reaches storage on
-  the write path: redaction replaces PII, encryption (per-field RSA-OAEP /
-  AES-256-GCM) keeps the decryption key solely with the client. `stable-encrypt`
+  the write path: redaction replaces PII, encryption (per-field hybrid X25519 +
+  ML-KEM-768 / AES-256-GCM) keeps the decryption key solely with the client.
+  `stable-encrypt`
   (AES-SIV) is opt-in for JOIN keys and derives from the API key secret, never
   the raw secret.
 - Every authenticated request resolves its user through the


### PR DESCRIPTION
Follow-up to the hybrid X25519 + ML-KEM-768 envelope implementation (ADR 0011 / PR #108).

- Re-measured `envelope-encrypt` and published the hybrid numbers: **~35M fuel/field** (vs ~52M for RSA-2048 OAEP), with per-field `enc_dek` growing 256 B → 1120 B.
- Added `docs/encryption.md` — a deep-dive chapter on the envelope construction, key format, primitives, and security properties.
- Marked `docs/post-quantum-crypto.md` as shipped; moved it out of the "Roadmap" section.
- Cleared the remaining RSA-OAEP references from `docs/security.md`, `docs/avro.md`, `plugin_registry.rs` (fuel comment), and the dashboard copy.
- Swapped the benchmark harness (`bench_filters.rs`) from the RSA fixture to the committed hybrid public key.

Docs build (`mdbook build docs`) passes; `cargo fmt --check` and affected crates compile clean.