### PR TITLE
fix(ci): push the release tag with the PAT, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -38,6 +38,10 @@ jobs:
           # Full history (and tags) so we can diff the previous commit's
           # Cargo.toml and check whether the tag already exists.
           fetch-depth: 0
+          # Don't persist the GITHUB_TOKEN credential helper: it would override
+          # the PAT URL below and push the tag as github-actions[bot], which
+          # cannot trigger release.yml.
+          persist-credentials: false
 
       - name: Detect version bump
         id: version
@@ -68,5 +72,6 @@ jobs:
             exit 0
           fi
           git tag "$tag"
+          git config --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin "refs/tags/$tag"


### PR DESCRIPTION
The tag push in tag-on-version-bump.yml failed because actions/checkout's persisted GITHUB_TOKEN credential helper overrode the PAT URL, so the push was attempted as github-actions[bot] and got 403. This PR adds `persist-credentials: false` to checkout and unsets the extraheader before pushing, so the tag is pushed authenticated as the RELEASE_TOKEN PAT.