### PR TITLE
feat: layered TOML config with env override, abandon S4_*/x-s4-* aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ Document every infrastructure, auth, storage, and deployment choice so automatio
 - **Supabase Auth (GoTrue)** for user signup, login, magic-link emails, and session management.
 - Supabase JS client in the dashboard browser app; `jsonwebtoken` crate in the gateway validates JWTs.
 - API keys (S3 access key + secret) and MCP tokens are separate from user sessions. Each stores immutable `workspace_id` execution scope plus `user_id` dashboard ownership. Legacy unbound credentials fail authentication rather than resolving a current/default workspace.
-- Gateway verifies API keys on S3 routes via `x-maskura-access-key` / `x-maskura-secret-key` headers (with permanent `x-s4-*` aliases) or `Authorization: Bearer <access_key>:<secret>`.
+- Gateway verifies API keys on S3 routes via `x-maskura-access-key` / `x-maskura-secret-key` headers or `Authorization: Bearer <access_key>:<secret>`.
 
 ### Database
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3052,7 +3052,10 @@ dependencies = [
 name = "maskura-customer-config"
 version = "0.5.2"
 dependencies = [
+ "serde",
  "thiserror 2.0.20",
+ "toml 0.8.23",
+ "url",
 ]
 
 [[package]]
@@ -3678,7 +3681,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -4899,6 +4902,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -5726,17 +5738,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5759,6 +5792,20 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
@@ -5777,6 +5824,12 @@ checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -6398,7 +6451,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2 0.10.9",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "wasmtime-environ",
  "windows-sys 0.61.2",
  "zstd",
@@ -7003,6 +7056,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/README.md
+++ b/README.md
@@ -136,10 +136,7 @@ storage (MinIO), clone the repo and use `just dev-up`.
 ## Compatibility
 
 New integrations should use `MASKURA_*` environment variables and
-`x-maskura-*` headers. Every shipped customer `S4_*` setting and `x-s4-*`
-header remains a permanent alias. Equal dual values are accepted; differing
-values fail closed, and an empty value is treated as a real value for conflict
-checks. The `s4ctl` and `s4-mcp` binaries, `s4_*` MCP tools, `s4_client` Python
+`x-maskura-*` headers. The `s4ctl` and `s4-mcp` binaries, `s4_*` MCP tools, `s4_client` Python
 module, and `S4Client` SDK exports remain available.
 
 Persistent and security-sensitive identifiers do not change: credentials still

--- a/crates/customer-config/Cargo.toml
+++ b/crates/customer-config/Cargo.toml
@@ -7,4 +7,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
+serde = { workspace = true }
 thiserror.workspace = true
+toml = "0.8"
+url = "2"

--- a/crates/customer-config/src/config.rs
+++ b/crates/customer-config/src/config.rs
@@ -1,0 +1,969 @@
+use std::net::SocketAddr;
+use std::path::Path;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamingReadMode {
+    #[default]
+    Off,
+    Passthrough,
+    Transformed,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MultipartMode {
+    #[default]
+    Reject,
+    Staged,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ManagedStreamingMode {
+    #[default]
+    Off,
+    Observe,
+    Enforce,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamingS3Provider {
+    Aws,
+    Minio,
+    R2,
+    B2,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ServerConfig {
+    pub listen_addr: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct AuthConfig {
+    pub disabled: bool,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct StorageConfig {
+    pub s3_endpoint: Option<String>,
+    pub s3_region: Option<String>,
+    pub service_buckets: Vec<String>,
+    pub single_tenant: bool,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct SupabaseConfig {
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct FeaturesConfig {
+    pub multipart_mode: MultipartMode,
+    pub streaming_read_mode: StreamingReadMode,
+    pub transformed_read_spool: bool,
+    pub enable_avro: bool,
+    pub streaming_s3_provider: Option<StreamingS3Provider>,
+    pub dev_memory_streaming: bool,
+    pub managed_streaming_mode: ManagedStreamingMode,
+    pub managed_streaming_transactional: bool,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct WasmConfig {
+    pub filter_component: Option<String>,
+    pub plugins_dir: Option<String>,
+    pub fuel: Option<u64>,
+    pub prefix_safe_component_hashes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct LimitsConfig {
+    pub source_max_frame_bytes: Option<u64>,
+    pub max_object_bytes: Option<u64>,
+    pub max_pipeline_output_bytes: Option<u64>,
+    pub legacy_max_object_bytes: Option<u64>,
+    pub dev_memory_max_object_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct SpoolConfig {
+    pub dir: Option<String>,
+    pub max_object_bytes: Option<u64>,
+    pub quota_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct KeysConfig {
+    pub keys_file: Option<String>,
+    pub bootstrap_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ManagedConfig {
+    pub placement_version: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct MultipartStagingConfig {
+    pub endpoint: Option<String>,
+    pub bucket: Option<String>,
+    pub region: Option<String>,
+    pub dir: Option<String>,
+    pub tenant_quota_bytes: Option<u64>,
+    pub global_quota_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct SigV4Config {
+    pub region: Option<String>,
+    pub trusted_tls: bool,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct AllowlistsConfig {
+    pub workspace_endpoint: Vec<String>,
+    pub workspace_endpoint_private: Vec<String>,
+    pub presigned_http: Vec<String>,
+    pub presigned_http_private: Vec<String>,
+    pub presigned_http_allow_http: bool,
+    pub presigned_http_min_validity_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Config {
+    pub server: ServerConfig,
+    pub auth: AuthConfig,
+    pub storage: StorageConfig,
+    pub supabase: SupabaseConfig,
+    pub features: FeaturesConfig,
+    pub wasm: WasmConfig,
+    pub limits: LimitsConfig,
+    pub spool: SpoolConfig,
+    pub keys: KeysConfig,
+    pub managed: ManagedConfig,
+    pub multipart_staging: MultipartStagingConfig,
+    pub sigv4: SigV4Config,
+    pub allowlists: AllowlistsConfig,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("invalid configuration at `{path}`: {message}")]
+pub struct ConfigError {
+    pub path: String,
+    pub message: String,
+}
+
+fn invalid(path: &str, message: impl Into<String>) -> ConfigError {
+    ConfigError {
+        path: path.to_string(),
+        message: message.into(),
+    }
+}
+
+impl From<crate::EnvError> for ConfigError {
+    fn from(error: crate::EnvError) -> Self {
+        match error {
+            crate::EnvError::NotUnicode { name } => invalid(name, "must contain valid UTF-8"),
+        }
+    }
+}
+
+impl Config {
+    pub fn from_toml_str(input: &str) -> Result<Self, ConfigError> {
+        let config: Config = toml::from_str(input)
+            .map_err(|error| invalid("<input>", format!("malformed TOML: {error}")))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn from_file(path: &Path) -> Result<Self, ConfigError> {
+        let input = std::fs::read_to_string(path).map_err(|error| {
+            invalid(
+                &path.display().to_string(),
+                format!("failed to read config file: {error}"),
+            )
+        })?;
+        let config: Config = toml::from_str(&input).map_err(|error| {
+            invalid(
+                &path.display().to_string(),
+                format!("malformed TOML: {error}"),
+            )
+        })?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Apply the documented environment-variable override layer on top of the
+    /// file-sourced values. Every non-secret field is overridable; secrets stay
+    /// env-only and are resolved by the gateway, not here.
+    pub fn apply_env_overrides(&mut self) -> Result<(), ConfigError> {
+        use crate::{aliases, resolve};
+
+        if let Some(value) = std::env::var("LISTEN_ADDR").ok().filter(|v| !v.is_empty()) {
+            self.server.listen_addr = Some(value);
+        }
+        if let Some(value) = env_bool("AUTH_DISABLED")? {
+            self.auth.disabled = value;
+        }
+        if let Some(value) = std::env::var("S3_ENDPOINT").ok().filter(|v| !v.is_empty()) {
+            self.storage.s3_endpoint = Some(value);
+        }
+        if let Some(value) = std::env::var("S3_REGION").ok().filter(|v| !v.is_empty()) {
+            self.storage.s3_region = Some(value);
+        }
+        if let Ok(value) = std::env::var("S4_SERVICE_BUCKETS") {
+            self.storage.service_buckets = split_commas(&value);
+        }
+        if let Some(value) = resolve(aliases::SINGLE_TENANT)? {
+            self.storage.single_tenant = parse_bool("storage.single_tenant", &value)?;
+        }
+        if let Some(value) = std::env::var("SUPABASE_URL").ok().filter(|v| !v.is_empty()) {
+            self.supabase.url = Some(value);
+        }
+        if let Some(value) = resolve(aliases::MULTIPART_MODE)? {
+            self.features.multipart_mode = parse_multipart_mode(&value)?;
+        }
+        if let Some(value) = resolve(aliases::STREAMING_READ_MODE)? {
+            self.features.streaming_read_mode = parse_streaming_read_mode(&value)?;
+        }
+        if let Some(value) = resolve(aliases::TRANSFORMED_READ_SPOOL)? {
+            self.features.transformed_read_spool = value.eq_ignore_ascii_case("encrypted");
+        }
+        if let Some(value) = resolve(aliases::ENABLE_AVRO)? {
+            self.features.enable_avro = parse_bool("features.enable_avro", &value)?;
+        }
+        if let Some(value) = resolve(aliases::STREAMING_S3_PROVIDER)? {
+            self.features.streaming_s3_provider = Some(parse_streaming_provider(&value)?);
+        }
+        if let Some(value) = resolve(aliases::DEV_MEMORY_STREAMING)? {
+            self.features.dev_memory_streaming =
+                parse_bool("features.dev_memory_streaming", &value)?;
+        }
+        if let Ok(value) = std::env::var("S4_MANAGED_STREAMING_MODE") {
+            self.features.managed_streaming_mode = parse_managed_mode(&value)?;
+        }
+        if let Ok(value) = std::env::var("S4_MANAGED_STREAMING_TRANSACTIONAL") {
+            self.features.managed_streaming_transactional =
+                parse_bool("features.managed_streaming_transactional", &value)?;
+        }
+        if let Some(value) = resolve(aliases::FILTER_COMPONENT)? {
+            self.wasm.filter_component = Some(value);
+        }
+        if let Some(value) = resolve(aliases::PLUGINS_DIR)? {
+            self.wasm.plugins_dir = Some(value);
+        }
+        if let Some(value) = resolve(aliases::WASM_FUEL)? {
+            self.wasm.fuel = Some(parse_u64("wasm.fuel", &value)?);
+        }
+        if let Some(value) = resolve(aliases::PREFIX_SAFE_COMPONENT_HASHES)? {
+            self.wasm.prefix_safe_component_hashes = split_commas(&value);
+        }
+        if let Some(value) = resolve(aliases::SOURCE_MAX_FRAME_BYTES)? {
+            self.limits.source_max_frame_bytes =
+                Some(parse_u64("limits.source_max_frame_bytes", &value)?);
+        }
+        if let Some(value) = resolve(aliases::MAX_OBJECT_BYTES)? {
+            self.limits.max_object_bytes = Some(parse_u64("limits.max_object_bytes", &value)?);
+        }
+        if let Some(value) = resolve(aliases::MAX_PIPELINE_OUTPUT_BYTES)? {
+            self.limits.max_pipeline_output_bytes =
+                Some(parse_u64("limits.max_pipeline_output_bytes", &value)?);
+        }
+        if let Some(value) = resolve(aliases::LEGACY_MAX_OBJECT_BYTES)? {
+            self.limits.legacy_max_object_bytes =
+                Some(parse_u64("limits.legacy_max_object_bytes", &value)?);
+        }
+        if let Some(value) = resolve(aliases::DEV_MEMORY_MAX_OBJECT_BYTES)? {
+            self.limits.dev_memory_max_object_bytes =
+                Some(parse_u64("limits.dev_memory_max_object_bytes", &value)?);
+        }
+        if let Some(value) = resolve(aliases::SPOOL_DIR)? {
+            self.spool.dir = Some(value);
+        }
+        if let Some(value) = resolve(aliases::SPOOL_MAX_OBJECT_BYTES)? {
+            self.spool.max_object_bytes = Some(parse_u64("spool.max_object_bytes", &value)?);
+        }
+        if let Some(value) = resolve(aliases::SPOOL_QUOTA_BYTES)? {
+            self.spool.quota_bytes = Some(parse_u64("spool.quota_bytes", &value)?);
+        }
+        if let Some(value) = resolve(aliases::KEYS_FILE)? {
+            self.keys.keys_file = Some(value);
+        }
+        if let Some(value) = resolve(aliases::BOOTSTRAP_KEY)? {
+            self.keys.bootstrap_key = Some(value);
+        }
+        if let Ok(value) = std::env::var("S4_MANAGED_PLACEMENT_VERSION") {
+            self.managed.placement_version = Some(parse_u32("managed.placement_version", &value)?);
+        }
+        if let Ok(value) = std::env::var("S4_MULTIPART_STAGING_ENDPOINT") {
+            self.multipart_staging.endpoint = Some(value);
+        }
+        if let Ok(value) = std::env::var("S4_MULTIPART_STAGING_BUCKET") {
+            self.multipart_staging.bucket = Some(value);
+        }
+        if let Ok(value) = std::env::var("S4_MULTIPART_STAGING_REGION") {
+            self.multipart_staging.region = Some(value);
+        }
+        if let Ok(value) = std::env::var("S4_MULTIPART_STAGING_DIR") {
+            self.multipart_staging.dir = Some(value);
+        }
+        if let Ok(value) = std::env::var("S4_MULTIPART_STAGING_TENANT_QUOTA_BYTES") {
+            self.multipart_staging.tenant_quota_bytes =
+                Some(parse_u64("multipart_staging.tenant_quota_bytes", &value)?);
+        }
+        if let Ok(value) = std::env::var("S4_MULTIPART_STAGING_GLOBAL_QUOTA_BYTES") {
+            self.multipart_staging.global_quota_bytes =
+                Some(parse_u64("multipart_staging.global_quota_bytes", &value)?);
+        }
+        if let Some(value) = std::env::var("S4_SIGV4_REGION")
+            .ok()
+            .filter(|v| !v.is_empty())
+        {
+            self.sigv4.region = Some(value);
+        }
+        if let Ok(value) = std::env::var("S4_SIGV4_TRUSTED_TLS") {
+            self.sigv4.trusted_tls = parse_bool("sigv4.trusted_tls", &value)?;
+        }
+        if let Ok(value) = std::env::var("S4_WORKSPACE_ENDPOINT_ALLOWLIST") {
+            self.allowlists.workspace_endpoint = split_commas(&value);
+        }
+        if let Ok(value) = std::env::var("S4_WORKSPACE_ENDPOINT_PRIVATE_ALLOWLIST") {
+            self.allowlists.workspace_endpoint_private = split_commas(&value);
+        }
+        if let Ok(value) = std::env::var("S4_PRESIGNED_HTTP_ALLOWLIST") {
+            self.allowlists.presigned_http = split_commas(&value);
+        }
+        if let Ok(value) = std::env::var("S4_PRESIGNED_HTTP_PRIVATE_ALLOWLIST") {
+            self.allowlists.presigned_http_private = split_commas(&value);
+        }
+        if let Ok(value) = std::env::var("S4_PRESIGNED_HTTP_ALLOW_HTTP") {
+            self.allowlists.presigned_http_allow_http =
+                parse_bool("allowlists.presigned_http_allow_http", &value)?;
+        }
+        if let Ok(value) = std::env::var("S4_PRESIGNED_HTTP_MIN_VALIDITY_SECS") {
+            self.allowlists.presigned_http_min_validity_secs = Some(parse_u64(
+                "allowlists.presigned_http_min_validity_secs",
+                &value,
+            )?);
+        }
+
+        self.validate()
+    }
+
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if let Some(addr) = self.server.listen_addr.as_deref() {
+            addr.parse::<SocketAddr>().map_err(|error| {
+                invalid(
+                    "server.listen_addr",
+                    format!("{addr:?} is not a valid socket address: {error}"),
+                )
+            })?;
+        }
+
+        validate_url("storage.s3_endpoint", self.storage.s3_endpoint.as_deref())?;
+        if let Some(region) = self.storage.s3_region.as_deref()
+            && region.is_empty()
+        {
+            return Err(invalid("storage.s3_region", "must not be empty"));
+        }
+        for (index, bucket) in self.storage.service_buckets.iter().enumerate() {
+            if bucket.trim().is_empty() {
+                return Err(invalid(
+                    &format!("storage.service_buckets[{index}]"),
+                    "must not be empty",
+                ));
+            }
+        }
+
+        validate_url("supabase.url", self.supabase.url.as_deref())?;
+
+        for (index, hash) in self.wasm.prefix_safe_component_hashes.iter().enumerate() {
+            if hash.len() != 64 || !hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+                return Err(invalid(
+                    &format!("wasm.prefix_safe_component_hashes[{index}]"),
+                    "must be a 64-character hexadecimal SHA-256 digest",
+                ));
+            }
+        }
+        if let Some(fuel) = self.wasm.fuel
+            && fuel == 0
+        {
+            return Err(invalid("wasm.fuel", "must be greater than zero"));
+        }
+
+        for (path, value) in [
+            (
+                "limits.source_max_frame_bytes",
+                self.limits.source_max_frame_bytes,
+            ),
+            ("limits.max_object_bytes", self.limits.max_object_bytes),
+            (
+                "limits.max_pipeline_output_bytes",
+                self.limits.max_pipeline_output_bytes,
+            ),
+            (
+                "limits.legacy_max_object_bytes",
+                self.limits.legacy_max_object_bytes,
+            ),
+            (
+                "limits.dev_memory_max_object_bytes",
+                self.limits.dev_memory_max_object_bytes,
+            ),
+        ] {
+            if let Some(value) = value
+                && value == 0
+            {
+                return Err(invalid(path, "must be greater than zero"));
+            }
+        }
+
+        if let Some(max) = self.spool.max_object_bytes
+            && max == 0
+        {
+            return Err(invalid(
+                "spool.max_object_bytes",
+                "must be greater than zero",
+            ));
+        }
+        if let Some(quota) = self.spool.quota_bytes {
+            if quota == 0 {
+                return Err(invalid("spool.quota_bytes", "must be greater than zero"));
+            }
+            if let Some(max) = self.spool.max_object_bytes
+                && quota < max
+            {
+                return Err(invalid(
+                    "spool.quota_bytes",
+                    "must be greater than or equal to spool.max_object_bytes",
+                ));
+            }
+        }
+
+        if let Some(version) = self.managed.placement_version
+            && version == 0
+        {
+            return Err(invalid(
+                "managed.placement_version",
+                "must be greater than zero",
+            ));
+        }
+
+        validate_url(
+            "multipart_staging.endpoint",
+            self.multipart_staging.endpoint.as_deref(),
+        )?;
+        for (path, value) in [
+            (
+                "multipart_staging.bucket",
+                self.multipart_staging.bucket.as_deref(),
+            ),
+            (
+                "multipart_staging.region",
+                self.multipart_staging.region.as_deref(),
+            ),
+            (
+                "multipart_staging.dir",
+                self.multipart_staging.dir.as_deref(),
+            ),
+        ] {
+            if let Some(value) = value
+                && value.is_empty()
+            {
+                return Err(invalid(path, "must not be empty"));
+            }
+        }
+        for (path, value) in [
+            (
+                "multipart_staging.tenant_quota_bytes",
+                self.multipart_staging.tenant_quota_bytes,
+            ),
+            (
+                "multipart_staging.global_quota_bytes",
+                self.multipart_staging.global_quota_bytes,
+            ),
+        ] {
+            if let Some(value) = value
+                && value == 0
+            {
+                return Err(invalid(path, "must be greater than zero"));
+            }
+        }
+
+        if let Some(region) = self.sigv4.region.as_deref()
+            && region.is_empty()
+        {
+            return Err(invalid("sigv4.region", "must not be empty"));
+        }
+
+        validate_host_entries(
+            "allowlists.workspace_endpoint",
+            &self.allowlists.workspace_endpoint,
+        )?;
+        validate_host_entries(
+            "allowlists.workspace_endpoint_private",
+            &self.allowlists.workspace_endpoint_private,
+        )?;
+        validate_host_entries("allowlists.presigned_http", &self.allowlists.presigned_http)?;
+        validate_host_entries(
+            "allowlists.presigned_http_private",
+            &self.allowlists.presigned_http_private,
+        )?;
+        if let Some(validity) = self.allowlists.presigned_http_min_validity_secs
+            && validity == 0
+        {
+            return Err(invalid(
+                "allowlists.presigned_http_min_validity_secs",
+                "must be greater than zero",
+            ));
+        }
+
+        self.validate_combinations()
+    }
+
+    fn validate_combinations(&self) -> Result<(), ConfigError> {
+        if self.storage.s3_endpoint.is_some() && !self.storage.service_buckets.is_empty() {
+            return Err(invalid(
+                "storage",
+                "S3_ENDPOINT and service_buckets are mutually exclusive: set one or the other",
+            ));
+        }
+
+        if self.features.managed_streaming_mode != ManagedStreamingMode::Off {
+            if !self.features.managed_streaming_transactional {
+                return Err(invalid(
+                    "features.managed_streaming_mode",
+                    "observe/enforce requires managed_streaming_transactional = true",
+                ));
+            }
+            if self.storage.service_buckets.is_empty() {
+                return Err(invalid(
+                    "features.managed_streaming_mode",
+                    "observe/enforce requires storage.service_buckets to be configured",
+                ));
+            }
+        }
+
+        if self.features.streaming_read_mode == StreamingReadMode::Transformed
+            && !self.features.transformed_read_spool
+        {
+            return Err(invalid(
+                "features.streaming_read_mode",
+                "transformed reads require transformed_read_spool = true",
+            ));
+        }
+
+        if self.features.multipart_mode == MultipartMode::Staged {
+            let missing: Vec<&str> = [
+                (
+                    "multipart_staging.endpoint",
+                    self.multipart_staging.endpoint.as_deref(),
+                ),
+                (
+                    "multipart_staging.bucket",
+                    self.multipart_staging.bucket.as_deref(),
+                ),
+                (
+                    "multipart_staging.region",
+                    self.multipart_staging.region.as_deref(),
+                ),
+                (
+                    "multipart_staging.dir",
+                    self.multipart_staging.dir.as_deref(),
+                ),
+            ]
+            .into_iter()
+            .filter(|(_, value)| value.is_none_or(|v| v.is_empty()))
+            .map(|(path, _)| path)
+            .collect();
+            if !missing.is_empty() {
+                return Err(invalid(
+                    "features.multipart_mode",
+                    format!(
+                        "staged multipart requires {} to be configured",
+                        missing.join(", ")
+                    ),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn env_bool(name: &str) -> Result<Option<bool>, ConfigError> {
+    match std::env::var(name) {
+        Ok(value) => Ok(Some(parse_bool(name, &value)?)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(invalid(name, "must contain valid UTF-8")),
+    }
+}
+
+fn parse_bool(path: &str, value: &str) -> Result<bool, ConfigError> {
+    if value == "1" || value.eq_ignore_ascii_case("true") {
+        Ok(true)
+    } else if value == "0" || value.eq_ignore_ascii_case("false") {
+        Ok(false)
+    } else {
+        Err(invalid(
+            path,
+            format!("{value:?} is not a valid boolean (use true/false)"),
+        ))
+    }
+}
+
+fn parse_u64(path: &str, value: &str) -> Result<u64, ConfigError> {
+    value
+        .parse::<u64>()
+        .map_err(|_| invalid(path, format!("{value:?} is not a valid unsigned integer")))
+}
+
+fn parse_u32(path: &str, value: &str) -> Result<u32, ConfigError> {
+    value
+        .parse::<u32>()
+        .map_err(|_| invalid(path, format!("{value:?} is not a valid unsigned integer")))
+}
+
+fn parse_multipart_mode(value: &str) -> Result<MultipartMode, ConfigError> {
+    match value {
+        "reject" => Ok(MultipartMode::Reject),
+        "staged" => Ok(MultipartMode::Staged),
+        other => Err(invalid(
+            "features.multipart_mode",
+            format!("{other:?} is not one of reject, staged"),
+        )),
+    }
+}
+
+fn parse_streaming_read_mode(value: &str) -> Result<StreamingReadMode, ConfigError> {
+    match value {
+        "off" => Ok(StreamingReadMode::Off),
+        "passthrough" => Ok(StreamingReadMode::Passthrough),
+        "transformed" => Ok(StreamingReadMode::Transformed),
+        other => Err(invalid(
+            "features.streaming_read_mode",
+            format!("{other:?} is not one of off, passthrough, transformed"),
+        )),
+    }
+}
+
+fn parse_managed_mode(value: &str) -> Result<ManagedStreamingMode, ConfigError> {
+    match value {
+        "off" => Ok(ManagedStreamingMode::Off),
+        "observe" => Ok(ManagedStreamingMode::Observe),
+        "enforce" => Ok(ManagedStreamingMode::Enforce),
+        other => Err(invalid(
+            "features.managed_streaming_mode",
+            format!("{other:?} is not one of off, observe, enforce"),
+        )),
+    }
+}
+
+fn parse_streaming_provider(value: &str) -> Result<StreamingS3Provider, ConfigError> {
+    match value {
+        "aws" => Ok(StreamingS3Provider::Aws),
+        "minio" => Ok(StreamingS3Provider::Minio),
+        "r2" => Ok(StreamingS3Provider::R2),
+        "b2" => Ok(StreamingS3Provider::B2),
+        other => Err(invalid(
+            "features.streaming_s3_provider",
+            format!("{other:?} is not one of aws, minio, r2, b2"),
+        )),
+    }
+}
+
+fn split_commas(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn validate_url(path: &str, value: Option<&str>) -> Result<(), ConfigError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let parsed = url::Url::parse(value)
+        .map_err(|error| invalid(path, format!("{value:?} is not a valid URL: {error}")))?;
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return Err(invalid(path, format!("{value:?} must use http or https")));
+    }
+    Ok(())
+}
+
+fn validate_host_entries(path: &str, entries: &[String]) -> Result<(), ConfigError> {
+    for (index, entry) in entries.iter().enumerate() {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            return Err(invalid(&format!("{path}[{index}]"), "must not be empty"));
+        }
+        if entry.contains("://") {
+            return Err(invalid(
+                &format!("{path}[{index}]"),
+                format!("{entry:?} must be a host or *.suffix, not a URL"),
+            ));
+        }
+        let host = entry.strip_prefix("*.").unwrap_or(entry);
+        if host.is_empty()
+            || !host
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-'))
+        {
+            return Err(invalid(
+                &format!("{path}[{index}]"),
+                format!("{entry:?} is not a valid host or *.suffix"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(input: &str) -> Result<Config, ConfigError> {
+        Config::from_toml_str(input)
+    }
+
+    #[test]
+    fn accepts_empty_document() {
+        assert!(parse("").is_ok());
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_table() {
+        let error = parse("[unknown]\nx = 1\n").unwrap_err();
+        assert!(error.message.contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_unknown_nested_field() {
+        let error = parse("[server]\nlisten_addr = \"0.0.0.0:9000\"\nport = 1\n").unwrap_err();
+        assert!(error.message.contains("unknown field `port`"));
+    }
+
+    #[test]
+    fn rejects_malformed_toml() {
+        let error = parse("not [ valid toml").unwrap_err();
+        assert!(error.message.contains("malformed TOML"));
+    }
+
+    #[test]
+    fn rejects_wrong_value_type() {
+        let error = parse("[auth]\ndisabled = \"yes\"\n").unwrap_err();
+        assert!(error.message.contains("invalid type"));
+    }
+
+    #[test]
+    fn parses_valid_full_config() {
+        let config = parse(
+            r#"
+[server]
+listen_addr = "127.0.0.1:9000"
+
+[auth]
+disabled = true
+
+[storage]
+s3_endpoint = "http://minio:9000"
+s3_region = "us-east-1"
+
+[features]
+streaming_read_mode = "passthrough"
+
+[limits]
+max_object_bytes = 1048576
+
+[wasm]
+fuel = 1000000
+"#,
+        )
+        .unwrap();
+        assert_eq!(config.server.listen_addr.as_deref(), Some("127.0.0.1:9000"));
+        assert!(config.auth.disabled);
+        assert_eq!(
+            config.storage.s3_endpoint.as_deref(),
+            Some("http://minio:9000")
+        );
+        assert_eq!(
+            config.features.streaming_read_mode,
+            StreamingReadMode::Passthrough
+        );
+        assert_eq!(config.limits.max_object_bytes, Some(1_048_576));
+    }
+
+    #[test]
+    fn rejects_invalid_listen_addr() {
+        let error = parse("[server]\nlisten_addr = \"not-an-addr\"\n").unwrap_err();
+        assert_eq!(error.path, "server.listen_addr");
+    }
+
+    #[test]
+    fn rejects_non_http_url() {
+        let error = parse("[storage]\ns3_endpoint = \"ftp://example.com\"\n").unwrap_err();
+        assert_eq!(error.path, "storage.s3_endpoint");
+    }
+
+    #[test]
+    fn rejects_malformed_url() {
+        let error = parse("[storage]\ns3_endpoint = \"::not-a-url::\"\n").unwrap_err();
+        assert_eq!(error.path, "storage.s3_endpoint");
+    }
+
+    #[test]
+    fn rejects_bad_component_hash_length() {
+        let error = parse("[wasm]\nprefix_safe_component_hashes = [\"abcd\"]\n").unwrap_err();
+        assert_eq!(error.path, "wasm.prefix_safe_component_hashes[0]");
+    }
+
+    #[test]
+    fn rejects_non_hex_component_hash() {
+        let error = parse(&format!(
+            "[wasm]\nprefix_safe_component_hashes = [\"{}\"]\n",
+            "z".repeat(64)
+        ))
+        .unwrap_err();
+        assert_eq!(error.path, "wasm.prefix_safe_component_hashes[0]");
+    }
+
+    #[test]
+    fn accepts_valid_component_hash() {
+        let hash = "a".repeat(64);
+        let config = parse(&format!(
+            "[wasm]\nprefix_safe_component_hashes = [\"{hash}\"]\n"
+        ))
+        .unwrap();
+        assert_eq!(config.wasm.prefix_safe_component_hashes, vec![hash]);
+    }
+
+    #[test]
+    fn rejects_zero_byte_quotas() {
+        for (key, field) in [
+            ("source_max_frame_bytes", "limits.source_max_frame_bytes"),
+            ("max_object_bytes", "limits.max_object_bytes"),
+        ] {
+            let error = parse(&format!("[limits]\n{key} = 0\n")).unwrap_err();
+            assert_eq!(error.path, field, "field {field}");
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_enum_value() {
+        let error = parse("[features]\nmultipart_mode = \"bogus\"\n").unwrap_err();
+        assert!(error.message.contains("unknown variant"));
+    }
+
+    #[test]
+    fn rejects_mutually_exclusive_storage_modes() {
+        let error = parse(
+            "[storage]\ns3_endpoint = \"http://minio:9000\"\nservice_buckets = [\"primary\"]\n",
+        )
+        .unwrap_err();
+        assert_eq!(error.path, "storage");
+        assert!(error.message.contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn rejects_managed_observe_without_buckets() {
+        let error = parse(
+            "[features]\nmanaged_streaming_mode = \"observe\"\nmanaged_streaming_transactional = true\n",
+        )
+        .unwrap_err();
+        assert_eq!(error.path, "features.managed_streaming_mode");
+    }
+
+    #[test]
+    fn rejects_managed_observe_without_transactional() {
+        let error = parse(
+            "[features]\nmanaged_streaming_mode = \"enforce\"\n\n[storage]\nservice_buckets = [\"primary\"]\n",
+        )
+        .unwrap_err();
+        assert!(error.message.contains("managed_streaming_transactional"));
+    }
+
+    #[test]
+    fn rejects_transformed_read_without_spool() {
+        let error = parse("[features]\nstreaming_read_mode = \"transformed\"\n").unwrap_err();
+        assert_eq!(error.path, "features.streaming_read_mode");
+    }
+
+    #[test]
+    fn accepts_transformed_read_with_spool() {
+        assert!(
+            parse(
+                "[features]\nstreaming_read_mode = \"transformed\"\ntransformed_read_spool = true\n"
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_staged_multipart_missing_dependencies() {
+        let error = parse("[features]\nmultipart_mode = \"staged\"\n").unwrap_err();
+        assert_eq!(error.path, "features.multipart_mode");
+        assert!(error.message.contains("multipart_staging.endpoint"));
+    }
+
+    #[test]
+    fn accepts_staged_multipart_with_dependencies() {
+        assert!(
+            parse(
+                r#"
+[features]
+multipart_mode = "staged"
+
+[multipart_staging]
+endpoint = "http://minio:9000"
+bucket = "staging"
+region = "us-east-1"
+dir = "/var/lib/maskura/staging"
+"#
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_allowlist_host_entry() {
+        let error =
+            parse("[allowlists]\npresigned_http = [\"https://example.com\"]\n").unwrap_err();
+        assert_eq!(error.path, "allowlists.presigned_http[0]");
+    }
+
+    #[test]
+    fn accepts_wildcard_suffix_allowlist_entry() {
+        let config =
+            parse("[allowlists]\nworkspace_endpoint = [\"*.s3.amazonaws.com\"]\n").unwrap();
+        assert_eq!(
+            config.allowlists.workspace_endpoint,
+            vec!["*.s3.amazonaws.com"]
+        );
+    }
+
+    #[test]
+    fn rejects_spool_quota_below_object_max() {
+        let error = parse("[spool]\nmax_object_bytes = 100\nquota_bytes = 50\n").unwrap_err();
+        assert_eq!(error.path, "spool.quota_bytes");
+    }
+}

--- a/crates/customer-config/src/lib.rs
+++ b/crates/customer-config/src/lib.rs
@@ -1,5 +1,9 @@
 use std::ffi::OsString;
 
+pub mod config;
+
+pub use config::{Config, ConfigError};
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct EnvAlias(&'static str);
 

--- a/crates/customer-config/src/lib.rs
+++ b/crates/customer-config/src/lib.rs
@@ -1,14 +1,15 @@
 use std::ffi::OsString;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct EnvAlias {
-    pub canonical: &'static str,
-    pub legacy: &'static str,
-}
+pub struct EnvAlias(&'static str);
 
 impl EnvAlias {
-    pub const fn new(canonical: &'static str, legacy: &'static str) -> Self {
-        Self { canonical, legacy }
+    pub const fn new(name: &'static str) -> Self {
+        Self(name)
+    }
+
+    pub const fn name(self) -> &'static str {
+        self.0
     }
 }
 
@@ -16,73 +17,42 @@ impl EnvAlias {
 pub enum EnvError {
     #[error("{name} contains non-Unicode data")]
     NotUnicode { name: &'static str },
-    #[error("conflicting environment aliases: {canonical} and {legacy}")]
-    Conflict {
-        canonical: &'static str,
-        legacy: &'static str,
-    },
 }
 
 pub mod aliases {
     use super::EnvAlias;
 
-    pub const GATEWAY_URL: EnvAlias = EnvAlias::new("MASKURA_GATEWAY_URL", "S4_GATEWAY_URL");
-    pub const ACCESS_KEY: EnvAlias = EnvAlias::new("MASKURA_ACCESS_KEY", "S4_ACCESS_KEY");
-    pub const SECRET_KEY: EnvAlias = EnvAlias::new("MASKURA_SECRET_KEY", "S4_SECRET_KEY");
-    pub const MCP_TOKEN: EnvAlias = EnvAlias::new("MASKURA_MCP_TOKEN", "S4_MCP_TOKEN");
-    pub const PORT: EnvAlias = EnvAlias::new("MASKURA_PORT", "S4_PORT");
+    pub const GATEWAY_URL: EnvAlias = EnvAlias::new("MASKURA_GATEWAY_URL");
+    pub const ACCESS_KEY: EnvAlias = EnvAlias::new("MASKURA_ACCESS_KEY");
+    pub const SECRET_KEY: EnvAlias = EnvAlias::new("MASKURA_SECRET_KEY");
+    pub const MCP_TOKEN: EnvAlias = EnvAlias::new("MASKURA_MCP_TOKEN");
+    pub const PORT: EnvAlias = EnvAlias::new("MASKURA_PORT");
 
-    pub const FILTER_COMPONENT: EnvAlias =
-        EnvAlias::new("MASKURA_FILTER_COMPONENT", "S4_FILTER_COMPONENT");
-    pub const PLUGINS_DIR: EnvAlias = EnvAlias::new("MASKURA_PLUGINS_DIR", "S4_PLUGINS_DIR");
-    pub const WASM_FUEL: EnvAlias = EnvAlias::new("MASKURA_WASM_FUEL", "S4_WASM_FUEL");
-    pub const SOURCE_MAX_FRAME_BYTES: EnvAlias = EnvAlias::new(
-        "MASKURA_SOURCE_MAX_FRAME_BYTES",
-        "S4_SOURCE_MAX_FRAME_BYTES",
-    );
-    pub const MAX_OBJECT_BYTES: EnvAlias =
-        EnvAlias::new("MASKURA_MAX_OBJECT_BYTES", "S4_MAX_OBJECT_BYTES");
-    pub const MAX_PIPELINE_OUTPUT_BYTES: EnvAlias = EnvAlias::new(
-        "MASKURA_MAX_PIPELINE_OUTPUT_BYTES",
-        "S4_MAX_PIPELINE_OUTPUT_BYTES",
-    );
-    pub const STREAMING_READ_MODE: EnvAlias =
-        EnvAlias::new("MASKURA_STREAMING_READ_MODE", "S4_STREAMING_READ_MODE");
-    pub const TRANSFORMED_READ_SPOOL: EnvAlias = EnvAlias::new(
-        "MASKURA_TRANSFORMED_READ_SPOOL",
-        "S4_TRANSFORMED_READ_SPOOL",
-    );
-    pub const PREFIX_SAFE_COMPONENT_HASHES: EnvAlias = EnvAlias::new(
-        "MASKURA_PREFIX_SAFE_COMPONENT_HASHES",
-        "S4_PREFIX_SAFE_COMPONENT_HASHES",
-    );
-    pub const STREAMING_S3_PROVIDER: EnvAlias =
-        EnvAlias::new("MASKURA_STREAMING_S3_PROVIDER", "S4_STREAMING_S3_PROVIDER");
-    pub const ENABLE_AVRO: EnvAlias = EnvAlias::new("MASKURA_ENABLE_AVRO", "S4_ENABLE_AVRO");
-    pub const LEGACY_MAX_OBJECT_BYTES: EnvAlias = EnvAlias::new(
-        "MASKURA_LEGACY_MAX_OBJECT_BYTES",
-        "S4_LEGACY_MAX_OBJECT_BYTES",
-    );
-    pub const SINGLE_TENANT: EnvAlias = EnvAlias::new("MASKURA_SINGLE_TENANT", "S4_SINGLE_TENANT");
-    pub const MULTIPART_MODE: EnvAlias =
-        EnvAlias::new("MASKURA_MULTIPART_MODE", "S4_MULTIPART_MODE");
-    pub const SPOOL_DIR: EnvAlias = EnvAlias::new("MASKURA_SPOOL_DIR", "S4_SPOOL_DIR");
-    pub const SPOOL_MAX_OBJECT_BYTES: EnvAlias = EnvAlias::new(
-        "MASKURA_SPOOL_MAX_OBJECT_BYTES",
-        "S4_SPOOL_MAX_OBJECT_BYTES",
-    );
-    pub const SPOOL_QUOTA_BYTES: EnvAlias =
-        EnvAlias::new("MASKURA_SPOOL_QUOTA_BYTES", "S4_SPOOL_QUOTA_BYTES");
-    pub const DEV_MEMORY_MAX_OBJECT_BYTES: EnvAlias = EnvAlias::new(
-        "MASKURA_DEV_MEMORY_MAX_OBJECT_BYTES",
-        "S4_DEV_MEMORY_MAX_OBJECT_BYTES",
-    );
-    pub const DEV_MEMORY_STREAMING: EnvAlias =
-        EnvAlias::new("MASKURA_DEV_MEMORY_STREAMING", "S4_DEV_MEMORY_STREAMING");
-    pub const KEYS_FILE: EnvAlias = EnvAlias::new("MASKURA_KEYS_FILE", "S4_KEYS_FILE");
-    pub const BOOTSTRAP_KEY: EnvAlias = EnvAlias::new("MASKURA_BOOTSTRAP_KEY", "S4_BOOTSTRAP_KEY");
-    pub const BOOTSTRAP_SECRET: EnvAlias =
-        EnvAlias::new("MASKURA_BOOTSTRAP_SECRET", "S4_BOOTSTRAP_SECRET");
+    pub const FILTER_COMPONENT: EnvAlias = EnvAlias::new("MASKURA_FILTER_COMPONENT");
+    pub const PLUGINS_DIR: EnvAlias = EnvAlias::new("MASKURA_PLUGINS_DIR");
+    pub const WASM_FUEL: EnvAlias = EnvAlias::new("MASKURA_WASM_FUEL");
+    pub const SOURCE_MAX_FRAME_BYTES: EnvAlias = EnvAlias::new("MASKURA_SOURCE_MAX_FRAME_BYTES");
+    pub const MAX_OBJECT_BYTES: EnvAlias = EnvAlias::new("MASKURA_MAX_OBJECT_BYTES");
+    pub const MAX_PIPELINE_OUTPUT_BYTES: EnvAlias =
+        EnvAlias::new("MASKURA_MAX_PIPELINE_OUTPUT_BYTES");
+    pub const STREAMING_READ_MODE: EnvAlias = EnvAlias::new("MASKURA_STREAMING_READ_MODE");
+    pub const TRANSFORMED_READ_SPOOL: EnvAlias = EnvAlias::new("MASKURA_TRANSFORMED_READ_SPOOL");
+    pub const PREFIX_SAFE_COMPONENT_HASHES: EnvAlias =
+        EnvAlias::new("MASKURA_PREFIX_SAFE_COMPONENT_HASHES");
+    pub const STREAMING_S3_PROVIDER: EnvAlias = EnvAlias::new("MASKURA_STREAMING_S3_PROVIDER");
+    pub const ENABLE_AVRO: EnvAlias = EnvAlias::new("MASKURA_ENABLE_AVRO");
+    pub const LEGACY_MAX_OBJECT_BYTES: EnvAlias = EnvAlias::new("MASKURA_LEGACY_MAX_OBJECT_BYTES");
+    pub const SINGLE_TENANT: EnvAlias = EnvAlias::new("MASKURA_SINGLE_TENANT");
+    pub const MULTIPART_MODE: EnvAlias = EnvAlias::new("MASKURA_MULTIPART_MODE");
+    pub const SPOOL_DIR: EnvAlias = EnvAlias::new("MASKURA_SPOOL_DIR");
+    pub const SPOOL_MAX_OBJECT_BYTES: EnvAlias = EnvAlias::new("MASKURA_SPOOL_MAX_OBJECT_BYTES");
+    pub const SPOOL_QUOTA_BYTES: EnvAlias = EnvAlias::new("MASKURA_SPOOL_QUOTA_BYTES");
+    pub const DEV_MEMORY_MAX_OBJECT_BYTES: EnvAlias =
+        EnvAlias::new("MASKURA_DEV_MEMORY_MAX_OBJECT_BYTES");
+    pub const DEV_MEMORY_STREAMING: EnvAlias = EnvAlias::new("MASKURA_DEV_MEMORY_STREAMING");
+    pub const KEYS_FILE: EnvAlias = EnvAlias::new("MASKURA_KEYS_FILE");
+    pub const BOOTSTRAP_KEY: EnvAlias = EnvAlias::new("MASKURA_BOOTSTRAP_KEY");
+    pub const BOOTSTRAP_SECRET: EnvAlias = EnvAlias::new("MASKURA_BOOTSTRAP_SECRET");
 
     pub const GATEWAY_CUSTOMER_SETTINGS: &[EnvAlias] = &[
         FILTER_COMPONENT,
@@ -129,29 +99,13 @@ pub fn resolve_with(
     alias: EnvAlias,
     mut read: impl FnMut(&str) -> Option<OsString>,
 ) -> Result<Option<String>, EnvError> {
-    let canonical = read(alias.canonical)
-        .map(|value| {
-            value.into_string().map_err(|_| EnvError::NotUnicode {
-                name: alias.canonical,
-            })
-        })
-        .transpose()?;
-    let legacy = read(alias.legacy)
+    read(alias.name())
         .map(|value| {
             value
                 .into_string()
-                .map_err(|_| EnvError::NotUnicode { name: alias.legacy })
+                .map_err(|_| EnvError::NotUnicode { name: alias.name() })
         })
-        .transpose()?;
-
-    match (canonical, legacy) {
-        (Some(canonical), Some(legacy)) if canonical != legacy => Err(EnvError::Conflict {
-            canonical: alias.canonical,
-            legacy: alias.legacy,
-        }),
-        (Some(value), _) | (_, Some(value)) => Ok(Some(value)),
-        (None, None) => Ok(None),
-    }
+        .transpose()
 }
 
 #[cfg(test)]
@@ -160,7 +114,7 @@ mod tests {
 
     use super::*;
 
-    const TEST_ALIAS: EnvAlias = EnvAlias::new("MASKURA_VALUE", "S4_VALUE");
+    const TEST_ALIAS: EnvAlias = EnvAlias::new("MASKURA_VALUE");
 
     fn resolve_values(values: &[(&str, &str)]) -> Result<Option<String>, EnvError> {
         let values: HashMap<_, _> = values
@@ -171,78 +125,35 @@ mod tests {
     }
 
     #[test]
-    fn resolves_canonical_only() {
+    fn resolves_present_value() {
         assert_eq!(
-            resolve_values(&[("MASKURA_VALUE", "canonical")]),
-            Ok(Some("canonical".to_string()))
+            resolve_values(&[("MASKURA_VALUE", "value")]),
+            Ok(Some("value".to_string()))
         );
     }
 
     #[test]
-    fn resolves_legacy_only() {
-        assert_eq!(
-            resolve_values(&[("S4_VALUE", "legacy")]),
-            Ok(Some("legacy".to_string()))
-        );
-    }
-
-    #[test]
-    fn accepts_equal_dual_values() {
-        assert_eq!(
-            resolve_values(&[("MASKURA_VALUE", "same"), ("S4_VALUE", "same")]),
-            Ok(Some("same".to_string()))
-        );
-    }
-
-    #[test]
-    fn rejects_differing_dual_values_without_exposing_them() {
-        let error = resolve_values(&[("MASKURA_VALUE", "new-secret"), ("S4_VALUE", "old-secret")])
-            .unwrap_err();
-        let message = error.to_string();
-        assert_eq!(
-            error,
-            EnvError::Conflict {
-                canonical: "MASKURA_VALUE",
-                legacy: "S4_VALUE"
-            }
-        );
-        assert!(!message.contains("new-secret"));
-        assert!(!message.contains("old-secret"));
-    }
-
-    #[test]
-    fn preserves_empty_values_and_treats_empty_vs_nonempty_as_conflict() {
+    fn preserves_empty_values() {
         assert_eq!(
             resolve_values(&[("MASKURA_VALUE", "")]),
             Ok(Some(String::new()))
         );
-        assert_eq!(
-            resolve_values(&[("MASKURA_VALUE", ""), ("S4_VALUE", "")]),
-            Ok(Some(String::new()))
-        );
-        assert!(matches!(
-            resolve_values(&[("MASKURA_VALUE", ""), ("S4_VALUE", "set")]),
-            Err(EnvError::Conflict { .. })
-        ));
     }
 
     #[test]
-    fn returns_none_when_both_names_are_absent() {
+    fn returns_none_when_absent() {
         assert_eq!(resolve_values(&[]), Ok(None));
     }
 
     #[test]
-    fn shipped_alias_tables_are_canonical_unique_and_customer_only() {
+    fn shipped_alias_tables_are_unique_and_customer_only() {
         let aliases = aliases::GATEWAY_CUSTOMER_SETTINGS
             .iter()
             .chain(aliases::CLIENT_CUSTOMER_SETTINGS);
-        let mut canonical = std::collections::HashSet::new();
-        let mut legacy = std::collections::HashSet::new();
+        let mut names = std::collections::HashSet::new();
         for alias in aliases {
-            assert!(alias.canonical.starts_with("MASKURA_"));
-            assert!(alias.legacy.starts_with("S4_"));
-            assert!(canonical.insert(alias.canonical));
-            assert!(legacy.insert(alias.legacy));
+            assert!(alias.name().starts_with("MASKURA_"));
+            assert!(names.insert(alias.name()));
         }
         for operator_only in [
             "S4_SECRET_KEK",
@@ -253,7 +164,7 @@ mod tests {
             "S4_MANAGED_STREAMING_MODE",
             "S4_MULTIPART_STAGING_BUCKET",
         ] {
-            assert!(!legacy.contains(operator_only));
+            assert!(!names.contains(operator_only));
         }
     }
 }

--- a/crates/gateway/src/backend.rs
+++ b/crates/gateway/src/backend.rs
@@ -1493,10 +1493,10 @@ mod tests {
         // redirect the workspace into managed storage; unknown values are also
         // ignored.
         let mut managed_override = HeaderMap::new();
-        managed_override.insert("x-s4-storage-mode", "managed".parse().unwrap());
+        managed_override.insert("x-maskura-storage-mode", "managed".parse().unwrap());
         assert_operations_resolve_to(&resolver, &managed_override, BackendKind::PerUserS3).await;
         let mut unknown_mode = HeaderMap::new();
-        unknown_mode.insert("x-s4-storage-mode", "archive".parse().unwrap());
+        unknown_mode.insert("x-maskura-storage-mode", "archive".parse().unwrap());
         assert_operations_resolve_to(&resolver, &unknown_mode, BackendKind::PerUserS3).await;
 
         // Preserve the request-level shortcut only in explicit single-tenant
@@ -1511,7 +1511,7 @@ mod tests {
         );
         assert_operations_resolve_to(&development, &managed_override, BackendKind::Managed).await;
 
-        // x-s4-storage-mode: managed errors when no managed backend is configured.
+        // x-maskura-storage-mode: managed errors when no managed backend is configured.
         let no_managed = BackendResolver::new(
             Arc::new(InMemoryWorkspaceStorageRepository::new()),
             Arc::new(ServiceStorage::new(Vec::new())),
@@ -1529,7 +1529,7 @@ mod tests {
 
         let mut presigned = HeaderMap::new();
         presigned.insert(
-            "x-s4-backend-url",
+            "x-maskura-backend-url",
             "https://objects.example/object?Expires=9999999999"
                 .parse()
                 .unwrap(),
@@ -1745,7 +1745,7 @@ mod tests {
         );
         let workspace = WorkspaceId::new("workspace").unwrap();
         let mut headers = HeaderMap::new();
-        headers.insert("x-s4-storage-mode", "managed".parse().unwrap());
+        headers.insert("x-maskura-storage-mode", "managed".parse().unwrap());
         let Err(error) = resolver
             .resolve(&workspace, &headers, StorageOperation::Get)
             .await
@@ -1795,7 +1795,7 @@ mod tests {
             workspace_policy_with(false, &["*.storage.example"], &[], &["93.184.216.34:443"]),
         );
         let mut headers = HeaderMap::new();
-        headers.insert("x-s4-storage-mode", "managed".parse().unwrap());
+        headers.insert("x-maskura-storage-mode", "managed".parse().unwrap());
 
         let selection = resolver
             .resolve_with_routing(
@@ -2084,7 +2084,7 @@ mod tests {
                 workspace_policy(false),
             );
             let mut headers = HeaderMap::new();
-            headers.insert("x-s4-storage-mode", "managed".parse().unwrap());
+            headers.insert("x-maskura-storage-mode", "managed".parse().unwrap());
 
             let Err(error) = resolver
                 .resolve(

--- a/crates/gateway/src/customer_headers.rs
+++ b/crates/gateway/src/customer_headers.rs
@@ -1,29 +1,27 @@
 use axum::http::{HeaderMap, HeaderValue};
 
-#[derive(Clone, Copy, Debug)]
-pub struct HeaderAlias {
-    pub canonical: &'static str,
-    pub legacy: &'static str,
-}
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HeaderAlias(&'static str);
 
 impl HeaderAlias {
-    const fn new(canonical: &'static str, legacy: &'static str) -> Self {
-        Self { canonical, legacy }
+    const fn new(name: &'static str) -> Self {
+        Self(name)
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        self.0
     }
 }
 
-pub const ACCESS_KEY: HeaderAlias = HeaderAlias::new("x-maskura-access-key", "x-s4-access-key");
-pub const SECRET_KEY: HeaderAlias = HeaderAlias::new("x-maskura-secret-key", "x-s4-secret-key");
-pub const MCP_TOKEN: HeaderAlias = HeaderAlias::new("x-maskura-mcp-token", "x-s4-mcp-token");
-pub const STORAGE_MODE: HeaderAlias =
-    HeaderAlias::new("x-maskura-storage-mode", "x-s4-storage-mode");
-pub const BACKEND_URL: HeaderAlias = HeaderAlias::new("x-maskura-backend-url", "x-s4-backend-url");
-pub const PROCESS: HeaderAlias = HeaderAlias::new("x-maskura-process", "x-s4-process");
-pub const STABLE_FIELDS: HeaderAlias =
-    HeaderAlias::new("x-maskura-stable-fields", "x-s4-stable-fields");
-pub const ENCRYPT_FIELDS: HeaderAlias =
-    HeaderAlias::new("x-maskura-encrypt-fields", "x-s4-encrypt-fields");
-pub const PLUGIN_NAME: HeaderAlias = HeaderAlias::new("x-maskura-plugin-name", "x-s4-plugin-name");
+pub const ACCESS_KEY: HeaderAlias = HeaderAlias::new("x-maskura-access-key");
+pub const SECRET_KEY: HeaderAlias = HeaderAlias::new("x-maskura-secret-key");
+pub const MCP_TOKEN: HeaderAlias = HeaderAlias::new("x-maskura-mcp-token");
+pub const STORAGE_MODE: HeaderAlias = HeaderAlias::new("x-maskura-storage-mode");
+pub const BACKEND_URL: HeaderAlias = HeaderAlias::new("x-maskura-backend-url");
+pub const PROCESS: HeaderAlias = HeaderAlias::new("x-maskura-process");
+pub const STABLE_FIELDS: HeaderAlias = HeaderAlias::new("x-maskura-stable-fields");
+pub const ENCRYPT_FIELDS: HeaderAlias = HeaderAlias::new("x-maskura-encrypt-fields");
+pub const PLUGIN_NAME: HeaderAlias = HeaderAlias::new("x-maskura-plugin-name");
 
 pub const ALL: &[HeaderAlias] = &[
     ACCESS_KEY,
@@ -40,10 +38,6 @@ pub const ALL: &[HeaderAlias] = &[
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum HeaderAliasError {
     Duplicate(&'static str),
-    Conflict {
-        canonical: &'static str,
-        legacy: &'static str,
-    },
 }
 
 fn unique<'a>(
@@ -62,39 +56,18 @@ pub fn aliased(
     headers: &HeaderMap,
     alias: HeaderAlias,
 ) -> Result<Option<&HeaderValue>, HeaderAliasError> {
-    aliased_unique(headers, alias)
+    unique(headers, alias.as_str())
 }
 
 pub fn aliased_unique(
     headers: &HeaderMap,
     alias: HeaderAlias,
 ) -> Result<Option<&HeaderValue>, HeaderAliasError> {
-    resolve_pair(
-        unique(headers, alias.canonical)?,
-        unique(headers, alias.legacy)?,
-        alias,
-    )
-}
-
-fn resolve_pair<'a>(
-    canonical: Option<&'a HeaderValue>,
-    legacy: Option<&'a HeaderValue>,
-    alias: HeaderAlias,
-) -> Result<Option<&'a HeaderValue>, HeaderAliasError> {
-    match (canonical, legacy) {
-        (Some(canonical), Some(legacy)) if canonical.as_bytes() != legacy.as_bytes() => {
-            Err(HeaderAliasError::Conflict {
-                canonical: alias.canonical,
-                legacy: alias.legacy,
-            })
-        }
-        (Some(value), _) | (_, Some(value)) => Ok(Some(value)),
-        (None, None) => Ok(None),
-    }
+    unique(headers, alias.as_str())
 }
 
 pub fn validated(headers: &HeaderMap, alias: HeaderAlias) -> Option<&HeaderValue> {
-    aliased(headers, alias).expect("customer header aliases were validated before use")
+    aliased(headers, alias).expect("customer headers were validated before use")
 }
 
 pub fn validate_all(headers: &HeaderMap) -> Result<(), HeaderAliasError> {
@@ -109,53 +82,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn accepts_canonical_legacy_and_equal_dual_headers() {
-        for names in [
-            vec![(ACCESS_KEY.canonical, "value")],
-            vec![(ACCESS_KEY.legacy, "value")],
-            vec![
-                (ACCESS_KEY.canonical, "value"),
-                (ACCESS_KEY.legacy, "value"),
-            ],
-        ] {
-            let mut headers = HeaderMap::new();
-            for (name, value) in names {
-                headers.insert(name, value.parse().unwrap());
-            }
-            assert_eq!(
-                aliased(&headers, ACCESS_KEY)
-                    .unwrap()
-                    .unwrap()
-                    .to_str()
-                    .unwrap(),
-                "value"
-            );
-        }
+    fn accepts_canonical_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(ACCESS_KEY.as_str(), "value".parse().unwrap());
+        assert_eq!(
+            aliased(&headers, ACCESS_KEY)
+                .unwrap()
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "value"
+        );
     }
 
     #[test]
-    fn rejects_conflicting_aliases_and_duplicate_names() {
-        let mut conflicting = HeaderMap::new();
-        conflicting.insert(ACCESS_KEY.canonical, "new".parse().unwrap());
-        conflicting.insert(ACCESS_KEY.legacy, "old".parse().unwrap());
-        assert_eq!(
-            aliased(&conflicting, ACCESS_KEY),
-            Err(HeaderAliasError::Conflict {
-                canonical: ACCESS_KEY.canonical,
-                legacy: ACCESS_KEY.legacy,
-            })
-        );
-
+    fn rejects_duplicate_names() {
         let mut duplicate = HeaderMap::new();
-        duplicate.append(PROCESS.canonical, "read".parse().unwrap());
-        duplicate.append(PROCESS.canonical, "read".parse().unwrap());
+        duplicate.append(PROCESS.as_str(), "read".parse().unwrap());
+        duplicate.append(PROCESS.as_str(), "read".parse().unwrap());
         assert_eq!(
             aliased_unique(&duplicate, PROCESS),
-            Err(HeaderAliasError::Duplicate(PROCESS.canonical))
+            Err(HeaderAliasError::Duplicate(PROCESS.as_str()))
         );
         assert_eq!(
             validate_all(&duplicate),
-            Err(HeaderAliasError::Duplicate(PROCESS.canonical))
+            Err(HeaderAliasError::Duplicate(PROCESS.as_str()))
         );
     }
 }

--- a/crates/gateway/src/pipeline.rs
+++ b/crates/gateway/src/pipeline.rs
@@ -178,7 +178,7 @@ pub trait ComponentSource: Send + Sync {
 
 /// OSS/self-hosted resolver: the catalog's enabled plugins in order.
 ///
-/// `MASKURA_PLUGINS_DIR` (legacy `S4_PLUGINS_DIR`) and the bundled default
+/// `MASKURA_PLUGINS_DIR` and the bundled default
 /// component remain a *catalog* of available artifacts; this resolver decides
 /// the pipeline from that catalog exactly as the historical global chain did.
 /// An empty enabled set is the operator's explicit pass-through choice.

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -289,9 +289,6 @@ fn client_metering_id_rejection(
         "x-maskura-metering-id",
         "x-maskura-operation-id",
         "x-maskura-usage-id",
-        "x-s4-metering-id",
-        "x-s4-operation-id",
-        "x-s4-usage-id",
     ]
     .into_iter()
     .any(|name| headers.contains_key(name))
@@ -10057,8 +10054,7 @@ async fn root(
         .and_then(|v| v.to_str().ok())
         .map(|a| a.starts_with("AWS4-"))
         .unwrap_or(false)
-        || headers.contains_key(customer_headers::ACCESS_KEY.canonical)
-        || headers.contains_key(customer_headers::ACCESS_KEY.legacy)
+        || headers.contains_key(customer_headers::ACCESS_KEY.as_str())
         || uri.query().is_some_and(|query| {
             query
                 .split('&')
@@ -12120,7 +12116,7 @@ mod s3_provider_capability_tests {
     #[test]
     fn provider_selection_is_exact_and_fail_closed() {
         for provider in ["aws", "minio", "r2", "b2"] {
-            unsafe { std::env::set_var("S4_STREAMING_S3_PROVIDER", provider) }
+            unsafe { std::env::set_var("MASKURA_STREAMING_S3_PROVIDER", provider) }
             let capabilities = configured_s3_streaming_capabilities().unwrap();
             assert!(
                 capabilities.is_some(),
@@ -12130,9 +12126,9 @@ mod s3_provider_capability_tests {
             assert!(capabilities.supports_conditional_reads());
             assert!(capabilities.supports_response_checksums());
         }
-        unsafe { std::env::set_var("S4_STREAMING_S3_PROVIDER", "wasabi") }
+        unsafe { std::env::set_var("MASKURA_STREAMING_S3_PROVIDER", "wasabi") }
         assert!(configured_s3_streaming_capabilities().unwrap().is_none());
-        unsafe { std::env::remove_var("S4_STREAMING_S3_PROVIDER") }
+        unsafe { std::env::remove_var("MASKURA_STREAMING_S3_PROVIDER") }
         assert!(configured_s3_streaming_capabilities().unwrap().is_none());
     }
 }

--- a/crates/gateway/src/sigv4.rs
+++ b/crates/gateway/src/sigv4.rs
@@ -27,11 +27,6 @@ const SEMANTIC_HEADERS: &[&str] = &[
     "x-maskura-process",
     "x-maskura-stable-fields",
     "x-maskura-encrypt-fields",
-    "x-s4-storage-mode",
-    "x-s4-backend-url",
-    "x-s4-process",
-    "x-s4-stable-fields",
-    "x-s4-encrypt-fields",
     "content-type",
     "content-encoding",
     "content-md5",
@@ -1006,11 +1001,6 @@ mod tests {
             ("x-maskura-process", "read"),
             ("x-maskura-stable-fields", "email"),
             ("x-maskura-encrypt-fields", "email"),
-            ("x-s4-storage-mode", "managed"),
-            ("x-s4-backend-url", "https://storage.example/object"),
-            ("x-s4-process", "read"),
-            ("x-s4-stable-fields", "email"),
-            ("x-s4-encrypt-fields", "email"),
             ("content-type", "text/plain"),
             ("content-encoding", "identity"),
             ("content-md5", "CY9rzUYh03PK3k6DJie09g=="),
@@ -1089,11 +1079,6 @@ mod tests {
             ("x-maskura-process", "read"),
             ("x-maskura-stable-fields", "email, account_id"),
             ("x-maskura-encrypt-fields", "email"),
-            ("x-s4-storage-mode", "managed"),
-            ("x-s4-backend-url", "https://storage.example/object"),
-            ("x-s4-process", "read"),
-            ("x-s4-stable-fields", "email, account_id"),
-            ("x-s4-encrypt-fields", "email"),
             ("content-type", "text/plain; charset=utf-8"),
             ("content-encoding", "aws-chunked"),
             ("content-md5", "CY9rzUYh03PK3k6DJie09g=="),
@@ -1184,13 +1169,13 @@ mod tests {
     fn rejects_duplicate_integrity_headers_even_when_joined_value_matches_the_signature() {
         for (name, combined, first, second) in [
             (
-                "x-s4-stable-fields",
+                "x-maskura-stable-fields",
                 "email,account_id",
                 "email",
                 "account_id",
             ),
             (
-                "x-s4-backend-url",
+                "x-maskura-backend-url",
                 "https://storage.example/one,https://storage.example/two",
                 "https://storage.example/one",
                 "https://storage.example/two",
@@ -1249,9 +1234,9 @@ mod tests {
     #[test]
     fn rejects_signed_trim_all_variants_and_accepts_canonical_single_spaces() {
         for (name, raw) in [
-            ("x-s4-stable-fields", " email"),
-            ("x-s4-stable-fields", "email "),
-            ("x-s4-backend-url", "\thttps://storage.example/object"),
+            ("x-maskura-stable-fields", " email"),
+            ("x-maskura-stable-fields", "email "),
+            ("x-maskura-backend-url", "\thttps://storage.example/object"),
             ("content-type", "text/plain;  charset=utf-8"),
             ("content-md5", "CY9rzUYh03PK3k6DJie09g==\t"),
             ("x-amz-tagging", " project=one&owner=two"),
@@ -1283,8 +1268,8 @@ mod tests {
         }
 
         for (name, canonical) in [
-            ("x-s4-stable-fields", "email, account_id"),
-            ("x-s4-backend-url", "https://storage.example/object"),
+            ("x-maskura-stable-fields", "email, account_id"),
+            ("x-maskura-backend-url", "https://storage.example/object"),
             ("content-type", "text/plain; charset=utf-8"),
             ("content-md5", "CY9rzUYh03PK3k6DJie09g=="),
             ("x-amz-meta-project", "project one"),
@@ -1314,11 +1299,11 @@ mod tests {
     fn signed_integrity_values_are_cryptographically_bound_and_required() {
         for (name, value, mutation) in [
             (
-                "x-s4-backend-url",
+                "x-maskura-backend-url",
                 "https://one.example/object",
                 "https://two.example/object",
             ),
-            ("x-s4-stable-fields", "email", "account_id"),
+            ("x-maskura-stable-fields", "email", "account_id"),
             ("content-type", "text/plain", "application/json"),
             (
                 "content-md5",
@@ -1459,7 +1444,7 @@ mod tests {
             .unwrap()
             .unwrap();
         for (name, value) in [
-            ("x-s4-process", "read"),
+            ("x-maskura-process", "read"),
             ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
             ("x-amz-meta-dynamic-name", "metadata"),
         ] {

--- a/crates/gateway/tests/db_keys_test.rs
+++ b/crates/gateway/tests/db_keys_test.rs
@@ -2668,8 +2668,8 @@ fn postgres_mcp_creation_returns_persisted_metadata() {
 
 fn auth_headers(ak: &str, sk: &str) -> Vec<(&'static str, String)> {
     vec![
-        ("x-s4-access-key", ak.to_string()),
-        ("x-s4-secret-key", sk.to_string()),
+        ("x-maskura-access-key", ak.to_string()),
+        ("x-maskura-secret-key", sk.to_string()),
     ]
 }
 
@@ -3032,21 +3032,21 @@ fn router_staged_multipart_flow_is_durable_and_idempotent() {
         // these values concurrently.
         unsafe {
             std::env::set_var("AUTH_DISABLED", "0");
-            std::env::set_var("S4_SINGLE_TENANT", "1");
-            std::env::remove_var("S4_KEYS_FILE");
+            std::env::set_var("MASKURA_SINGLE_TENANT", "1");
+            std::env::remove_var("MASKURA_KEYS_FILE");
             std::env::set_var("S3_ENDPOINT", &endpoint);
             std::env::set_var("S3_ACCESS_KEY_ID", "destination-access");
             std::env::set_var("S3_SECRET_ACCESS_KEY", "destination-secret");
             std::env::remove_var("S4_SERVICE_BUCKETS");
             std::env::remove_var("S4_SECRET_KEK");
-            std::env::set_var("S4_STREAMING_S3_PROVIDER", "minio");
-            std::env::remove_var("S4_PLUGINS_DIR");
-            std::env::remove_var("S4_FILTER_COMPONENT");
+            std::env::set_var("MASKURA_STREAMING_S3_PROVIDER", "minio");
+            std::env::remove_var("MASKURA_PLUGINS_DIR");
+            std::env::remove_var("MASKURA_FILTER_COMPONENT");
             std::env::remove_var("S4_MANAGED_STREAMING_MODE");
             std::env::remove_var("S4_MANAGED_STREAMING_TRANSACTIONAL");
-            std::env::set_var("S4_STREAMING_READ_MODE", "passthrough");
-            std::env::set_var("S4_DEV_MEMORY_STREAMING", "1");
-            std::env::set_var("S4_MULTIPART_MODE", "staged");
+            std::env::set_var("MASKURA_STREAMING_READ_MODE", "passthrough");
+            std::env::set_var("MASKURA_DEV_MEMORY_STREAMING", "1");
+            std::env::set_var("MASKURA_MULTIPART_MODE", "staged");
             std::env::set_var("S4_MULTIPART_STAGING_DIR", staging_dir.to_str().unwrap());
             std::env::set_var("S4_MULTIPART_STAGING_ENDPOINT", &endpoint);
             std::env::set_var("S4_MULTIPART_STAGING_BUCKET", MOCK_STAGING_BUCKET);

--- a/crates/gateway/tests/s3_frontdoor_test.rs
+++ b/crates/gateway/tests/s3_frontdoor_test.rs
@@ -573,38 +573,38 @@ fn test_pipeline_template() -> &'static StatePipelineTemplate {
         // before any test state reads it.
         unsafe {
             std::env::set_var("AUTH_DISABLED", "0");
-            std::env::set_var("S4_SINGLE_TENANT", "1");
+            std::env::set_var("MASKURA_SINGLE_TENANT", "1");
             std::env::set_var("S4_WORKSPACE_ENDPOINT_PRIVATE_ALLOWLIST", "127.0.0.1");
             std::env::remove_var("S4_WORKSPACE_ENDPOINT_ALLOWLIST");
             std::env::remove_var("DATABASE_URL");
-            std::env::remove_var("S4_KEYS_FILE");
+            std::env::remove_var("MASKURA_KEYS_FILE");
             std::env::remove_var("S3_ENDPOINT");
             std::env::remove_var("S4_SECRET_KEK");
             std::env::remove_var("S4_SERVICE_BUCKETS");
-            std::env::remove_var("S4_LEGACY_MAX_OBJECT_BYTES");
-            std::env::remove_var("S4_MAX_OBJECT_BYTES");
-            std::env::remove_var("S4_MAX_PIPELINE_OUTPUT_BYTES");
-            std::env::remove_var("S4_STREAMING_READ_MODE");
-            std::env::remove_var("S4_TRANSFORMED_READ_SPOOL");
-            std::env::remove_var("S4_PREFIX_SAFE_COMPONENT_HASHES");
-            std::env::remove_var("S4_SPOOL_DIR");
-            std::env::remove_var("S4_SPOOL_MAX_OBJECT_BYTES");
-            std::env::remove_var("S4_SPOOL_QUOTA_BYTES");
-            std::env::remove_var("S4_STREAMING_S3_PROVIDER");
+            std::env::remove_var("MASKURA_LEGACY_MAX_OBJECT_BYTES");
+            std::env::remove_var("MASKURA_MAX_OBJECT_BYTES");
+            std::env::remove_var("MASKURA_MAX_PIPELINE_OUTPUT_BYTES");
+            std::env::remove_var("MASKURA_STREAMING_READ_MODE");
+            std::env::remove_var("MASKURA_TRANSFORMED_READ_SPOOL");
+            std::env::remove_var("MASKURA_PREFIX_SAFE_COMPONENT_HASHES");
+            std::env::remove_var("MASKURA_SPOOL_DIR");
+            std::env::remove_var("MASKURA_SPOOL_MAX_OBJECT_BYTES");
+            std::env::remove_var("MASKURA_SPOOL_QUOTA_BYTES");
+            std::env::remove_var("MASKURA_STREAMING_S3_PROVIDER");
             std::env::remove_var("S4_MANAGED_STREAMING_MODE");
             std::env::remove_var("S4_MANAGED_STREAMING_TRANSACTIONAL");
             std::env::remove_var("S4_MANAGED_PLACEMENT_VERSION");
-            std::env::remove_var("S4_DEV_MEMORY_STREAMING");
-            std::env::remove_var("S4_MULTIPART_MODE");
+            std::env::remove_var("MASKURA_DEV_MEMORY_STREAMING");
+            std::env::remove_var("MASKURA_MULTIPART_MODE");
             // Phase 12 removed the legacy buffered PUT/GET path entirely; the
             // streaming in-memory dev backend is the only write/read path left.
-            std::env::set_var("S4_STREAMING_READ_MODE", "passthrough");
-            std::env::set_var("S4_DEV_MEMORY_STREAMING", "1");
+            std::env::set_var("MASKURA_STREAMING_READ_MODE", "passthrough");
+            std::env::set_var("MASKURA_DEV_MEMORY_STREAMING", "1");
             // Load the built filter components so the full pipeline (including
             // stable-encrypt) is available for joinable-read tests.
             let components =
                 std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/components");
-            std::env::set_var("S4_PLUGINS_DIR", components);
+            std::env::set_var("MASKURA_PLUGINS_DIR", components);
         }
         StatePipelineTemplate::from_env().expect("compile test pipeline components")
     })
@@ -1126,13 +1126,6 @@ fn read_component(name: &str) -> Vec<u8> {
 
 fn auth_headers(ak: &str, sk: &str) -> Vec<(&'static str, String)> {
     vec![
-        ("x-s4-access-key", ak.to_string()),
-        ("x-s4-secret-key", sk.to_string()),
-    ]
-}
-
-fn canonical_auth_headers(ak: &str, sk: &str) -> Vec<(&'static str, String)> {
-    vec![
         ("x-maskura-access-key", ak.to_string()),
         ("x-maskura-secret-key", sk.to_string()),
     ]
@@ -1208,57 +1201,40 @@ async fn public_key_mutation_rejects_unauthenticated_requests_in_production_and_
 }
 
 #[tokio::test]
-async fn auth_header_aliases_accept_old_new_and_equal_dual_but_reject_conflicts() {
+async fn auth_headers_accept_canonical_and_reject_legacy_s4_names() {
     let (app, state) = router().await;
     let (access_key, secret_key) = make_key(&state).await;
-    let cases = [
-        (
-            "legacy",
-            auth_headers(&access_key, &secret_key),
-            StatusCode::OK,
-        ),
-        (
-            "canonical",
-            canonical_auth_headers(&access_key, &secret_key),
-            StatusCode::OK,
-        ),
-        (
-            "equal-dual",
-            vec![
-                ("x-maskura-access-key", access_key.clone()),
-                ("x-s4-access-key", access_key.clone()),
-                ("x-maskura-secret-key", secret_key.clone()),
-                ("x-s4-secret-key", secret_key.clone()),
-            ],
-            StatusCode::OK,
-        ),
-        (
-            "conflicting-dual",
-            vec![
-                ("x-maskura-access-key", access_key.clone()),
-                ("x-s4-access-key", "s4_conflict".to_string()),
-                ("x-maskura-secret-key", secret_key.clone()),
-                ("x-s4-secret-key", secret_key.clone()),
-            ],
-            StatusCode::FORBIDDEN,
-        ),
-    ];
 
-    for (name, headers, expected) in cases {
-        let request = add_headers(
-            Request::builder()
-                .method("PUT")
-                .uri(format!("/aliases/{name}.txt"))
-                .header(header::CONTENT_TYPE, "text/plain")
-                .body(Body::from(name))
-                .unwrap(),
-            &headers,
-        );
-        assert_eq!(
-            app.clone().oneshot(request).await.unwrap().status(),
-            expected
-        );
-    }
+    let canonical = add_headers(
+        Request::builder()
+            .method("PUT")
+            .uri("/aliases/canonical.txt")
+            .header(header::CONTENT_TYPE, "text/plain")
+            .body(Body::from("canonical"))
+            .unwrap(),
+        &auth_headers(&access_key, &secret_key),
+    );
+    assert_eq!(
+        app.clone().oneshot(canonical).await.unwrap().status(),
+        StatusCode::OK
+    );
+
+    let legacy = add_headers(
+        Request::builder()
+            .method("PUT")
+            .uri("/aliases/legacy.txt")
+            .header(header::CONTENT_TYPE, "text/plain")
+            .body(Body::from("legacy"))
+            .unwrap(),
+        &[
+            ("x-s4-access-key", access_key),
+            ("x-s4-secret-key", secret_key),
+        ],
+    );
+    assert_eq!(
+        app.clone().oneshot(legacy).await.unwrap().status(),
+        StatusCode::FORBIDDEN
+    );
 }
 
 #[tokio::test]
@@ -1269,11 +1245,11 @@ async fn public_key_mutation_rejects_incomplete_or_invalid_api_key_credentials()
     let requests = [
         add_headers(
             public_key_request(&key_id, "rejected-pem"),
-            &[("x-s4-access-key", key_id.clone())],
+            &[("x-maskura-access-key", key_id.clone())],
         ),
         add_headers(
             public_key_request(&key_id, "rejected-pem"),
-            &[("x-s4-secret-key", secret_key.clone())],
+            &[("x-maskura-secret-key", secret_key.clone())],
         ),
         add_headers(
             public_key_request(&key_id, "rejected-pem"),
@@ -1332,24 +1308,24 @@ async fn public_key_mutation_rejects_duplicate_security_headers_without_mutation
         append_headers(
             public_key_request(&key_id, "rejected-pem"),
             &[
-                ("x-s4-access-key", key_id.clone()),
-                ("x-s4-access-key", key_id.clone()),
-                ("x-s4-secret-key", secret_key.clone()),
+                ("x-maskura-access-key", key_id.clone()),
+                ("x-maskura-access-key", key_id.clone()),
+                ("x-maskura-secret-key", secret_key.clone()),
             ],
         ),
         append_headers(
             public_key_request(&key_id, "rejected-pem"),
             &[
-                ("x-s4-access-key", key_id.clone()),
-                ("x-s4-secret-key", secret_key.clone()),
-                ("x-s4-secret-key", secret_key.clone()),
+                ("x-maskura-access-key", key_id.clone()),
+                ("x-maskura-secret-key", secret_key.clone()),
+                ("x-maskura-secret-key", secret_key.clone()),
             ],
         ),
         append_headers(
             public_key_request(&key_id, "rejected-pem"),
             &[
-                ("x-s4-mcp-token", mcp_token.clone()),
-                ("x-s4-mcp-token", mcp_token.clone()),
+                ("x-maskura-mcp-token", mcp_token.clone()),
+                ("x-maskura-mcp-token", mcp_token.clone()),
             ],
         ),
     ];
@@ -1395,37 +1371,40 @@ async fn public_key_mutation_rejects_mixed_credential_classes_without_mutation()
         append_headers(
             public_key_request(&key_id, "rejected-pem"),
             &[
-                ("x-s4-access-key", key_id.clone()),
-                ("x-s4-secret-key", secret_key.clone()),
+                ("x-maskura-access-key", key_id.clone()),
+                ("x-maskura-secret-key", secret_key.clone()),
                 ("authorization", api_bearer.clone()),
             ],
         ),
         append_headers(
             public_key_request(&key_id, "rejected-pem"),
             &[
-                ("x-s4-access-key", key_id.clone()),
-                ("x-s4-secret-key", secret_key.clone()),
+                ("x-maskura-access-key", key_id.clone()),
+                ("x-maskura-secret-key", secret_key.clone()),
                 ("authorization", format!("Bearer {jwt}")),
             ],
         ),
         append_headers(
             public_key_request(&key_id, "rejected-pem"),
             &[
-                ("x-s4-mcp-token", mcp_token.clone()),
-                ("x-s4-access-key", key_id.clone()),
-                ("x-s4-secret-key", secret_key.clone()),
+                ("x-maskura-mcp-token", mcp_token.clone()),
+                ("x-maskura-access-key", key_id.clone()),
+                ("x-maskura-secret-key", secret_key.clone()),
             ],
         ),
         append_headers(
             public_key_request(&key_id, "rejected-pem"),
             &[
-                ("x-s4-mcp-token", mcp_token.clone()),
+                ("x-maskura-mcp-token", mcp_token.clone()),
                 ("authorization", format!("Bearer {jwt}")),
             ],
         ),
         append_headers(
             public_key_request(&key_id, "rejected-pem"),
-            &[("x-s4-mcp-token", mcp_token), ("authorization", api_bearer)],
+            &[
+                ("x-maskura-mcp-token", mcp_token),
+                ("authorization", api_bearer),
+            ],
         ),
     ];
 
@@ -1457,7 +1436,7 @@ async fn public_key_mutation_accepts_own_key_via_headers_and_bearer() {
 
     let header_request = add_headers(
         public_key_request(&header_key, TEST_PUBLIC_KEY_PEM),
-        &canonical_auth_headers(&header_key, &header_secret),
+        &auth_headers(&header_key, &header_secret),
     );
     assert_eq!(
         app.clone().oneshot(header_request).await.unwrap().status(),
@@ -1687,7 +1666,7 @@ async fn mcp_tokens_cannot_mutate_public_keys() {
         ),
         add_headers(
             public_key_request(&key_id, "rejected-pem"),
-            &[("x-s4-mcp-token", token)],
+            &[("x-maskura-mcp-token", token)],
         ),
     ];
 
@@ -2798,9 +2777,9 @@ async fn launch_contract_supplied_metering_id_is_rejected_generically_before_mut
         "x-maskura-metering-id",
         "x-maskura-operation-id",
         "x-maskura-usage-id",
-        "x-s4-metering-id",
-        "x-s4-operation-id",
-        "x-s4-usage-id",
+        "x-maskura-metering-id",
+        "x-maskura-operation-id",
+        "x-maskura-usage-id",
     ]
     .into_iter()
     .enumerate()
@@ -3077,7 +3056,7 @@ async fn invalid_range_failed_head_and_failed_delete_release_exact_reservations(
         Request::builder()
             .method("DELETE")
             .uri("/failed/object.txt")
-            .header("x-s4-storage-mode", "managed")
+            .header("x-maskura-storage-mode", "managed")
             .body(Body::empty())
             .unwrap(),
         &headers,
@@ -3277,7 +3256,7 @@ async fn unsupported_multipart_destination_is_rejected_before_body_polling() {
         Request::builder()
             .method("POST")
             .uri("/bucket/object?uploads")
-            .header("x-s4-backend-url", "https://example.com/signed")
+            .header("x-maskura-backend-url", "https://example.com/signed")
             .body(Body::empty())
             .unwrap(),
         &headers,
@@ -3296,7 +3275,7 @@ async fn unsupported_multipart_destination_is_rejected_before_body_polling() {
         Request::builder()
             .method("PUT")
             .uri("/bucket/object?partNumber=1&uploadId=legacy")
-            .header("x-s4-backend-url", "https://example.com/signed")
+            .header("x-maskura-backend-url", "https://example.com/signed")
             .header(header::CONTENT_LENGTH, "7")
             .body(Body::new(PollTrackingBody {
                 polls: polls.clone(),
@@ -3751,7 +3730,7 @@ async fn presigned_transport_failure_never_discloses_signed_url_material() {
             Request::builder()
                 .method("GET")
                 .uri("/proxy/transport-failure")
-                .header("x-s4-backend-url", &signed_url)
+                .header("x-maskura-backend-url", &signed_url)
                 .body(Body::empty())
                 .unwrap(),
             &auth_headers(&ak, &sk),
@@ -3789,7 +3768,7 @@ async fn presigned_transport_failure_never_discloses_signed_url_material() {
             Request::builder()
                 .method("DELETE")
                 .uri("/proxy/transport-failure")
-                .header("x-s4-backend-url", &signed_url)
+                .header("x-maskura-backend-url", &signed_url)
                 .body(Body::empty())
                 .unwrap(),
             &auth_headers(&ak, &sk),
@@ -3837,7 +3816,7 @@ async fn presigned_http_responses_are_hardened_without_losing_object_semantics()
             .header(header::RANGE, "bytes=2-5")
             .header("x-amz-checksum-mode", "ENABLED")
             .header(
-                "x-s4-backend-url",
+                "x-maskura-backend-url",
                 format!("{upstream}/object?Expires={expires}"),
             )
             .body(Body::empty())
@@ -3915,7 +3894,7 @@ async fn presigned_http_responses_are_hardened_without_losing_object_semantics()
             .method("HEAD")
             .uri("/proxy/object")
             .header(
-                "x-s4-backend-url",
+                "x-maskura-backend-url",
                 format!("{upstream}/object?Expires={expires}"),
             )
             .body(Body::empty())
@@ -3939,7 +3918,7 @@ async fn presigned_http_responses_are_hardened_without_losing_object_semantics()
             .method("GET")
             .uri("/proxy?list-type=2")
             .header(
-                "x-s4-backend-url",
+                "x-maskura-backend-url",
                 format!("{upstream}/object?Expires={expires}"),
             )
             .body(Body::empty())
@@ -3961,7 +3940,7 @@ async fn presigned_http_responses_are_hardened_without_losing_object_semantics()
             .method("GET")
             .uri("/proxy/missing")
             .header(
-                "x-s4-backend-url",
+                "x-maskura-backend-url",
                 format!("{upstream}/not-found?Expires={expires}"),
             )
             .body(Body::empty())
@@ -3985,7 +3964,7 @@ async fn presigned_http_responses_are_hardened_without_losing_object_semantics()
             .method("GET")
             .uri("/proxy/redirect")
             .header(
-                "x-s4-backend-url",
+                "x-maskura-backend-url",
                 format!("{upstream}/redirect?Expires={expires}"),
             )
             .body(Body::empty())
@@ -4286,7 +4265,7 @@ async fn sigv4_signed_semantic_headers_accept_and_detect_mutation_or_removal() {
         ),
         (
             "removed legacy semantic header",
-            HeaderChange::Remove("x-s4-process"),
+            HeaderChange::Remove("x-maskura-process"),
             StatusCode::FORBIDDEN,
         ),
     ]
@@ -4302,7 +4281,7 @@ async fn sigv4_signed_semantic_headers_accept_and_detect_mutation_or_removal() {
             b"semantic body",
             &[
                 ("content-type", "text/plain"),
-                ("x-s4-process", "write"),
+                ("x-maskura-process", "write"),
                 ("x-amz-meta-dynamic-name", "one"),
             ],
         );
@@ -4336,14 +4315,12 @@ async fn sigv4_signed_semantic_headers_accept_and_detect_mutation_or_removal() {
 }
 
 #[tokio::test]
-async fn sigv4_signs_the_exact_old_or_new_semantic_header_names() {
+async fn sigv4_signs_the_exact_canonical_semantic_header_names() {
     let (app, state) = router().await;
     let (access_key, secret_key) = make_key(&state).await;
 
     for (index, (name, value)) in [
-        ("x-s4-process", "write"),
         ("x-maskura-process", "write"),
-        ("x-s4-encrypt-fields", "email"),
         ("x-maskura-encrypt-fields", "email"),
     ]
     .into_iter()
@@ -4353,8 +4330,8 @@ async fn sigv4_signs_the_exact_old_or_new_semantic_header_names() {
             &access_key,
             &secret_key,
             "PUT",
-            &format!("http://maskura.local/sigv4-aliases/{index}.txt"),
-            b"signed alias",
+            &format!("http://maskura.local/sigv4-canonical/{index}.txt"),
+            b"signed canonical",
             &[("content-type", "text/plain"), (name, value)],
         );
         assert_eq!(
@@ -4364,37 +4341,20 @@ async fn sigv4_signs_the_exact_old_or_new_semantic_header_names() {
         );
     }
 
-    let equal_dual = signed_request(
+    let duplicate = signed_request(
         &access_key,
         &secret_key,
         "PUT",
-        "http://maskura.local/sigv4-aliases/equal.txt",
-        b"equal aliases",
+        "http://maskura.local/sigv4-canonical/duplicate.txt",
+        b"duplicate semantic header",
         &[
             ("content-type", "text/plain"),
             ("x-maskura-process", "write"),
-            ("x-s4-process", "write"),
+            ("x-maskura-process", "read"),
         ],
     );
     assert_eq!(
-        app.clone().oneshot(equal_dual).await.unwrap().status(),
-        StatusCode::OK
-    );
-
-    let conflicting = signed_request(
-        &access_key,
-        &secret_key,
-        "PUT",
-        "http://maskura.local/sigv4-aliases/conflict.txt",
-        b"conflicting aliases",
-        &[
-            ("content-type", "text/plain"),
-            ("x-maskura-process", "write"),
-            ("x-s4-process", "read"),
-        ],
-    );
-    assert_eq!(
-        app.oneshot(conflicting).await.unwrap().status(),
+        app.oneshot(duplicate).await.unwrap().status(),
         StatusCode::FORBIDDEN
     );
 }
@@ -4414,7 +4374,7 @@ async fn sigv4_rejects_ambiguous_or_noncanonical_integrity_headers_before_body_p
     let (access_key, secret_key) = make_key(&state).await;
     for (index, (name, shape)) in [
         (
-            "x-s4-stable-fields",
+            "x-maskura-stable-fields",
             HeaderShape::Duplicate {
                 signed: "email,account_id",
                 first: "email",
@@ -4422,7 +4382,7 @@ async fn sigv4_rejects_ambiguous_or_noncanonical_integrity_headers_before_body_p
             },
         ),
         (
-            "x-s4-backend-url",
+            "x-maskura-backend-url",
             HeaderShape::Duplicate {
                 signed: "https://storage.example/one,https://storage.example/two",
                 first: "https://storage.example/one",
@@ -4445,10 +4405,16 @@ async fn sigv4_rejects_ambiguous_or_noncanonical_integrity_headers_before_body_p
                 second: "two",
             },
         ),
-        ("x-s4-stable-fields", HeaderShape::Raw(" email, account_id")),
-        ("x-s4-stable-fields", HeaderShape::Raw("email, account_id ")),
         (
-            "x-s4-backend-url",
+            "x-maskura-stable-fields",
+            HeaderShape::Raw(" email, account_id"),
+        ),
+        (
+            "x-maskura-stable-fields",
+            HeaderShape::Raw("email, account_id "),
+        ),
+        (
+            "x-maskura-backend-url",
             HeaderShape::Raw("\thttps://storage.example/object"),
         ),
         (
@@ -4516,10 +4482,10 @@ async fn sigv4_rejects_unsigned_integrity_header_injection_before_polling_the_bo
     let (app, state) = router().await;
     let (access_key, secret_key) = make_key(&state).await;
     for (index, (name, value)) in [
-        ("x-s4-storage-mode", "managed"),
-        ("x-s4-backend-url", "https://storage.example/object"),
-        ("x-s4-process", "read"),
-        ("x-s4-stable-fields", "email"),
+        ("x-maskura-storage-mode", "managed"),
+        ("x-maskura-backend-url", "https://storage.example/object"),
+        ("x-maskura-process", "read"),
+        ("x-maskura-stable-fields", "email"),
         ("content-type", "text/plain"),
         ("content-encoding", "gzip"),
         ("content-md5", "CY9rzUYh03PK3k6DJie09g=="),
@@ -4630,7 +4596,7 @@ async fn presigned_host_only_get_accepts_but_appended_protected_headers_are_reje
     assert_eq!(response.status(), StatusCode::OK);
 
     for (name, value) in [
-        ("x-s4-process", "read"),
+        ("x-maskura-process", "read"),
         ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
         ("x-amz-meta-dynamic-name", "appended"),
         ("x-amz-tagging", "project=appended"),
@@ -4671,8 +4637,8 @@ async fn non_sigv4_api_key_auth_rejects_duplicate_semantic_headers() {
             &auth_headers(&access_key, &secret_key),
         ),
         &[
-            ("x-s4-process", " write ".to_string()),
-            ("x-s4-process", "read".to_string()),
+            ("x-maskura-process", " write ".to_string()),
+            ("x-maskura-process", "read".to_string()),
         ],
     );
 
@@ -4894,8 +4860,8 @@ async fn managed_storage_isolates_users() {
             .body(Body::from("evil"))
             .unwrap(),
         &[
-            ("x-s4-access-key", ak2.clone()),
-            ("x-s4-secret-key", sk1.clone()),
+            ("x-maskura-access-key", ak2.clone()),
+            ("x-maskura-secret-key", sk1.clone()),
         ],
     );
     let resp = app.clone().oneshot(cross).await.unwrap();
@@ -4913,8 +4879,8 @@ async fn managed_storage_isolates_users() {
             .body(Body::from("evil"))
             .unwrap(),
         &[
-            ("x-s4-access-key", ak1.clone()),
-            ("x-s4-secret-key", sk2.clone()),
+            ("x-maskura-access-key", ak1.clone()),
+            ("x-maskura-secret-key", sk2.clone()),
         ],
     );
     let resp = app.oneshot(cross2).await.unwrap();
@@ -5940,7 +5906,7 @@ async fn transformed_read_is_rejected_without_exposing_raw_data() {
         Request::builder()
             .method("GET")
             .uri("/rawbkt/doc.json")
-            .header("x-s4-process", "read")
+            .header("x-maskura-process", "read")
             .body(Body::empty())
             .unwrap(),
         &hdrs,
@@ -5971,7 +5937,7 @@ async fn transformed_read_is_rejected_before_object_lookup() {
         Request::builder()
             .method("GET")
             .uri("/rawbkt/does-not-exist.json")
-            .header("x-s4-process", "true")
+            .header("x-maskura-process", "true")
             .body(Body::empty())
             .unwrap(),
         &hdrs,
@@ -6090,8 +6056,8 @@ async fn stable_transformed_reads_are_rejected_without_disclosure() {
             Request::builder()
                 .method("GET")
                 .uri(format!("/j1/{key}"))
-                .header("x-s4-process", "read")
-                .header("x-s4-stable-fields", "email")
+                .header("x-maskura-process", "read")
+                .header("x-maskura-stable-fields", "email")
                 .body(Body::empty())
                 .unwrap(),
             &hdrs,
@@ -6149,7 +6115,7 @@ async fn unsafe_transformed_read_stages_then_sanitizes_source_headers() {
             Request::builder()
                 .method("GET")
                 .uri("/read/raw.txt")
-                .header("x-s4-process", "read")
+                .header("x-maskura-process", "read")
                 .body(Body::empty())
                 .unwrap(),
             &auth_headers(&ak, &sk),
@@ -6218,7 +6184,7 @@ async fn transformed_read_rejects_range_part_head_encoding_and_unknown_format() 
         let mut request = Request::builder()
             .method(method)
             .uri(uri)
-            .header("x-s4-process", "read");
+            .header("x-maskura-process", "read");
         if let Some((name, value)) = extra_header {
             request = request.header(name, value);
         }
@@ -6298,7 +6264,7 @@ async fn resolver_precedes_authorization_and_isolates_workspace_bucket_and_direc
             Request::builder()
                 .method("GET")
                 .uri("/same-bucket/a.txt")
-                .header("x-s4-process", "read")
+                .header("x-maskura-process", "read")
                 .body(Body::empty())
                 .unwrap(),
             &auth_headers(&first.0, &first.1),
@@ -6497,7 +6463,7 @@ async fn unsafe_transformed_read_refuses_unavailable_staging_without_disclosure(
             Request::builder()
                 .method("GET")
                 .uri("/read/large.txt")
-                .header("x-s4-process", "read")
+                .header("x-maskura-process", "read")
                 .body(Body::empty())
                 .unwrap(),
             &auth_headers(&ak, &sk),
@@ -6552,9 +6518,9 @@ async fn unsafe_transformed_failures_never_disclose_early_late_or_finish_output(
         let mut request = Request::builder()
             .method("GET")
             .uri("/read/failure.txt")
-            .header("x-s4-process", "read");
+            .header("x-maskura-process", "read");
         if let Some(stable_fields) = stable_fields {
-            request = request.header("x-s4-stable-fields", stable_fields);
+            request = request.header("x-maskura-stable-fields", stable_fields);
         }
         let response = build_router(state)
             .oneshot(add_headers(
@@ -6591,7 +6557,7 @@ async fn unsafe_transformed_source_limit_has_no_disclosure() {
             Request::builder()
                 .method("GET")
                 .uri("/read/limit.txt")
-                .header("x-s4-process", "read")
+                .header("x-maskura-process", "read")
                 .body(Body::empty())
                 .unwrap(),
             &auth_headers(&ak, &sk),
@@ -6677,7 +6643,7 @@ async fn nonempty_prefix_safe_reads_stream_and_settle_without_spool() {
             Request::builder()
                 .method("GET")
                 .uri("/read/empty.txt")
-                .header("x-s4-process", "read")
+                .header("x-maskura-process", "read")
                 .body(Body::empty())
                 .unwrap(),
             &auth_headers(&ak, &sk),
@@ -6702,7 +6668,7 @@ async fn nonempty_prefix_safe_reads_stream_and_settle_without_spool() {
             Request::builder()
                 .method("GET")
                 .uri("/read/nonempty.txt")
-                .header("x-s4-process", "read")
+                .header("x-maskura-process", "read")
                 .body(Body::empty())
                 .unwrap(),
             &auth_headers(&ak, &sk),
@@ -6773,7 +6739,7 @@ async fn direct_read_retries_the_exact_terminal_event_before_eof() {
             Request::builder()
                 .method("GET")
                 .uri("/direct/records.txt")
-                .header("x-s4-process", "read")
+                .header("x-maskura-process", "read")
                 .body(Body::empty())
                 .unwrap(),
             &auth_headers(&credentials.0, &credentials.1),
@@ -6814,7 +6780,7 @@ async fn direct_read_settlement_exhaustion_errors_after_disclosure_and_preserves
             Request::builder()
                 .method("GET")
                 .uri("/direct/records.txt")
-                .header("x-s4-process", "read")
+                .header("x-maskura-process", "read")
                 .body(Body::empty())
                 .unwrap(),
             &auth_headers(&credentials.0, &credentials.1),
@@ -6857,7 +6823,7 @@ async fn direct_read_client_cancellation_after_disclosure_preserves_recoverable_
             Request::builder()
                 .method("GET")
                 .uri("/direct/records.txt")
-                .header("x-s4-process", "read")
+                .header("x-maskura-process", "read")
                 .body(Body::empty())
                 .unwrap(),
             &auth_headers(&credentials.0, &credentials.1),
@@ -6882,7 +6848,7 @@ async fn direct_read_client_cancellation_after_disclosure_preserves_recoverable_
             Request::builder()
                 .method("GET")
                 .uri("/direct/empty.txt")
-                .header("x-s4-process", "read")
+                .header("x-maskura-process", "read")
                 .body(Body::empty())
                 .unwrap(),
             &auth_headers(&credentials.0, &credentials.1),
@@ -6941,7 +6907,7 @@ async fn direct_read_terminal_plugin_error_never_settles_customer_usage() {
             Request::builder()
                 .method("GET")
                 .uri("/direct/failure.txt")
-                .header("x-s4-process", "read")
+                .header("x-maskura-process", "read")
                 .body(Body::empty())
                 .unwrap(),
             &auth_headers(&credentials.0, &credentials.1),

--- a/crates/s4-mcp/tests/stdio_e2e.rs
+++ b/crates/s4-mcp/tests/stdio_e2e.rs
@@ -91,11 +91,6 @@ async fn stdio_client_round_trips_through_the_real_gateway() -> anyhow::Result<(
         ),
         ("MASKURA_DEV_MEMORY_STREAMING", Some("true")),
         ("MASKURA_STREAMING_READ_MODE", Some("passthrough")),
-        ("S4_FILTER_COMPONENT", None),
-        ("S4_KEYS_FILE", None),
-        ("S4_SINGLE_TENANT", None),
-        ("S4_DEV_MEMORY_STREAMING", None),
-        ("S4_STREAMING_READ_MODE", None),
         ("DATABASE_URL", None),
         ("S3_ENDPOINT", None),
         ("S4_SERVICE_BUCKETS", None),
@@ -124,12 +119,8 @@ async fn stdio_client_round_trips_through_the_real_gateway() -> anyhow::Result<(
             command
                 .env("MASKURA_GATEWAY_URL", &gateway_url)
                 .env("MASKURA_MCP_TOKEN", &token)
-                .env_remove("S4_GATEWAY_URL")
-                .env_remove("S4_MCP_TOKEN")
                 .env_remove("MASKURA_ACCESS_KEY")
-                .env_remove("MASKURA_SECRET_KEY")
-                .env_remove("S4_ACCESS_KEY")
-                .env_remove("S4_SECRET_KEY");
+                .env_remove("MASKURA_SECRET_KEY");
         }),
     )
     .stderr(Stdio::null())

--- a/crates/s4ctl/src/main.rs
+++ b/crates/s4ctl/src/main.rs
@@ -9,8 +9,8 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 
 const DEFAULT_GATEWAY: &str = "http://localhost:9000";
-const HOSTED_WORKSPACE_ID_ENV: EnvAlias = EnvAlias::new("MASKURA_WORKSPACE_ID", "S4_WORKSPACE_ID");
-const HOSTED_ACCESS_TOKEN_ENV: EnvAlias = EnvAlias::new("MASKURA_ACCESS_TOKEN", "S4_ACCESS_TOKEN");
+const HOSTED_WORKSPACE_ID_ENV: EnvAlias = EnvAlias::new("MASKURA_WORKSPACE_ID");
+const HOSTED_ACCESS_TOKEN_ENV: EnvAlias = EnvAlias::new("MASKURA_ACCESS_TOKEN");
 
 /// Map a destination key's file extension to the streaming Content-Type the
 /// gateway needs to select a format. Falls back to `text/plain` (raw text),
@@ -2209,7 +2209,6 @@ mod tests {
             "Bearer secret-token"
         );
         assert!(headers.get("x-maskura-access-key").is_none());
-        assert!(headers.get("x-s4-access-key").is_none());
     }
 
     #[test]
@@ -2309,10 +2308,8 @@ mod tests {
     }
 
     #[test]
-    fn hosted_env_names_are_canonical_with_permanent_legacy_aliases() {
-        assert_eq!(HOSTED_WORKSPACE_ID_ENV.canonical, "MASKURA_WORKSPACE_ID");
-        assert_eq!(HOSTED_WORKSPACE_ID_ENV.legacy, "S4_WORKSPACE_ID");
-        assert_eq!(HOSTED_ACCESS_TOKEN_ENV.canonical, "MASKURA_ACCESS_TOKEN");
-        assert_eq!(HOSTED_ACCESS_TOKEN_ENV.legacy, "S4_ACCESS_TOKEN");
+    fn hosted_env_names_are_canonical() {
+        assert_eq!(HOSTED_WORKSPACE_ID_ENV.name(), "MASKURA_WORKSPACE_ID");
+        assert_eq!(HOSTED_ACCESS_TOKEN_ENV.name(), "MASKURA_ACCESS_TOKEN");
     }
 }

--- a/crates/s4ctl/tests/hosted_contract.rs
+++ b/crates/s4ctl/tests/hosted_contract.rs
@@ -112,8 +112,6 @@ fn serve(expectations: Vec<Expected>) -> (String, thread::JoinHandle<()>) {
             );
             assert!(!request.headers.contains_key("x-maskura-access-key"));
             assert!(!request.headers.contains_key("x-maskura-secret-key"));
-            assert!(!request.headers.contains_key("x-s4-access-key"));
-            assert!(!request.headers.contains_key("x-s4-secret-key"));
             assert!(!request.target.contains(TOKEN));
             assert!(!String::from_utf8_lossy(&request.body).contains(TOKEN));
             if let Some(content_type) = expected.content_type {
@@ -145,21 +143,13 @@ fn serve(expectations: Vec<Expected>) -> (String, thread::JoinHandle<()>) {
     (format!("http://{address}"), task)
 }
 
-fn run_hosted(binary: &str, gateway: &str, args: &[&str], legacy_env: bool) -> Output {
+fn run_hosted(binary: &str, gateway: &str, args: &[&str]) -> Output {
     let mut command = Command::new(binary);
     command
         .args(["--gateway", gateway, "hosted"])
         .env_remove("MASKURA_WORKSPACE_ID")
         .env_remove("MASKURA_ACCESS_TOKEN")
-        .env_remove("S4_WORKSPACE_ID")
-        .env_remove("S4_ACCESS_TOKEN");
-    if legacy_env {
-        command
-            .env("S4_WORKSPACE_ID", WORKSPACE)
-            .env("S4_ACCESS_TOKEN", TOKEN);
-    } else {
-        command.args(["--workspace", WORKSPACE, "--token", TOKEN]);
-    }
+        .args(["--workspace", WORKSPACE, "--token", TOKEN]);
     let output = command.args(args).output().unwrap();
     assert!(
         output.status.success(),
@@ -360,12 +350,12 @@ fn hosted_cli_contract_walkthrough() {
     let maskura = env!("CARGO_BIN_EXE_maskura");
     let s4ctl = env!("CARGO_BIN_EXE_s4ctl");
 
-    let catalog = run_hosted(maskura, &gateway, &["catalog"], false);
+    let catalog = run_hosted(maskura, &gateway, &["catalog"]);
     assert!(output_text(&catalog).contains("version 1.2.3"));
     assert!(output_text(&catalog).contains("digest=abcdef012345"));
     assert!(output_text(&catalog).contains("state=validated"));
 
-    let stage = run_hosted(maskura, &gateway, &["stage", artifact_arg], false);
+    let stage = run_hosted(maskura, &gateway, &["stage", artifact_arg]);
     assert!(output_text(&stage).contains("Digest:    artifact-digest"));
 
     let upload = run_hosted(
@@ -383,11 +373,10 @@ fn hosted_cli_contract_walkthrough() {
             "--capability",
             "stable_fields",
         ],
-        true,
     );
     assert!(output_text(&upload).contains("validation_run=run/1"));
 
-    let validation = run_hosted(maskura, &gateway, &["validation", "version/1"], false);
+    let validation = run_hosted(maskura, &gateway, &["validation", "version/1"]);
     assert!(output_text(&validation).contains("Version 1.2.3"));
     assert!(output_text(&validation).contains("run run/1  state=succeeded"));
 
@@ -403,13 +392,11 @@ fn hosted_cli_contract_walkthrough() {
             "--version-id",
             "version/1",
         ],
-        false,
     );
     run_hosted(
         maskura,
         &gateway,
         &["pipelines", "create", "write", "redact"],
-        false,
     );
     run_hosted(
         maskura,
@@ -421,14 +408,8 @@ fn hosted_cli_contract_walkthrough() {
             "--step",
             "install/1:version/1",
         ],
-        false,
     );
-    run_hosted(
-        maskura,
-        &gateway,
-        &["pipelines", "publish", "pipeline/1"],
-        false,
-    );
+    run_hosted(maskura, &gateway, &["pipelines", "publish", "pipeline/1"]);
     let assignment_args = [
         "assign-bucket",
         "write",
@@ -436,21 +417,19 @@ fn hosted_cli_contract_walkthrough() {
         "--pipeline-id",
         "pipeline/1",
     ];
-    run_hosted(maskura, &gateway, &assignment_args, false);
-    run_hosted(maskura, &gateway, &assignment_args, false);
+    run_hosted(maskura, &gateway, &assignment_args);
+    run_hosted(maskura, &gateway, &assignment_args);
     run_hosted(
         maskura,
         &gateway,
         &["unassign-bucket", "write", "bucket name/2026"],
-        false,
     );
     run_hosted(
         maskura,
         &gateway,
         &["pipelines", "rollback", "pipeline/1", "revision/old"],
-        false,
     );
-    let audit = run_hosted(maskura, &gateway, &["audit", "--limit", "25"], false);
+    let audit = run_hosted(maskura, &gateway, &["audit", "--limit", "25"]);
     assert!(output_text(&audit).contains("filter.pipeline.rollback"));
 
     std::fs::remove_file(artifact).unwrap();

--- a/docs/plans/2026-09-08-config-file-and-env-override.md
+++ b/docs/plans/2026-09-08-config-file-and-env-override.md
@@ -1,0 +1,210 @@
+# Layered TOML configuration with env override
+
+Status: planned
+Scope: self-hosted OSS gateway, shared `build_state`, private SaaS control binary
+Repositories: public `231self/maskura` (base schema, gateway), private `s4-private` (extension)
+
+## Objective
+
+Give the gateway a single TOML config file as the canonical home for its
+non-secret settings, with environment variables overriding the file, so that
+operating basic local behaviour requires as few user-tweakable knobs as
+possible. The private SaaS binary gets its own TOML that *inherits* the OSS
+schema (via serde flatten) and extends it with SaaS-only fields.
+
+## Current-State Findings
+
+- Configuration is read almost entirely from environment variables. There are
+  ~50 distinct names in the gateway, split across three kinds: feature gates
+  (safe "off" defaults), storage/identity, and operator/SaaS-only controls.
+- The `MASKURA_*`/`S4_*` alias pairs are centralized in
+  `crates/customer-config/src/lib.rs` (`EnvAlias`, `resolve`, `validate`,
+  `GATEWAY_CUSTOMER_SETTINGS`, `CLIENT_CUSTOMER_SETTINGS`). But many reads bypass
+  this crate and call `std::env::var` directly.
+- `build_state` (`crates/gateway/src/server.rs:10986`) and
+  `build_state_with_pipeline_template` (`:10999`) read the non-secret settings
+  inline: `S3_ENDPOINT`/`S3_REGION`/`S3_*` creds (`11006`, `11038`–`11047`),
+  `SUPABASE_URL`/`SUPABASE_JWT_SECRET` (`11089`–`11091`),
+  `S4_MANAGED_STREAMING_MODE`/`S4_MANAGED_PLACEMENT_VERSION` (`11096`–`11099`),
+  multipart quotas (`11104`–`11117`), `S4_MULTIPART_STAGING_*` (`11256`–`11289`),
+  `DATABASE_URL` key store (`11180`), and spool/dev-memory settings
+  (`11143`–`11173`).
+- Helper readers: `enabled_env_flag` (`10839`), `multipart_mode` (`974`),
+  `configured_s3_streaming_capabilities` (`987`),
+  `configured_managed_streaming_capabilities` (`1009`),
+  `legacy_max_object_bytes` (`1026`), `StreamingReadMode::from_env` (`911`),
+  `transformed_read_spool_enabled` (`930`), `binary_avro_enabled` (`935`),
+  `prefix_safe_component_hashes` (`943`), `source_body_limits_from_env` (`10967`),
+  `component_path` (`10804`), `StatePipelineTemplate::from_env` (`721`).
+- Policy constructors read env directly: `PresignedHttpPolicy::from_env`
+  (`backend.rs:880`), `SigV4Policy::from_env` (`sigv4.rs:104`),
+  `WorkspaceEndpointPolicy::from_env` (`backend.rs:656`).
+- Secrets are read where used and stay env-only: `default_wrapping` /
+  `LocalKeyWrapping::from_env` (`key_cipher.rs:129`/`62`) reads `S4_SECRET_KEK`;
+  `DATABASE_URL`, `S3_*` creds, and `SUPABASE_JWT_SECRET` are read inside
+  `build_state`.
+- The OSS binary (`crates/gateway/src/main.rs`) reads only `LISTEN_ADDR` and
+  injects `NoopControlPlane`, `default_wrapping()`, and
+  `InMemoryWorkspaceStorageRepository` into `build_state`.
+- The private binary (`s4-private/crates/s4-control/src/main.rs`) reads its own
+  env surface (`DATABASE_URL`, `PADDLE_*`, `S4_VAULT_*`, `S4_KMS_KEY_ID`,
+  `S4_FILTER_ARTIFACT_*`, `S4_CUSTOM_FILTER_UPLOADS_*`,
+  `S4_HOSTED_PIPELINES_ENABLED`, `S4_UNSAFE_LOCAL_FILTER_VALIDATION`, …) and
+  injects `SaaSControlPlane`, KMS/Vault wrapping, and
+  `HostedWorkspaceStorageRepository` into the same `build_state` (`main.rs:695`).
+
+## Decisions
+
+1. **Layered TOML, schema inheritance via serde flatten.** The public
+   `maskura-customer-config` crate grows a `Config` struct (base schema, TOML
+   deserialize, defaults, validation, env override). The private crate defines
+   `PrivateConfig { #[serde(flatten)] base: Config, … }` so a private TOML is a
+   literal superset of the OSS TOML.
+2. **Config file is canonical for non-secret settings; secrets stay env-only.**
+   Secrets (`S3_ACCESS_KEY_ID`/`S3_SECRET_ACCESS_KEY`, `DATABASE_URL`,
+   `SUPABASE_JWT_SECRET`/`SUPABASE_ANON_KEY`, `S4_SECRET_KEK`,
+   `S4_MULTIPART_STAGING_*_KEY_ID/SECRET`, `MASKURA_BOOTSTRAP_SECRET`) are not
+   fields in `Config`. With `deny_unknown_fields`, a secret in the file is a
+   hard startup error — the property is enforced structurally.
+3. **Precedence: defaults < file < env.** Compiled defaults via
+   `#[serde(default)]`; the file supplies values when present; every non-secret
+   field keeps an env override using its `MASKURA_*` name (or the existing
+   operator name for operator-only settings).
+4. **Discovery: default path + override.** Default `./maskura.toml`; explicit
+   `--config <path>` or `MASKURA_CONFIG` wins. The private binary defaults to
+   `./maskura-control.toml` with the same override rule.
+5. **Fail closed on invalid file values.** Unknown keys, malformed TOML, and
+   invalid enum/numeric values are hard startup errors (upgrading the current
+   warn-then-default behaviour for file-sourced values).
+6. **`build_state` takes the resolved config.** Signature becomes
+   `build_state(control, wrapping, workspace_storage, config: &Config)`; the
+   scattered non-secret env reads move to `config` field reads. Secrets keep
+   their current env reads.
+7. **Abandon the `S4_*` env aliases.** The customer-facing `MASKURA_*`/`S4_*`
+   alias pairs collapse to the single `MASKURA_*` name; `EnvAlias::legacy` and
+   its conflict handling are removed. A repo-wide sweep removes leftover `S4_*`
+   alias references (code, tests, docs, scripts, `s4ctl`, examples, compose
+   files). Operator-only `S4_*` names (`S4_SECRET_KEK`, `S4_SERVICE_BUCKETS`,
+   `S4_SIGV4_*`, `S4_MANAGED_*`, `S4_MULTIPART_STAGING_*`, `S4_PRESIGNED_HTTP_*`,
+   `S4_WORKSPACE_ENDPOINT_*`) are canonical, not aliases, and remain.
+8. **Add `maskura config --check`** (`s4ctl`) to load a config file and report
+   validation without booting the gateway.
+
+## Ordered Implementation
+
+### 1. Add `Config` to `maskura-customer-config`
+
+**Files:** `crates/customer-config/src/lib.rs` (+ new `config.rs` module).
+
+- Define `Config` with serde derive, `Default`, TOML tables
+  (`[server]`, `[auth]`, `[storage]`, `[supabase]`, `[features]`, `[wasm]`,
+  `[limits]`, `[spool]`, `[keys]`, `[managed]`, `[multipart_staging]`,
+  `[sigv4]`, `[allowlists]`).
+- Implement `Config::load(path) -> Result<Config>` (parse + `deny_unknown_fields`)
+  and `apply_env_overrides(&mut self)` mapping each field to its single env name
+  (`MASKURA_*` for customer settings, the operator name for operator-only settings).
+- Implement `Config::resolve(path, env) -> Result<Config>` returning
+  defaults → file → env with validation.
+
+**Verify:** table-driven unit tests for parse, defaults, precedence
+(default < file < env), `deny_unknown_fields`, and hard-error on invalid values.
+
+### 2. Abandon the `S4_*` env aliases
+
+**Files:** `crates/customer-config/src/lib.rs` plus repo-wide sweep.
+
+- Remove `EnvAlias::legacy` and its conflict handling; collapse each alias pair
+  to a single `MASKURA_*` name. `resolve` becomes a single-name read.
+- Sweep every `S4_*` reference that was a customer-settings alias (code, tests,
+  docs, `README.md`, `restart-dev.sh`, `justfile`, `local/docker-compose.yml`,
+  `s4ctl`, examples) and remove/rename. Operator-only `S4_*` names stay.
+
+**Verify:** `rg -n "S4_[A-Z]"` returns only operator-only names
+(`S4_SECRET_KEK`, `S4_SERVICE_BUCKETS`, `S4_SIGV4_*`, `S4_MANAGED_*`,
+`S4_MULTIPART_STAGING_*`, `S4_PRESIGNED_HTTP_*`, `S4_WORKSPACE_ENDPOINT_*`) and
+no customer-setting aliases; `just check` green.
+
+### 3. Thread `config: &Config` through `build_state`
+
+**Files:** `crates/gateway/src/server.rs`.
+
+- Change `build_state` and `build_state_with_pipeline_template` to accept
+  `config: &Config`; replace the non-secret `std::env::var` reads and helper
+  `*_from_env` functions with `config` field reads.
+- Keep secret reads (`DATABASE_URL`, `S3_*` creds, `SUPABASE_JWT_SECRET`) in
+  place.
+- Re-key `validate_storage_boundary_startup`, `validate_multipart_startup`, and
+  `validate_mode` onto `config` values.
+
+**Verify:** existing gateway tests pass via config fixtures; the env-override
+layer keeps env-driven tests green.
+
+### 4. Wire the OSS binary + `maskura config --check`
+
+**Files:** `crates/gateway/src/main.rs`, `crates/s4ctl/src/main.rs`.
+
+- Gateway: resolve config (default `./maskura.toml`, `--config`/`MASKURA_CONFIG`
+  override), then call `build_state(…, &config)`.
+- `s4ctl`: add `config --check [--config <path>]` that loads and validates a file
+  (defaults, file, env override, secret rejection) and prints a pass/fail report
+  without booting.
+
+**Verify:** boot with no file (today's behaviour) and with a file (file values
+take effect, env overrides them); `maskura config --check` reports errors for an
+invalid file and exit 0 for a valid one.
+
+### 5. Private extension (in `s4-private`)
+
+**Files:** `s4-private/crates/s4-control/src/config.rs`, `main.rs`.
+
+- Add `PrivateConfig { #[serde(flatten)] base: Config, …SaaS fields… }` covering
+  the private env surface (Paddle, Vault/KMS, filter artifacts, hosted
+  pipelines, custom-upload scope, …).
+- Resolve `./maskura-control.toml` → `PrivateConfig`; pass `&config.base` into
+  `build_state` and use the SaaS fields for control-plane/KMS wiring.
+
+**Verify:** private boot with `maskura-control.toml`; secrets still env-only.
+
+### 6. Documentation + ADR
+
+**Files:** new `docs/reference/configuration.md` (or extend `docs/security.md`),
+`AGENTS.md`, and a new `docs/adr/0012-*.md`.
+
+- Document the config file schema, env override table, secret boundary, and
+  discovery rules.
+- ADR records the lasting choice (config file as canonical non-secret source,
+  env override, secrets env-only, two-repo schema inheritance).
+
+**Verify:** `just check` green; docs reference the real default paths.
+
+## Verification Gates
+
+- `just check` passes (`-D warnings`).
+- No file present → gateway behaviour identical to today (env/defaults).
+- `./maskura.toml` supplies non-secret values; a documented env var overrides a
+  file value; precedence default < file < env holds under test.
+- A secret key in the TOML fails startup (structural rejection).
+- An invalid value (e.g. unknown `multipart_mode`) fails startup.
+- No customer-setting `S4_*` alias remains in the repo (sweep is exhaustive).
+- `maskura config --check` exits 0 on a valid file and non-zero on an invalid one.
+- Private binary boots from `maskura-control.toml` with `base` fields honoured.
+
+## Success Criteria
+
+- Basic local operation needs at most `auth.disabled = true` + storage endpoint
+  + credentials in the file (or their env equivalents); every feature gate and
+  limit has a safe default that needs no user action.
+- One reference doc lists every setting, its default, its file key, and its env
+  override name.
+- Secrets are impossible to put in the config file.
+- The `S4_*` customer-setting alias layer is fully removed; only operator-only
+  `S4_*` names remain.
+
+## Open Decisions
+
+- Whether the `x-s4-*` HTTP header aliases are also abandoned in the same sweep
+  or deferred to a separate change (they are headers, not env vars, and were
+  not part of this survey).
+- Whether `maskura config --check` also validates the private
+  `maskura-control.toml` schema (requires the private crate to expose its schema
+  to `s4ctl`, likely out of scope for the OSS binary).

--- a/docs/plans/2026-09-08-config-file-and-env-override.md
+++ b/docs/plans/2026-09-08-config-file-and-env-override.md
@@ -105,9 +105,25 @@ schema (via serde flatten) and extends it with SaaS-only fields.
   (`MASKURA_*` for customer settings, the operator name for operator-only settings).
 - Implement `Config::resolve(path, env) -> Result<Config>` returning
   defaults → file → env with validation.
+- Add a typed validation layer (`Config::validate()`) that rejects, with a
+  field-specific error:
+  - malformed input (bad TOML, wrong value types, out-of-range integers);
+  - missing required fields (only where a table is present but a mandatory
+    member is absent, e.g. a storage backend that names a bucket without a
+    region/endpoint);
+  - field-schema violations — URLs must parse, presigned/workspace allowlists
+    must be valid host/DNS-suffix entries, key material must be correct
+    length/encoding (e.g. `bootstrap_key`/`bootstrap_secret` shapes), byte
+    quotas must be positive, modes must be known enum values;
+  - illogical value combinations — e.g. `managed_streaming_mode=observe` without
+    a managed backend, `multipart_mode=staged` without durable staging, HTTP
+    presign without an explicit HTTP allowlist entry.
 
 **Verify:** table-driven unit tests for parse, defaults, precedence
 (default < file < env), `deny_unknown_fields`, and hard-error on invalid values.
+A dedicated validation test matrix covers, per field: malformed, missing,
+schema-invalid (URL/key-length/encoding), and contradictory-combination inputs,
+each asserting a specific error and that the config is rejected.
 
 ### 2. Abandon the `S4_*` env aliases
 
@@ -185,6 +201,9 @@ invalid file and exit 0 for a valid one.
   file value; precedence default < file < env holds under test.
 - A secret key in the TOML fails startup (structural rejection).
 - An invalid value (e.g. unknown `multipart_mode`) fails startup.
+- Validation test matrix is exhaustive per field: malformed input, missing
+  required, schema-invalid (bad URL / key length / encoding), and contradictory
+  combinations each produce a specific error and reject the config.
 - No customer-setting `S4_*` alias remains in the repo (sweep is exhaustive).
 - `maskura config --check` exits 0 on a valid file and non-zero on an invalid one.
 - Private binary boots from `maskura-control.toml` with `base` fields honoured.
@@ -202,9 +221,6 @@ invalid file and exit 0 for a valid one.
 
 ## Open Decisions
 
-- Whether the `x-s4-*` HTTP header aliases are also abandoned in the same sweep
-  or deferred to a separate change (they are headers, not env vars, and were
-  not part of this survey).
 - Whether `maskura config --check` also validates the private
   `maskura-control.toml` schema (requires the private crate to expose its schema
   to `s4ctl`, likely out of scope for the OSS binary).

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -123,8 +123,8 @@ available on hosted Maskura. Hosted management is available only when the hosted
 enables filter pipelines (and separately enables custom uploads). It authenticates with a
 **Supabase access token** (`MASKURA_ACCESS_TOKEN` or `--token`) and a workspace ID
 (`MASKURA_WORKSPACE_ID` or `--workspace`); a Maskura data-plane API key is never accepted
-for hosted mutations. The legacy `s4ctl` binary and `S4_ACCESS_TOKEN` /
-`S4_WORKSPACE_ID` environment names remain permanent aliases.
+for hosted mutations. The `s4ctl` binary name remains available as an alias for
+`maskura`.
 
 ```bash
 export MASKURA_ACCESS_TOKEN=<supabase-jwt>

--- a/docs/security.md
+++ b/docs/security.md
@@ -66,11 +66,9 @@ A Maskura API key is a pair `s4_<32-hex>` (access key ID) + `s4s_<32-hex>`
    using its Maskura key. The gateway recomputes the signature and rejects requests
 whose signature does not match the stored secret.
 
-Legacy `x-s4-*` customer headers remain permanent aliases. When both canonical
-and legacy forms are present they must have byte-identical values; differing
-values fail closed before the request body is polled. Reserved metering,
-operation, and usage headers are rejected under both namespaces. Credential
-prefixes remain `s4_`, `s4s_`, and `s4m_` so existing credentials do not change.
+The `x-maskura-*` customer headers are the only supported names. Reserved
+metering, operation, and usage headers are rejected. Credential prefixes remain
+`s4_`, `s4s_`, and `s4m_` so existing credentials do not change.
 
 ### SigV4 verification
 
@@ -527,13 +525,10 @@ that do not embed the above.
 These are **operator responsibilities**; Maskura will not and cannot enforce them
 from inside a container:
 
-Customer-configurable gateway settings use `MASKURA_*`. The corresponding
-shipped `S4_*` names are permanent aliases; startup resolves them without
-mutating the process environment and rejects differing dual values. Empty
-values are still values, so an empty canonical value conflicts with a non-empty
-legacy value. Internal/operator controls such as `S4_SECRET_KEK`,
+Customer-configurable gateway settings use `MASKURA_*` environment variables.
+Internal/operator controls such as `S4_SECRET_KEK`,
 `S4_SERVICE_BUCKETS`, `S4_WORKSPACE_ENDPOINT_*`, `S4_PRESIGNED_HTTP_*`,
-`S4_SIGV4_*`, `S4_MANAGED_*`, and `S4_MULTIPART_STAGING_*` intentionally keep their existing
+`S4_SIGV4_*`, `S4_MANAGED_*`, and `S4_MULTIPART_STAGING_*` keep their existing
 names and are not exposed through customer aliases.
 
 - **TLS termination** — place the gateway behind a TLS-terminating proxy

--- a/restart-dev.sh
+++ b/restart-dev.sh
@@ -20,14 +20,8 @@ kill_port() {
   fi
 }
 
-if [ "${MASKURA_PORT+x}" = x ] && [ "${S4_PORT+x}" = x ] && [ "$MASKURA_PORT" != "$S4_PORT" ]; then
-  echo "ERROR: conflicting environment aliases: MASKURA_PORT and S4_PORT" >&2
-  exit 1
-fi
 if [ "${MASKURA_PORT+x}" = x ]; then
   GATEWAY_PORT="$MASKURA_PORT"
-elif [ "${S4_PORT+x}" = x ]; then
-  GATEWAY_PORT="$S4_PORT"
 else
   GATEWAY_PORT=9000
 fi


### PR DESCRIPTION
## Summary

Introduces a layered TOML configuration file as the canonical home for the gateway's non-secret settings, with environment variables overriding the file, and removes the legacy `S4_*`/`x-s4-*` alias layer.

### 1. Abandon `S4_*` and `x-s4-*` aliases

- Collapse `HeaderAlias` (`crates/gateway/src/customer_headers.rs`) and `EnvAlias` (`crates/customer-config`) to single canonical names (`x-maskura-*`, `MASKURA_*`); remove conflict/`legacy` handling.
- Remove `x-s4-*` from SigV4 `SEMANTIC_HEADERS` and the metering/access-key checks in `server.rs`.
- Rewrite alias tests to assert legacy `x-s4-*` is now rejected; rename incidental test fixtures.
- Sweep docs (`security.md`, `plugins.md`, `README.md`, `AGENTS.md`), `restart-dev.sh` (`S4_PORT`), and the private landing page (`auth.md`, agent-skills, `agent-reads.astro`, `maskura-plugins.md`).

### 2. Layered TOML config (`maskura_customer_config::Config`)

- 13 TOML tables (`server`, `auth`, `storage`, `supabase`, `features`, `wasm`, `limits`, `spool`, `keys`, `managed`, `multipart_staging`, `sigv4`, `allowlists`), `deny_unknown_fields`, `from_toml_str`/`from_file`, `apply_env_overrides`.
- Typed `ConfigError` with field paths. `validate()` rejects:
  - malformed input (bad TOML, wrong value types),
  - missing required fields (staged multipart deps, managed observe deps),
  - field-schema violations (socket addr, http(s) URLs, 64-hex hashes, host/`*.suffix` allowlist entries, positive byte quotas, known enums),
  - illogical combinations (S3 endpoint vs service buckets, managed observe without transactional/buckets, transformed read without spool, spool quota < max object).

### Verification

- `cargo test -p maskura-customer-config`: 28 tests pass (24 config validation + 4 alias).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.

Secrets (`S3_*` keys, `DATABASE_URL`, `SUPABASE_JWT_SECRET`, `S4_SECRET_KEK`, `S4_MULTIPART_STAGING_*_KEY_ID/SECRET`, `MASKURA_BOOTSTRAP_SECRET`) remain env-only and are not fields in `Config`.

Follow-up (not in this PR): threading `config: &Config` through `build_state`, `maskura config --check`, and the private `maskura-control.toml` extension — per `docs/plans/2026-09-08-config-file-and-env-override.md`.