### PR TITLE
Preserve staged parts during multipart completion

### DIFF
--- a/crates/gateway/src/multipart_staging.rs
+++ b/crates/gateway/src/multipart_staging.rs
@@ -119,6 +119,12 @@ pub enum MultipartLifecycle {
     Expired,
 }
 
+impl MultipartLifecycle {
+    fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Aborted | Self::Expired)
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MultipartUpload {
     pub identity: MultipartIdentity,
@@ -1234,7 +1240,10 @@ impl MultipartRepository for PostgresMultipartRepository {
             let Some(upload) = upload else { continue };
             let pending_is_old = attempt.lifecycle == "PENDING"
                 && attempt.created_at_ms <= now - RECONCILIATION_GRACE.as_millis() as i64;
-            if upload.lifecycle != "OPEN" || attempt.lifecycle == "RETIRED" || pending_is_old {
+            if lifecycle(&upload.lifecycle)?.is_terminal()
+                || attempt.lifecycle == "RETIRED"
+                || pending_is_old
+            {
                 result.push(CleanupCandidate {
                     upload_id: attempt.upload_id,
                     artifact_key: attempt.artifact_key,
@@ -1973,9 +1982,7 @@ impl MultipartRepository for InMemoryMultipartRepository {
                 let upload = state.uploads.get(&attempt.part.upload_id)?;
                 let old_pending = attempt.lifecycle == "PENDING"
                     && attempt.part.created_at_ms <= now - RECONCILIATION_GRACE.as_millis() as i64;
-                (upload.lifecycle != MultipartLifecycle::Open
-                    || attempt.lifecycle == "RETIRED"
-                    || old_pending)
+                (upload.lifecycle.is_terminal() || attempt.lifecycle == "RETIRED" || old_pending)
                     .then(|| CleanupCandidate {
                         upload_id: attempt.part.upload_id.clone(),
                         artifact_key: key.clone(),
@@ -3220,6 +3227,27 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn completing_upload_parts_are_not_cleanup_candidates() {
+        let repo = InMemoryMultipartRepository::new();
+        repo.create(upload()).await.unwrap();
+        current_part(&repo, 1, "\"one\"", "sha-one").await;
+        let request = vec![complete_part(1, "\"one\"", Some("sha-one"))];
+        assert!(matches!(
+            repo.acquire_completion(&identity(), "fingerprint", &request, "worker-a", 100, 0)
+                .await
+                .unwrap(),
+            CompletionAcquire::Acquired(_)
+        ));
+
+        assert!(
+            repo.cleanup_candidates(now_ms(), 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/crates/gateway/tests/db_keys_test.rs
+++ b/crates/gateway/tests/db_keys_test.rs
@@ -2786,13 +2786,14 @@ async fn mock_s3_handler(
             .cloned()
             .collect();
         keys.sort();
+        let last_modified = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
         let mut xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?><ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>{MOCK_STAGING_BUCKET}</Name><Prefix>{prefix}</Prefix><KeyCount>{}</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated>"#,
             keys.len()
         );
         for object_key in keys {
             xml.push_str(&format!(
-                "<Contents><Key>{object_key}</Key><LastModified>2026-01-01T00:00:00.000Z</LastModified><Size>{}</Size></Contents>",
+                "<Contents><Key>{object_key}</Key><LastModified>{last_modified}</LastModified><Size>{}</Size></Contents>",
                 objects.get(&object_key).map_or(0, Vec::len)
             ));
         }
@@ -3167,13 +3168,26 @@ fn router_staged_multipart_flow_is_durable_and_idempotent() {
             .block_destination_put
             .store(true, Ordering::Release);
         let destination_puts_before = mock_state.destination_put_count.load(Ordering::Acquire);
-        let first_completion = tokio::spawn(restarted_app.clone().oneshot(complete));
-        tokio::time::timeout(
-            Duration::from_secs(5),
-            mock_state.wait_for_destination_put_after(destination_puts_before),
-        )
-        .await
-        .expect("first completion reached the direct destination");
+        let mut first_completion = tokio::spawn(restarted_app.clone().oneshot(complete));
+        tokio::select! {
+            () = mock_state.wait_for_destination_put_after(destination_puts_before) => {}
+            result = &mut first_completion => {
+                let response = result
+                    .expect("first completion task")
+                    .expect("first completion response");
+                let status = response.status();
+                let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .expect("first completion error body");
+                panic!(
+                    "first completion returned {status} before reaching the direct destination: {}",
+                    String::from_utf8_lossy(&body)
+                );
+            }
+            () = tokio::time::sleep(Duration::from_secs(30)) => {
+                panic!("first completion did not reach the direct destination within 30 seconds");
+            }
+        }
         let busy = add_headers(
             Request::builder()
                 .method("POST")


### PR DESCRIPTION
## Summary

- preserve staged multipart parts while an upload is in the non-terminal `COMPLETING` state
- apply the same lifecycle rule to the Postgres and in-memory repositories
- add a regression test and make the Postgres race test report early completion failures directly
- keep mock S3 object timestamps inside the reconciliation grace period

## Root cause

The reconciliation worker treated every upload state other than `OPEN` as disposable. During completion, it could therefore delete selected staged parts after the lifecycle moved to `COMPLETING` but before the destination write read them.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- regression unit test
- failing Postgres scenario: 20/20 passes
- full Postgres integration suite: 25/25 passes

The local full `just check` reached the Wasm filter build, which requires the `wasm32-wasip1` target missing from this host's asdf Rust toolchain; GitHub CI has the configured target.
