### PR TITLE
docs(local): document Maskura Docker storage path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,20 @@ emails / SSNs / credit cards), `email-detect`, `ssn-detect`, `card-detect`,
 
 ## Quickstart
 
-No cloud account, no database, no repo clone — run the published image:
+No cloud account, database, MinIO service, or repo clone is needed. Run the
+published Maskura gateway image with its own local S3-compatible API and one
+durable Docker volume:
 
 ```bash
-docker run --rm -p 127.0.0.1:8791:8080 \
+docker run --rm -p 127.0.0.1:8791:8080 -v s4-local-keys:/data \
   -e AUTH_DISABLED=true \
+  -e MASKURA_KEYS_FILE=/data/keys.json \
+  -e MASKURA_STORAGE_MODE=local \
+  -e MASKURA_LOCAL_STORAGE_DIR=/data \
+  -e MASKURA_MULTIPART_MODE=staged \
   -e MASKURA_STREAMING_READ_MODE=passthrough \
   ghcr.io/231self/maskura/maskura:latest
-# open http://localhost:8791 → demo dashboard (no sign-up)
+# open http://localhost:8791 -> demo dashboard (no sign-up)
 ```
 
 The gateway speaks SigV4, so your existing `aws s3` CLI works as-is:
@@ -127,7 +133,7 @@ maskura get ingest/data.csv --bucket s4-local
 ```
 
 `maskura local init` pulls the gateway image tagged with the CLI version
-(`ghcr.io/231self/maskura/maskura:v0.4.1` for `maskura` 0.4.1; CLI and gateway always
+(`ghcr.io/231self/maskura/maskura:v0.5.3` for `maskura` 0.5.3; CLI and gateway always
 match, never `:latest`) and runs a durable single-node local FileStore
 (`AUTH_DISABLED=true`, staged multipart enabled, all state on one volume). It picks
 a free port (8080+) and only listens on localhost. `maskura local down` stops it.
@@ -206,12 +212,12 @@ Everything below is copy-paste runnable.
 **Redaction — PII filtered on write**
 
 ```bash
-# Local gateway (published image, Docker, in-memory storage):
+# Local gateway (Maskura-managed Docker container, durable FileStore):
 maskura local init
 maskura put ./data.csv ingest/data.csv --bucket s4-local
 maskura get ingest/data.csv --bucket s4-local     # emails/SSNs/cards redacted
 
-# Durable local storage (MinIO) from a repo clone:
+# Optional external-backend validation path (MinIO + Docker Compose):
 just dev-up
 maskura put ./data.csv ingest/data.csv --bucket s4-local
 

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -10,6 +10,20 @@ just e2e                  # run the full suite
 bash scripts/e2e-local.sh # same, without `just`
 ```
 
+This suite intentionally validates the gateway's external S3 backend path using
+MinIO. It is separate from the standalone Docker deployment used by customers.
+For the standalone path, run the Maskura-managed container instead:
+
+```bash
+maskura local init
+# Maskura itself is the S3 endpoint; no MinIO container is started.
+```
+
+That command uses the Docker API to run one published gateway container with the
+`s4-local-keys` volume mounted at `/data`, `MASKURA_STORAGE_MODE=local`, and
+durable staged multipart enabled. Use the exact loopback URL and credentials it
+prints with `aws s3`, boto3, or another S3 client.
+
 ## How it is structured
 
 - `scripts/e2e-local.sh` — the orchestrator. Boots the shared environment

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,10 @@ and the result is forwarded to any S3-compatible storage backend.
 
 The quickest way to see it working is the README's
 [60-second Docker demo](https://github.com/231self/maskura#try-it-in-60-seconds):
-run the published image with `AUTH_DISABLED=true`, open the demo dashboard, and
-push a file through the pipeline. This site is the deeper documentation:
+run the published Maskura image with `AUTH_DISABLED=true` and a durable local
+volume, open the demo dashboard, and push a file through Maskura's own
+S3-compatible API. No MinIO service is involved in this path. This site is the
+deeper documentation:
 
 - **[Plugins](plugins.md)** — write, load, and compose your own Wasm filters.
 - **[Avro gate](avro.md)** — the typed Avro OCF processing path.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -33,7 +33,10 @@ contracts in `maskura-mcp-protocol` (re-exported as `s4_gateway::mcp`) and trust
 
 ## Run locally
 
-Start the published gateway image and copy the loopback URL printed by the CLI:
+Start the published Maskura gateway image through the CLI and copy the loopback
+URL it prints. The CLI calls the local Docker API directly; this starts one
+Maskura container with its own durable FileStore and S3-compatible API, not a
+MinIO sidecar:
 
 ```bash
 maskura local init

--- a/docs/plans/2026-09-08-local-filesystem-multipart-phase-2.md
+++ b/docs/plans/2026-09-08-local-filesystem-multipart-phase-2.md
@@ -27,9 +27,10 @@ distributed multi-node mode.
   `MultipartRepository` owns client uploads, parts, quota, completion fencing,
   replay, expiry, and cleanup. `OperationJournal` owns destination transaction
   recovery.
-- `MASKURA_MULTIPART_MODE=staged` currently requires Postgres, durable key
-  wrapping, and a separate S3-compatible artifact store. A
-  `FileOperationJournal` does not remove those dependencies by itself.
+- Hosted `MASKURA_MULTIPART_MODE=staged` requires Postgres, durable key wrapping,
+  and a separate S3-compatible artifact store. Standalone local staged mode uses
+  the FileStore-root file repository, `FileOperationJournal`, encrypted local
+  artifacts, and its persisted wrapping key instead.
 - The current multipart handlers and transformation-at-completion pipeline are
   already backend-neutral. Completion can construct `FileSinkTransaction`, but
   local startup cannot construct durable multipart staging.

