### PR TITLE
ci(release): auto-tag main on version bump

### DIFF
--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -1,0 +1,72 @@
+name: Tag on version bump
+
+# Auto-tags main with v<version> whenever the workspace version in the root
+# Cargo.toml changes, so release.yml (on: push: tags: ['v*']) builds and
+# publishes release artifacts. Tags stopped at v0.3.8 while Cargo.toml climbed
+# to 0.5.2, which is why no release artifacts have built since.
+#
+# SECRET REQUIREMENT
+# ------------------
+# A tag pushed with the default GITHUB_TOKEN does NOT trigger release.yml:
+# GitHub suppresses workflow/event fan-out from GITHUB_TOKEN to prevent loops.
+# The tag must instead be pushed with a Personal Access Token (PAT) that has
+# `contents: write` and `workflows: write` scopes.
+#
+#   1. Create a fine-grained PAT scoped to this repo (231self/maskura) with:
+#        Contents:  Read and write
+#        Workflows: Read and write
+#   2. Add it as an Actions secret named RELEASE_TOKEN
+#      (Settings → Secrets and variables → Actions → New repository secret).
+#
+# The token is referenced via secrets.RELEASE_TOKEN below and is never
+# committed to the repository.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tag-if-bumped:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history (and tags) so we can diff the previous commit's
+          # Cargo.toml and check whether the tag already exists.
+          fetch-depth: 0
+
+      - name: Detect version bump
+        id: version
+        run: |
+          current=$(awk '/^\[workspace.package\]/{f=1} f && /^version[[:space:]]*=/{gsub(/[" ]/, "", $3); print $3; exit}' Cargo.toml)
+          previous=$(git show HEAD~1:Cargo.toml 2>/dev/null | awk '/^\[workspace.package\]/{f=1} f && /^version[[:space:]]*=/{gsub(/[" ]/, "", $3); print $3; exit}')
+          echo "current=${current}"
+          echo "previous=${previous}"
+          if [ -n "$previous" ] && [ "$current" = "$previous" ]; then
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "bumped=true" >> "$GITHUB_OUTPUT"
+            echo "tag=v${current}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push tag
+        if: steps.version.outputs.bumped == 'true'
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          tag="${{ steps.version.outputs.tag }}"
+          if [ -z "$tag" ]; then
+            echo "could not determine workspace version; skipping tag"
+            exit 0
+          fi
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "tag $tag already exists; skipping"
+            exit 0
+          fi
+          git tag "$tag"
+          git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin "refs/tags/$tag"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/tag-on-version-bump.yml`, which tags `main` with `v<version>` whenever the `[workspace.package]` version in the root `Cargo.toml` changes. This closes the gap where `release.yml` (triggered on `push: tags: ['v*']`) stopped firing after tags stalled at `v0.3.8` while `Cargo.toml` climbed to `0.5.2`.

- **Trigger**: `push` to `main` (plus `workflow_dispatch` for manual testing).
- **Version source**: `[workspace.package]` in the root `Cargo.toml` (crates reference it via `version.workspace = true`).
- **Tag name**: `v<version>` — matches `release.yml`'s `tags: ['v*']` filter.
- **Idempotent**: skips (no-op, exit 0) if the tag already exists or the version didn't change vs. the previous `main` commit.

## Secret requirement (must be configured before this works)

A tag pushed with the default `GITHUB_TOKEN` **will not** trigger `release.yml` — GitHub suppresses event fan-out from `GITHUB_TOKEN` to prevent loops. The workflow pushes the tag with a PAT instead:

1. Create a fine-grained PAT scoped to this repo (`231self/maskura`) with:
   - **Contents**: Read and write
   - **Workflows**: Read and write
2. Add it as an Actions repository secret named **`RELEASE_TOKEN`** (Settings → Secrets and variables → Actions → New repository secret).

The token is referenced via `secrets.RELEASE_TOKEN` and is never committed.

## Open decision (flagging, not silently choosing)

**GitHub Release object ownership.** This workflow deliberately does **not** create the GitHub Release; `release.yml` already owns that via `gh release create` (with `--generate-notes` and all artifacts). Keeping the release object in `release.yml` means release notes + artifacts stay in one place and the tag workflow stays side-effect-free (just tagging). If you'd prefer the tag workflow to also create a draft/empty release, that's a small follow-up — but it would risk racing `release.yml`'s `gh release create`.

## Verification

- `awk ... Cargo.toml` → `0.5.2` (confirmed locally).
- No-op path: a `main` push that doesn't change `version` produces no tag.
- After merge, bumping the version in a follow-up PR should produce a `vX.Y.Z` tag and kick off a `release.yml` run.