--- a/docs/plans/2026-09-08-local-filesystem-storage-minio-replacement.md
+++ b/docs/plans/2026-09-08-local-filesystem-storage-minio-replacement.md
@@ -3,7 +3,7 @@
 Status: implemented (Phase 1 and Phase 2)
 Scope: self-hosted OSS gateway, durable local object storage, S3 data plane
 Repositories: public `231self/maskura` (gateway)
-Synced against: `main` @ `6407b629` (PR #113) and `s4-private` @ `9992d6cd` (PR #93)
+Synced against: public `main` after PR #116 and `s4-private` @ `9992d6cd` (PR #93)
 
 ## Objective
 

--- a/docs/plans/2026-09-08-local-filesystem-storage-minio-replacement.md
+++ b/docs/plans/2026-09-08-local-filesystem-storage-minio-replacement.md
@@ -21,6 +21,22 @@ redaction, envelope encryption â€” now hybrid X25519 + ML-KEM-768 per PR #108 â€
 per-field stable encryption) sits on the data path, so the S3 endpoint both
 stores objects *and* scrubs/encrypts them.
 
+## TODO: advanced MinIO parity
+
+The standalone Docker path is complete for the basic S3 object, bucket, listing,
+and multipart operations documented below. Full MinIO feature parity remains a
+separate follow-up and must not be implied by the local replacement quickstart.
+Track implementation and conformance coverage for:
+
+- object versioning and delete markers;
+- ACLs, bucket policies, and IAM-equivalent authorization;
+- SSE-S3/SSE-KMS and customer-managed encryption headers;
+- lifecycle rules, retention, WORM, and object locking;
+- event notifications, replication, and remaining advanced copy/tagging APIs.
+
+Each item needs an explicit compatibility test against a pinned MinIO release
+before it is advertised as supported.
+
 ## Historical findings before implementation
 
 - The release image (`Dockerfile.release`) contains only the gateway binary and

--- a/docs/security.md
+++ b/docs/security.md
@@ -350,7 +350,9 @@ backend requirements described below.
 Streaming writes (single-part `PUT`, and staged multipart when
 `MASKURA_MULTIPART_MODE=staged`) run through a durable transaction layer:
 
-- **Operation journal.** A Postgres-backed `OperationJournal`
+- **Operation journal.** Hosted deployments use the Postgres-backed
+  `OperationJournal`; standalone local deployments use the file-backed journal
+  under the FileStore root.
   (`DATABASE_URL`) records each operation's state machine:
   `INTENT → OPEN → COMPLETING → COMMITTED`, with `COMMIT_UNKNOWN` and
   `PROVEN_ABORTED` for crash recovery. Streaming writes in a non-development

--- a/examples/maskura-demo.sh
+++ b/examples/maskura-demo.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 EP="http://127.0.0.1:8791"
 IMG="ghcr.io/231self/maskura/maskura:latest"
 NAME="maskura-demo"
+VOLUME="maskura-demo-data"
 F="/tmp/customers.jsonl"
 export AWS_ACCESS_KEY_ID=demo AWS_SECRET_ACCESS_KEY=demo AWS_EC2_METADATA_DISABLED=true
 
@@ -28,9 +29,14 @@ pipeline() {
 comment "pull the gateway image"
 cmd docker pull "$IMG"
 
-comment "run it — auth off, streaming read on, in-memory store"
+comment "run the Maskura container — local S3 API, durable FileStore"
 cmd docker run --rm -d --name "$NAME" -p 127.0.0.1:8791:8080 \
+  -v "$VOLUME:/data" \
   -e AUTH_DISABLED=true \
+  -e MASKURA_KEYS_FILE=/data/keys.json \
+  -e MASKURA_STORAGE_MODE=local \
+  -e MASKURA_LOCAL_STORAGE_DIR=/data \
+  -e MASKURA_MULTIPART_MODE=staged \
   -e MASKURA_STREAMING_READ_MODE=passthrough "$IMG"
 
 for _ in $(seq 1 30); do curl -s -m 2 "$EP/health" >/dev/null 2>&1 && break; sleep 1; done
@@ -70,3 +76,5 @@ comment "read it back — email and ssn are ciphertext; same value = same cipher
 cmd aws s3 --endpoint-url "$EP" cp s3://s4-local/join/customers.jsonl -
 
 docker rm -f "$NAME" >/dev/null 2>&1 || true
+comment "the Docker volume keeps local objects and multipart state durable"
+show "docker volume inspect $VOLUME"


### PR DESCRIPTION
## Summary

- Document that `maskura local init` uses the Docker API to run one Maskura gateway container.
- Clarify that Maskura itself is the local S3 endpoint and MinIO is not required for this path.
- Update direct Docker, README, MCP, E2E, and demo-script usage to show durable FileStore volumes and staged multipart.
- Keep `just e2e` and `just dev-up` explicitly documented as the external MinIO validation path.

## Validation

- `mdbook build docs`
- `bash -n examples/maskura-demo.sh examples/local-quickstart.sh scripts/e2e-local.sh`
- Rebased onto merged `main` after PR #116.
