### PR TITLE
feat(clients): add hybrid encryption support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,11 @@ jobs:
         run: |
           bash scripts/generate-sdks.sh
           python3 -m compileall -q sdks/python/maskura_client sdks/python/s4_client
-          cd sdks/typescript && npm install --ignore-scripts --no-package-lock && npm run build && node --test test/highlevel-attach.test.cjs
+          python3 -m pip install -r sdks/python/requirements.txt pytest
+          PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=sdks/python python3 -m pytest -q \
+            sdks/python/test/test_highlevel_attach.py \
+            sdks/python/test/test_highlevel_crypto.py
+          cd sdks/typescript && npm install --ignore-scripts --no-package-lock && npm run build && node --test test/*.test.cjs
           cd ../..
           changes="$(git status --porcelain --untracked-files=all -- sdks/)"
           if [ -n "$changes" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,8 +156,8 @@ Document every infrastructure, auth, storage, and deployment choice so automatio
 - `just build-sdks` extracts spec, runs `openapi-generator` (Docker) to produce Python and TypeScript SDKs in `sdks/python/` and `sdks/typescript/`.
 - Schema is the single source of truth — SDKs always in sync with server changes.
 - `scripts/generate-sdks.sh` re-applies the hand-written high-level client from `sdks/overlay/<lang>/` after each generation, so it survives regeneration:
-  - `s4_client/highlevel.py` / `highlevel.ts` — `MaskuraClient` with `S4Client` compatibility and `put_object`/`get_object` S3 data-plane helpers.
-  - The high-level `generate_keypair` / `generateKeypair` and decrypt helpers are legacy RSA compatibility code. Current gateways reject those RSA public keys for new writes; packaged hybrid client support is a known gap documented in `docs/encryption.md`.
+  - `s4_client/highlevel.py` / `highlevel.ts` — `MaskuraClient` with `S4Client` compatibility, `put_object`/`get_object` S3 data-plane helpers, hybrid X25519 + ML-KEM-768 key generation, public-key attachment, and client-side hybrid decryption.
+  - The decrypt helpers retain dual-algorithm reads for historical RSA envelopes. New key generation is hybrid by default; explicit legacy RSA generation helpers exist only for pre-hybrid compatibility.
 
 ### Web Dashboard
 
@@ -207,8 +207,8 @@ Document every infrastructure, auth, storage, and deployment choice so automatio
   encryption. The `enc_dek` field carries an X25519 ephemeral public key plus
   the ML-KEM-768 ciphertext.
 - Existing `RSA-OAEP/AES-256-GCM` objects remain a legacy read compatibility
-  case. The public high-level SDK helpers currently cover that legacy format,
-  not new hybrid provisioning.
+  case. The public high-level SDK helpers decrypt both algorithms and generate
+  only hybrid keys by default.
 - `filters/stable-encrypt/` is a separate, opt-in AES-SIV transform for stable
   matching keys.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4613,14 +4613,21 @@ dependencies = [
 name = "s4ctl"
 version = "0.5.3"
 dependencies = [
+ "aes-gcm",
  "anyhow",
+ "base64 0.22.1",
  "clap",
  "dirs",
+ "hkdf",
  "maskura-customer-config",
+ "ml-kem",
+ "rand 0.8.7",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tokio",
+ "x25519-dalek",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ maskura put ./data.csv ingest/data.csv --bucket s4-local
 
 # Read it back
 maskura get ingest/data.csv --bucket s4-local
+
+# For recoverable PII, create a hybrid key with the API key and keep the
+# private key locally. New encrypted objects can then be decrypted on read.
+maskura key create --label recoverable --generate-encryption-key \
+  --private-key-out ./maskura-private-key.pem
+maskura get ingest/data.csv --bucket s4-local \
+  --decrypt ./maskura-private-key.pem
 ```
 
 `maskura local init` pulls the gateway image tagged with the CLI version
@@ -277,6 +284,12 @@ export B2_SECRET_ACCESS_KEY=your-application-key
 bash examples/b2-encrypt-demo.sh
 ```
 
+New writes use hybrid X25519 + ML-KEM-768 key encapsulation with AES-256-GCM.
+The CLI and the Python and TypeScript high-level clients generate compatible
+hybrid keypairs, attach only the public key, and decrypt locally with the
+client-held private key. Legacy RSA envelopes remain readable through explicit
+SDK compatibility helpers. See [Encryption](docs/encryption.md#client-tooling-status).
+
 **Plugins — bring your own transform**
 
 ```bash
@@ -291,7 +304,7 @@ maskura plugin reorder pii-default my-filter     # output of one feeds the next
 ```python
 from maskura_client import MaskuraClient
 client = MaskuraClient("http://localhost:8080", "s4_access_key", "s4s_secret_key")
-priv, pub = client.generate_keypair()                  # RSA-2048
+priv, pub = client.generate_keypair()                  # X25519 + ML-KEM-768
 client.attach_public_key(pub)                          # bind to your API key
 client.put_object("bucket", "key", b"jane@example.com 4111111111111111")
 blob = client.get_object("bucket", "key")

--- a/crates/s4ctl/Cargo.toml
+++ b/crates/s4ctl/Cargo.toml
@@ -21,3 +21,10 @@ tokio.workspace = true
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
 dirs = "6"
+aes-gcm.workspace = true
+base64 = "0.22"
+hkdf.workspace = true
+ml-kem.workspace = true
+rand.workspace = true
+sha2 = "0.10"
+x25519-dalek.workspace = true

--- a/crates/s4ctl/src/hybrid.rs
+++ b/crates/s4ctl/src/hybrid.rs
@@ -1,0 +1,236 @@
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use hkdf::Hkdf;
+use ml_kem::{Decapsulate, DecapsulationKey768, KeyExport, Seed};
+use rand::RngCore;
+use sha2::Sha256;
+use x25519_dalek::{X25519_BASEPOINT_BYTES, x25519};
+
+const ENVELOPE_ALG: &str = "X25519+ML-KEM-768/AES-256-GCM";
+const KDF_INFO: &[u8] = b"maskura/hybrid/envelope-dek/v1";
+const PUBLIC_LABEL: &str = "MASKURA HYBRID PUBLIC KEY";
+const PRIVATE_LABEL: &str = "MASKURA HYBRID PRIVATE KEY";
+const X25519_KEY_LEN: usize = 32;
+const MLKEM_EK_LEN: usize = 1184;
+const MLKEM_CT_LEN: usize = 1088;
+const MLKEM_SEED_LEN: usize = 64;
+const PRIVATE_KEY_LEN: usize = X25519_KEY_LEN + MLKEM_SEED_LEN;
+const PUBLIC_KEY_LEN: usize = X25519_KEY_LEN + MLKEM_EK_LEN;
+const ENC_DEK_LEN: usize = X25519_KEY_LEN + MLKEM_CT_LEN;
+
+#[derive(serde::Deserialize)]
+struct Envelope {
+    alg: String,
+    iv: String,
+    enc_dek: String,
+    ct: String,
+    tag: String,
+}
+
+pub fn generate_keypair() -> (String, String) {
+    let mut x25519_secret = [0u8; X25519_KEY_LEN];
+    let mut mlkem_seed = [0u8; MLKEM_SEED_LEN];
+    rand::rngs::OsRng.fill_bytes(&mut x25519_secret);
+    rand::rngs::OsRng.fill_bytes(&mut mlkem_seed);
+
+    let x25519_public = x25519(x25519_secret, X25519_BASEPOINT_BYTES);
+    let mlkem_private = DecapsulationKey768::from_seed(
+        Seed::try_from(&mlkem_seed[..]).expect("fixed-size ML-KEM seed"),
+    );
+    let mut public_raw = Vec::with_capacity(PUBLIC_KEY_LEN);
+    public_raw.extend_from_slice(&x25519_public);
+    public_raw.extend_from_slice(mlkem_private.encapsulation_key().to_bytes().as_slice());
+    let mut private_raw = Vec::with_capacity(PRIVATE_KEY_LEN);
+    private_raw.extend_from_slice(&x25519_secret);
+    private_raw.extend_from_slice(&mlkem_seed);
+    (
+        encode_pem(PRIVATE_LABEL, &private_raw),
+        encode_pem(PUBLIC_LABEL, &public_raw),
+    )
+}
+
+pub fn decrypt_payload(payload: &[u8], private_key_pem: &str) -> anyhow::Result<Vec<u8>> {
+    let private_raw = decode_pem(private_key_pem, PRIVATE_LABEL)?;
+    anyhow::ensure!(
+        private_raw.len() == PRIVATE_KEY_LEN,
+        "hybrid private key must contain {PRIVATE_KEY_LEN} bytes, got {}",
+        private_raw.len()
+    );
+    let mut x25519_secret = [0u8; X25519_KEY_LEN];
+    x25519_secret.copy_from_slice(&private_raw[..X25519_KEY_LEN]);
+    let mlkem_private = DecapsulationKey768::from_seed(
+        Seed::try_from(&private_raw[X25519_KEY_LEN..])
+            .map_err(|error| anyhow::anyhow!("invalid ML-KEM seed: {error}"))?,
+    );
+
+    let marker = format!("\"alg\":\"{ENVELOPE_ALG}\"").into_bytes();
+    let mut output = Vec::with_capacity(payload.len());
+    let mut position = 0;
+    while let Some(relative) = find_bytes(&payload[position..], &marker) {
+        let marker_start = position + relative;
+        let Some(start) = payload[..marker_start]
+            .iter()
+            .rposition(|byte| *byte == b'{')
+        else {
+            output.extend_from_slice(&payload[position..marker_start + marker.len()]);
+            position = marker_start + marker.len();
+            continue;
+        };
+        let Some(end) = matching_brace_end(payload, start) else {
+            break;
+        };
+        let envelope: Envelope = serde_json::from_slice(&payload[start..end])?;
+        output.extend_from_slice(&payload[position..start]);
+        output.extend_from_slice(&decrypt_envelope(&envelope, x25519_secret, &mlkem_private)?);
+        position = end;
+    }
+    output.extend_from_slice(&payload[position..]);
+    Ok(output)
+}
+
+fn decrypt_envelope(
+    envelope: &Envelope,
+    x25519_secret: [u8; X25519_KEY_LEN],
+    mlkem_private: &DecapsulationKey768,
+) -> anyhow::Result<Vec<u8>> {
+    anyhow::ensure!(
+        envelope.alg == ENVELOPE_ALG,
+        "unsupported envelope algorithm: {}",
+        envelope.alg
+    );
+    let encapsulated = BASE64.decode(&envelope.enc_dek)?;
+    anyhow::ensure!(
+        encapsulated.len() == ENC_DEK_LEN,
+        "hybrid enc_dek must contain {ENC_DEK_LEN} bytes, got {}",
+        encapsulated.len()
+    );
+    let mut ephemeral_public = [0u8; X25519_KEY_LEN];
+    ephemeral_public.copy_from_slice(&encapsulated[..X25519_KEY_LEN]);
+    let x25519_shared = x25519(x25519_secret, ephemeral_public);
+    let mlkem_shared = mlkem_private
+        .decapsulate_slice(&encapsulated[X25519_KEY_LEN..])
+        .map_err(|error| anyhow::anyhow!("ML-KEM-768 decapsulation failed: {error}"))?;
+    let dek = derive_dek(&x25519_shared, mlkem_shared.as_slice())?;
+    let iv = BASE64.decode(&envelope.iv)?;
+    anyhow::ensure!(iv.len() == 12, "AES-GCM IV must contain 12 bytes");
+    let mut ciphertext = BASE64.decode(&envelope.ct)?;
+    ciphertext.extend_from_slice(&BASE64.decode(&envelope.tag)?);
+    Aes256Gcm::new_from_slice(&dek)
+        .map_err(|error| anyhow::anyhow!("AES key initialization failed: {error}"))?
+        .decrypt(Nonce::from_slice(&iv), ciphertext.as_ref())
+        .map_err(|_| anyhow::anyhow!("AES-GCM authentication failed"))
+}
+
+fn derive_dek(x25519_shared: &[u8; 32], mlkem_shared: &[u8]) -> anyhow::Result<[u8; 32]> {
+    let mut ikm = [0u8; 64];
+    ikm[..32].copy_from_slice(x25519_shared);
+    ikm[32..].copy_from_slice(mlkem_shared);
+    let mut dek = [0u8; 32];
+    Hkdf::<Sha256>::new(None, &ikm)
+        .expand(KDF_INFO, &mut dek)
+        .map_err(|error| anyhow::anyhow!("HKDF-SHA256 expand failed: {error}"))?;
+    Ok(dek)
+}
+
+fn matching_brace_end(payload: &[u8], start: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    for (offset, byte) in payload.iter().enumerate().skip(start) {
+        match *byte {
+            b'{' => depth += 1,
+            b'}' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(offset + 1);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn decode_pem(pem: &str, label: &str) -> anyhow::Result<Vec<u8>> {
+    let begin = format!("-----BEGIN {label}-----");
+    let end = format!("-----END {label}-----");
+    let body = pem
+        .trim()
+        .strip_prefix(&begin)
+        .and_then(|rest| rest.strip_suffix(&end))
+        .ok_or_else(|| anyhow::anyhow!("expected a {label} PEM block"))?;
+    BASE64
+        .decode(
+            body.chars()
+                .filter(|value| !value.is_whitespace())
+                .collect::<String>(),
+        )
+        .map_err(Into::into)
+}
+
+fn encode_pem(label: &str, raw: &[u8]) -> String {
+    let base64 = BASE64.encode(raw);
+    let body = base64
+        .as_bytes()
+        .chunks(64)
+        .map(|chunk| std::str::from_utf8(chunk).expect("base64 is ASCII"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("-----BEGIN {label}-----\n{body}\n-----END {label}-----\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aes_gcm::aead::Aead;
+    use ml_kem::{B32, EncapsulationKey768, TryKeyInit};
+
+    #[test]
+    fn generated_keys_round_trip_a_gateway_compatible_envelope() {
+        let (private_pem, public_pem) = generate_keypair();
+        let public_raw = decode_pem(&public_pem, PUBLIC_LABEL).unwrap();
+        assert_eq!(decode_pem(&private_pem, PRIVATE_LABEL).unwrap().len(), 96);
+        assert_eq!(public_raw.len(), 1216);
+
+        let mut recipient_x25519 = [0u8; 32];
+        recipient_x25519.copy_from_slice(&public_raw[..32]);
+        let mlkem_public = EncapsulationKey768::new_from_slice(&public_raw[32..]).unwrap();
+        let ephemeral_secret = [0x33; 32];
+        let ephemeral_public = x25519(ephemeral_secret, X25519_BASEPOINT_BYTES);
+        let x25519_shared = x25519(ephemeral_secret, recipient_x25519);
+        let coins = B32::try_from(&[0x44; 32][..]).unwrap();
+        let (mlkem_ciphertext, mlkem_shared) = mlkem_public.encapsulate_deterministic(&coins);
+        let dek = derive_dek(&x25519_shared, mlkem_shared.as_slice()).unwrap();
+        let iv = [0x55; 12];
+        let sealed = Aes256Gcm::new_from_slice(&dek)
+            .unwrap()
+            .encrypt(Nonce::from_slice(&iv), b"alice@example.com".as_ref())
+            .unwrap();
+        let mut enc_dek = ephemeral_public.to_vec();
+        enc_dek.extend_from_slice(mlkem_ciphertext.as_slice());
+        let envelope = serde_json::json!({
+            "alg": ENVELOPE_ALG,
+            "iv": BASE64.encode(iv),
+            "enc_dek": BASE64.encode(enc_dek),
+            "ct": BASE64.encode(&sealed[..sealed.len() - 16]),
+            "tag": BASE64.encode(&sealed[sealed.len() - 16..]),
+        });
+        let payload = format!("before {envelope} after");
+        assert_eq!(
+            decrypt_payload(payload.as_bytes(), &private_pem).unwrap(),
+            b"before alice@example.com after"
+        );
+    }
+
+    #[test]
+    fn payload_without_envelopes_is_unchanged() {
+        let (private_pem, _) = generate_keypair();
+        assert_eq!(decrypt_payload(b"plain", &private_pem).unwrap(), b"plain");
+    }
+}

--- a/crates/s4ctl/src/main.rs
+++ b/crates/s4ctl/src/main.rs
@@ -8,6 +8,8 @@ use std::fmt;
 use std::net::IpAddr;
 use std::path::PathBuf;
 
+mod hybrid;
+
 const DEFAULT_GATEWAY: &str = "http://localhost:9000";
 const HOSTED_WORKSPACE_ID_ENV: EnvAlias = EnvAlias::new("MASKURA_WORKSPACE_ID");
 const HOSTED_ACCESS_TOKEN_ENV: EnvAlias = EnvAlias::new("MASKURA_ACCESS_TOKEN");
@@ -153,6 +155,9 @@ enum Command {
         /// Bucket name
         #[arg(short, long)]
         bucket: Option<String>,
+        /// Decrypt hybrid envelopes with this client-held private-key PEM
+        #[arg(long, value_name = "PRIVATE_KEY_PEM")]
+        decrypt: Option<PathBuf>,
     },
 
     /// List objects in the store
@@ -183,6 +188,12 @@ enum KeyCmd {
         /// Expiry: never, 30d, 90d, 1y
         #[arg(short, long, default_value = "never")]
         expiry: String,
+        /// Generate and attach a hybrid encryption key to the new API key
+        #[arg(long)]
+        generate_encryption_key: bool,
+        /// Private-key destination (defaults to maskura-private-key.pem)
+        #[arg(long, value_name = "PATH", requires = "generate_encryption_key")]
+        private_key_out: Option<PathBuf>,
     },
 
     /// List all API keys
@@ -1135,6 +1146,23 @@ fn project_root() -> anyhow::Result<PathBuf> {
     }
 }
 
+fn write_private_key(path: &std::path::Path, pem: &str) -> anyhow::Result<()> {
+    use std::io::Write;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("Cannot create private key at {}", path.display()))?;
+    file.write_all(pem.as_bytes())
+        .with_context(|| format!("Cannot write private key at {}", path.display()))
+}
+
 fn parse_expiry(expiry: &str) -> u64 {
     match expiry {
         "never" | "0" => 0,
@@ -1224,10 +1252,26 @@ async fn main() -> anyhow::Result<()> {
         Command::Key { cmd } => {
             let client = Client::new(&cli, &config)?;
             match cmd {
-                KeyCmd::Create { label, expiry } => {
+                KeyCmd::Create {
+                    label,
+                    expiry,
+                    generate_encryption_key,
+                    private_key_out,
+                } => {
+                    let encryption = if *generate_encryption_key {
+                        let path = private_key_out
+                            .clone()
+                            .unwrap_or_else(|| PathBuf::from("maskura-private-key.pem"));
+                        let (private_key_pem, public_key_pem) = hybrid::generate_keypair();
+                        write_private_key(&path, &private_key_pem)?;
+                        Some((path, public_key_pem))
+                    } else {
+                        None
+                    };
                     let body = serde_json::json!({
                         "label": label.as_deref().unwrap_or("cli"),
-                        "expires_in": parse_expiry(expiry)
+                        "expires_in": parse_expiry(expiry),
+                        "public_key_pem": encryption.as_ref().map(|(_, public_key)| public_key),
                     });
                     let resp: serde_json::Value =
                         client.api_post("/dashboard/api/keys", &body).await?;
@@ -1236,6 +1280,12 @@ async fn main() -> anyhow::Result<()> {
                     println!("Label:      {}", resp["label"].as_str().unwrap_or("?"));
                     if let Some(exp) = resp["expires_at"].as_str() {
                         println!("Expires at: {}", exp);
+                    }
+                    if let Some((path, _)) = &encryption {
+                        println!("Private key: {}", path.display());
+                        println!(
+                            "The public key is attached; the private key never left this machine."
+                        );
                     }
                     println!("\nSave this secret — it won't be shown again.");
                 }
@@ -1838,10 +1888,20 @@ async fn main() -> anyhow::Result<()> {
             );
         }
 
-        Command::Get { key, bucket } => {
+        Command::Get {
+            key,
+            bucket,
+            decrypt,
+        } => {
             let client = Client::new(&cli, &config)?;
             let bucket = client.bucket(&cli, bucket.as_deref());
-            let data = client.s3_get(&bucket, key).await?;
+            let mut data = client.s3_get(&bucket, key).await?;
+            if let Some(path) = decrypt {
+                let private_key_pem = std::fs::read_to_string(path)
+                    .with_context(|| format!("Cannot read private key at {}", path.display()))?;
+                data = hybrid::decrypt_payload(&data, &private_key_pem)
+                    .context("Cannot decrypt object payload")?;
+            }
             std::io::Write::write_all(&mut std::io::stdout(), &data)?;
         }
 
@@ -2312,6 +2372,63 @@ mod tests {
         );
         assert_eq!(Program::Maskura.name(), "maskura");
         assert_eq!(Program::S4ctl.name(), "s4ctl");
+    }
+
+    #[test]
+    fn cli_parses_hybrid_key_creation_and_decryption_paths() {
+        let create = Cli::try_parse_from([
+            "maskura",
+            "key",
+            "create",
+            "--generate-encryption-key",
+            "--private-key-out",
+            "private.pem",
+        ])
+        .unwrap();
+        assert!(matches!(
+            create.command,
+            Command::Key {
+                cmd: KeyCmd::Create {
+                    generate_encryption_key: true,
+                    private_key_out: Some(path),
+                    ..
+                }
+            } if path == std::path::Path::new("private.pem")
+        ));
+
+        let get =
+            Cli::try_parse_from(["maskura", "get", "object.jsonl", "--decrypt", "private.pem"])
+                .unwrap();
+        assert!(matches!(
+            get.command,
+            Command::Get {
+                decrypt: Some(path),
+                ..
+            } if path == std::path::Path::new("private.pem")
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_key_files_are_create_new_and_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = std::env::temp_dir().join(format!(
+            "maskura-private-key-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        write_private_key(&path, "private").unwrap();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert!(write_private_key(&path, "replacement").is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "private");
+        std::fs::remove_file(path).unwrap();
     }
 
     #[test]

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -113,16 +113,25 @@ The private key never touches the gateway.
 ## Client tooling status
 
 Current gateway releases accept only `MASKURA HYBRID PUBLIC KEY` PEM blocks for
-new encrypted writes. The Python and TypeScript high-level SDK overlays still
-generate RSA-2048 keys and decrypt the legacy `RSA-OAEP/AES-256-GCM` envelope.
-They remain in the release for reading older data, but their key-generation and
-attach flow is not compatible with a current gateway. Do not use
-`generate_keypair` or `generateKeypair` to provision a new encryption key.
+new encrypted writes. `MaskuraClient.generate_keypair()` in Python and
+`MaskuraClient.generateKeypair()` in TypeScript now create that exact hybrid
+format. Their decrypt helpers decapsulate current hybrid envelopes locally and
+also retain dual-algorithm read compatibility for old RSA envelopes. Explicit
+`generate_legacy_rsa_keypair()` and `generateLegacyRsaKeypair()` helpers exist
+only for pre-hybrid gateways and compatibility fixtures.
 
-The Rust implementation and round-trip tests are the current reference for the
-hybrid key format and decapsulation behavior. Packaged cross-language hybrid
-key generation and decryption are a known gap. Redaction and ordinary S3 object
-operations in the SDKs are unaffected.
+The CLI provides the same safe path: `maskura key create
+--generate-encryption-key --private-key-out <path>` attaches the public key to
+the newly created API key and writes the private key locally with create-new
+semantics (mode `0600` on Unix). `maskura get ... --decrypt <path>` decrypts
+hybrid envelopes before writing the object to stdout. The private key is never
+sent to Maskura.
+
+Python hybrid support requires `cryptography >= 47`. TypeScript uses the Noble
+X25519, HKDF-SHA256, and ML-KEM implementations while retaining CommonJS output.
+SDK and CLI tests exercise the gateway wire sizes and round-trip behavior. The
+Python and TypeScript implementations have also been verified against the
+deterministic envelope produced by the Rust gateway reference implementation.
 
 ## Security properties
 

--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -130,7 +130,7 @@ pyproject = pyproject.replace(
 )
 pyproject = pyproject.replace(
     '  "typing-extensions (>=4.7.1)"',
-    '  "typing-extensions (>=4.7.1)",\n  "requests (>=2.31)",\n  "cryptography (>=42)"',
+    '  "typing-extensions (>=4.7.1)",\n  "requests (>=2.31)",\n  "cryptography (>=47)"',
 )
 root.joinpath("pyproject.toml").write_text(pyproject)
 
@@ -148,7 +148,7 @@ setup = setup.replace('NAME = "maskura-client"', 'NAME = "maskura_client"', 1)
 setup = setup.replace('    url="",', '    url="https://github.com/231self/maskura",')
 setup = setup.replace(
     '    "typing-extensions >= 4.7.1",',
-    '    "typing-extensions >= 4.7.1",\n    "requests >= 2.31",\n    "cryptography >= 42",',
+    '    "typing-extensions >= 4.7.1",\n    "requests >= 2.31",\n    "cryptography >= 47",',
 )
 setup = setup.replace(
     'package_data={"s4_client": ["py.typed"]}',
@@ -157,7 +157,7 @@ setup = setup.replace(
 root.joinpath("setup.py").write_text(setup)
 
 requirements = root.joinpath("requirements.txt")
-requirements.write_text(requirements.read_text() + "requests >= 2.31\ncryptography >= 42\n")
+requirements.write_text(requirements.read_text() + "requests >= 2.31\ncryptography >= 47\n")
 
 git_push = root.joinpath("git_push.sh").read_text()
 git_push = git_push.replace('git_user_id="GIT_USER_ID"', 'git_user_id="231self"')

--- a/sdks/overlay/python/README.md
+++ b/sdks/overlay/python/README.md
@@ -35,12 +35,21 @@ client = MaskuraClient(
 )
 ```
 
-Object PUT/GET helpers work with current gateways. The high-level
-`generate_keypair` and `decrypt_payload` helpers implement the legacy RSA
-envelope for compatibility with older stored objects. Current gateways accept
-only Maskura hybrid X25519 + ML-KEM-768 public keys for new encrypted writes;
-see the [client tooling status](../../docs/encryption.md#client-tooling-status)
-before using envelope encryption.
+The high-level client supports the current hybrid encryption flow:
+
+```python
+private_pem, public_pem = MaskuraClient.generate_keypair()
+client.attach_public_key(public_pem)
+client.put_object("bucket", "data.jsonl", b'{"email":"jane@example.com"}')
+stored = client.get_object("bucket", "data.jsonl")
+plaintext = MaskuraClient.decrypt_payload(stored, private_pem)
+```
+
+Store `private_pem` securely; only the public key is uploaded. Hybrid support
+requires `cryptography >= 47`. `decrypt_payload` also reads legacy RSA
+envelopes, and `generate_legacy_rsa_keypair` remains available only for
+pre-hybrid gateways and compatibility fixtures. See the
+[encryption reference](../../docs/encryption.md#client-tooling-status).
 
 ## Tests
 

--- a/sdks/overlay/python/s4_client/highlevel.py
+++ b/sdks/overlay/python/s4_client/highlevel.py
@@ -1,24 +1,8 @@
-"""High-level Maskura client: object I/O plus legacy envelope compatibility.
+"""High-level Maskura client: object I/O and envelope encryption helpers.
 
-The generated low-level client covers the dashboard API (keys, plugins,
-backends). This module adds the S3 data-plane operations the gateway exposes
-plus the client side of the envelope-encryption scheme:
-
-* ``put_object`` / ``get_object`` — raw byte objects through the gateway,
-  authenticated with the Maskura API key headers (``x-maskura-access-key`` /
-  ``x-maskura-secret-key``).
-* ``generate_keypair`` / ``attach_public_key`` — legacy RSA provisioning for
-  pre-hybrid gateways. Current gateways reject these RSA public keys.
-* ``decrypt_payload`` — recover plaintext from legacy stored payloads: scans for
-  ``RSA-OAEP/AES-256-GCM`` envelopes, unwraps each DEK with the client-held
-  private key, and AES-256-GCM-decrypts the field back to plaintext.
-
-Legacy read path (client-side decryption):
-    raw = client.get_object("my-bucket", "ingest/data.jsonl")
-    plaintext = MaskuraClient.decrypt_payload(raw, private_pem)
-
-Extra dependencies beyond the generated client: ``requests`` and
-``cryptography``.
+The generated low-level client covers the dashboard API. This module adds the
+S3 data-plane operations plus client-held hybrid key generation and decryption.
+New keys use X25519 + ML-KEM-768; legacy RSA envelopes remain readable.
 """
 
 from __future__ import annotations
@@ -29,16 +13,40 @@ from typing import Tuple
 
 import requests
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.asymmetric import padding, rsa, x25519
+from cryptography.hazmat.primitives.asymmetric.mlkem import MLKEM768PrivateKey
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
-_ENVELOPE_ALG = "RSA-OAEP/AES-256-GCM"
-_MARKER = b'"alg":"' + _ENVELOPE_ALG.encode() + b'"'
+_HYBRID_ALG = "X25519+ML-KEM-768/AES-256-GCM"
+_LEGACY_RSA_ALG = "RSA-OAEP/AES-256-GCM"
+_HYBRID_PUBLIC_LABEL = "MASKURA HYBRID PUBLIC KEY"
+_HYBRID_PRIVATE_LABEL = "MASKURA HYBRID PRIVATE KEY"
+_KDF_INFO = b"maskura/hybrid/envelope-dek/v1"
+_X25519_KEY_LEN = 32
+_MLKEM_CIPHERTEXT_LEN = 1088
+_MLKEM_SEED_LEN = 64
 _OAEP = padding.OAEP(
     mgf=padding.MGF1(algorithm=hashes.SHA256()),
     algorithm=hashes.SHA256(),
     label=None,
 )
+
+
+def _encode_pem(label: str, raw: bytes) -> str:
+    body = base64.b64encode(raw).decode()
+    lines = "\n".join(body[offset : offset + 64] for offset in range(0, len(body), 64))
+    return f"-----BEGIN {label}-----\n{lines}\n-----END {label}-----\n"
+
+
+def _decode_pem(label: str, pem: str) -> bytes:
+    begin = f"-----BEGIN {label}-----"
+    end = f"-----END {label}-----"
+    value = pem.strip()
+    if not value.startswith(begin) or not value.endswith(end):
+        raise ValueError(f"expected a {label} PEM block")
+    body = "".join(value[len(begin) : -len(end)].split())
+    return base64.b64decode(body, validate=True)
 
 
 class MaskuraClient:
@@ -56,19 +64,28 @@ class MaskuraClient:
             "x-maskura-secret-key": self.secret_key,
         }
 
-    # -- keys ---------------------------------------------------------
-
     @staticmethod
     def generate_keypair() -> Tuple[str, str]:
-        """Generate a legacy RSA-2048 envelope keypair.
+        """Generate a gateway-compatible hybrid keypair.
 
-        Current gateways accept only Maskura hybrid public keys for new writes;
-        this helper exists to support pre-hybrid gateways and stored objects.
-
-        Returns ``(private_key_pem, public_key_pem)`` — PKCS#8 private key
-        and SPKI public key, both PEM. Store the private key somewhere safe;
-        it is the only way to decrypt what Maskura stores.
+        Returns ``(private_key_pem, public_key_pem)``. The private PEM contains
+        only the X25519 secret and the ML-KEM seed and must never be uploaded.
         """
+        x25519_private = x25519.X25519PrivateKey.generate()
+        mlkem_private = MLKEM768PrivateKey.generate()
+        private_raw = x25519_private.private_bytes_raw() + mlkem_private.private_bytes_raw()
+        public_raw = (
+            x25519_private.public_key().public_bytes_raw()
+            + mlkem_private.public_key().public_bytes_raw()
+        )
+        return (
+            _encode_pem(_HYBRID_PRIVATE_LABEL, private_raw),
+            _encode_pem(_HYBRID_PUBLIC_LABEL, public_raw),
+        )
+
+    @staticmethod
+    def generate_legacy_rsa_keypair() -> Tuple[str, str]:
+        """Generate an RSA keypair for pre-hybrid gateways and old fixtures."""
         private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
         private_pem = private.private_bytes(
             encoding=serialization.Encoding.PEM,
@@ -82,11 +99,7 @@ class MaskuraClient:
         return private_pem, public_pem
 
     def attach_public_key(self, public_key_pem: str) -> None:
-        """Bind a public key to this API key.
-
-        Current gateways reject the legacy RSA keys created by
-        ``generate_keypair``. This method remains for pre-hybrid gateways.
-        """
+        """Bind a Maskura hybrid public key to this API key."""
         resp = requests.put(
             f"{self.endpoint}/dashboard/api/keys/public-key",
             headers=self._headers(),
@@ -95,10 +108,8 @@ class MaskuraClient:
         )
         resp.raise_for_status()
 
-    # -- object data plane -------------------------------------------
-
     def put_object(self, bucket: str, key: str, data: bytes, content_type: str = "text/plain") -> None:
-        """Upload ``data`` to ``bucket/key`` through the Maskura filter pipeline."""
+        """Upload ``data`` to ``bucket/key`` through the Maskura pipeline."""
         resp = requests.put(
             f"{self.endpoint}/{bucket}/{key}",
             headers={**self._headers(), "Content-Type": content_type},
@@ -117,38 +128,40 @@ class MaskuraClient:
         resp.raise_for_status()
         return resp.content
 
-    # -- envelope crypto ----------------------------------------------
-
     @staticmethod
     def decrypt_payload(payload: bytes, private_key_pem: str) -> bytes:
-        """Decrypt every envelope in ``payload`` back to plaintext.
+        """Decrypt current hybrid or legacy RSA envelopes in ``payload``."""
+        if f"-----BEGIN {_HYBRID_PRIVATE_LABEL}-----" in private_key_pem:
+            key = MaskuraClient._load_hybrid_private_key(private_key_pem)
+            supported_alg = _HYBRID_ALG
+        else:
+            key = serialization.load_pem_private_key(private_key_pem.encode(), password=None)
+            if not isinstance(key, rsa.RSAPrivateKey):
+                raise ValueError("expected a Maskura hybrid or RSA private key")
+            supported_alg = _LEGACY_RSA_ALG
 
-        Encrypted fields are replaced in place; anything else (e.g. the
-        non-Luhn numbers the detector ignores) is left untouched.
-        """
-        key = serialization.load_pem_private_key(private_key_pem.encode(), password=None)
+        marker = b'"alg":"' + supported_alg.encode() + b'"'
         out = bytearray()
         pos = 0
         while True:
-            idx = payload.find(_MARKER, pos)
+            idx = payload.find(marker, pos)
             if idx < 0:
                 out += payload[pos:]
                 break
             start = payload.rfind(b"{", 0, idx)
             if start < 0:
-                out += payload[pos : idx + len(_MARKER)]
-                pos = idx + len(_MARKER)
+                out += payload[pos : idx + len(marker)]
+                pos = idx + len(marker)
                 continue
             depth = 0
             end = -1
-            for j in range(start, len(payload)):
-                c = payload[j]
-                if c == 0x7B:
+            for offset in range(start, len(payload)):
+                if payload[offset] == 0x7B:
                     depth += 1
-                elif c == 0x7D:
+                elif payload[offset] == 0x7D:
                     depth -= 1
                     if depth == 0:
-                        end = j + 1
+                        end = offset + 1
                         break
             if end < 0:
                 out += payload[pos:]
@@ -161,12 +174,40 @@ class MaskuraClient:
         return bytes(out)
 
     @staticmethod
+    def _load_hybrid_private_key(private_key_pem: str) -> tuple[x25519.X25519PrivateKey, MLKEM768PrivateKey]:
+        raw = _decode_pem(_HYBRID_PRIVATE_LABEL, private_key_pem)
+        expected = _X25519_KEY_LEN + _MLKEM_SEED_LEN
+        if len(raw) != expected:
+            raise ValueError(f"hybrid private key must contain {expected} bytes, got {len(raw)}")
+        return (
+            x25519.X25519PrivateKey.from_private_bytes(raw[:_X25519_KEY_LEN]),
+            MLKEM768PrivateKey.from_seed_bytes(raw[_X25519_KEY_LEN:]),
+        )
+
+    @staticmethod
     def _decrypt_envelope(env: dict, private_key) -> bytes:
-        assert env["alg"] == _ENVELOPE_ALG, env["alg"]
-        dek = private_key.decrypt(base64.b64decode(env["enc_dek"]), _OAEP)
-        ciphertext = base64.b64decode(env["ct"]) + base64.b64decode(env["tag"])
-        return AESGCM(dek).decrypt(base64.b64decode(env["iv"]), ciphertext, None)
+        algorithm = env.get("alg")
+        enc_dek = base64.b64decode(env["enc_dek"], validate=True)
+        if algorithm == _HYBRID_ALG:
+            x25519_private, mlkem_private = private_key
+            expected = _X25519_KEY_LEN + _MLKEM_CIPHERTEXT_LEN
+            if len(enc_dek) != expected:
+                raise ValueError(f"hybrid enc_dek must contain {expected} bytes, got {len(enc_dek)}")
+            x25519_public = x25519.X25519PublicKey.from_public_bytes(enc_dek[:_X25519_KEY_LEN])
+            shared = x25519_private.exchange(x25519_public) + mlkem_private.decapsulate(
+                enc_dek[_X25519_KEY_LEN:]
+            )
+            dek = HKDF(
+                algorithm=hashes.SHA256(), length=32, salt=None, info=_KDF_INFO
+            ).derive(shared)
+        elif algorithm == _LEGACY_RSA_ALG:
+            dek = private_key.decrypt(enc_dek, _OAEP)
+        else:
+            raise ValueError(f"unsupported envelope algorithm: {algorithm or 'missing'}")
+        ciphertext = base64.b64decode(env["ct"], validate=True) + base64.b64decode(
+            env["tag"], validate=True
+        )
+        return AESGCM(dek).decrypt(base64.b64decode(env["iv"], validate=True), ciphertext, None)
 
 
-# Permanent compatibility export for existing integrations.
 S4Client = MaskuraClient

--- a/sdks/overlay/python/test/test_highlevel_crypto.py
+++ b/sdks/overlay/python/test/test_highlevel_crypto.py
@@ -1,0 +1,77 @@
+import base64
+import json
+import os
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, x25519
+from cryptography.hazmat.primitives.asymmetric.mlkem import MLKEM768PublicKey
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from s4_client.highlevel import MaskuraClient
+
+
+def _pem_bytes(pem, label):
+    return base64.b64decode(
+        pem.replace(f"-----BEGIN {label}-----", "")
+        .replace(f"-----END {label}-----", "")
+        .replace("\n", "")
+    )
+
+
+def test_hybrid_keypair_and_gateway_envelope_roundtrip():
+    private_pem, public_pem = MaskuraClient.generate_keypair()
+    private_raw = _pem_bytes(private_pem, "MASKURA HYBRID PRIVATE KEY")
+    public_raw = _pem_bytes(public_pem, "MASKURA HYBRID PUBLIC KEY")
+    assert len(private_raw) == 96
+    assert len(public_raw) == 1216
+
+    ephemeral = x25519.X25519PrivateKey.generate()
+    x25519_shared = ephemeral.exchange(x25519.X25519PublicKey.from_public_bytes(public_raw[:32]))
+    mlkem_shared, mlkem_ciphertext = MLKEM768PublicKey.from_public_bytes(
+        public_raw[32:]
+    ).encapsulate()
+    dek = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=b"maskura/hybrid/envelope-dek/v1",
+    ).derive(x25519_shared + mlkem_shared)
+    iv = os.urandom(12)
+    sealed = AESGCM(dek).encrypt(iv, b"alice@example.com", None)
+    envelope = {
+        "alg": "X25519+ML-KEM-768/AES-256-GCM",
+        "iv": base64.b64encode(iv).decode(),
+        "enc_dek": base64.b64encode(
+            ephemeral.public_key().public_bytes_raw() + mlkem_ciphertext
+        ).decode(),
+        "ct": base64.b64encode(sealed[:-16]).decode(),
+        "tag": base64.b64encode(sealed[-16:]).decode(),
+    }
+    payload = b"before " + json.dumps(envelope, separators=(",", ":")).encode() + b" after"
+    assert MaskuraClient.decrypt_payload(payload, private_pem) == b"before alice@example.com after"
+
+
+def test_legacy_rsa_envelopes_remain_readable():
+    private_pem, public_pem = MaskuraClient.generate_legacy_rsa_keypair()
+    public_key = serialization.load_pem_public_key(public_pem.encode())
+    dek = os.urandom(32)
+    iv = os.urandom(12)
+    sealed = AESGCM(dek).encrypt(iv, b"legacy@example.com", None)
+    wrapped = public_key.encrypt(
+        dek,
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
+    )
+    envelope = {
+        "alg": "RSA-OAEP/AES-256-GCM",
+        "iv": base64.b64encode(iv).decode(),
+        "enc_dek": base64.b64encode(wrapped).decode(),
+        "ct": base64.b64encode(sealed[:-16]).decode(),
+        "tag": base64.b64encode(sealed[-16:]).decode(),
+    }
+    payload = json.dumps(envelope, separators=(",", ":")).encode()
+    assert MaskuraClient.decrypt_payload(payload, private_pem) == b"legacy@example.com"

--- a/sdks/overlay/typescript/README.md
+++ b/sdks/overlay/typescript/README.md
@@ -48,9 +48,19 @@ const client = new MaskuraClient({
 });
 ```
 
-Object PUT/GET helpers work with current gateways. The high-level
-`generateKeypair` and `decryptPayload` helpers implement the legacy RSA
-envelope for compatibility with older stored objects. Current gateways accept
-only Maskura hybrid X25519 + ML-KEM-768 public keys for new encrypted writes;
-see the [client tooling status](../../docs/encryption.md#client-tooling-status)
-before using envelope encryption.
+The high-level client supports the current hybrid encryption flow:
+
+```typescript
+const { privateKeyPem, publicKeyPem } = await MaskuraClient.generateKeypair();
+await client.attachPublicKey(publicKeyPem);
+await client.putObject("bucket", "data.jsonl", new TextEncoder().encode('{"email":"jane@example.com"}'));
+const stored = await client.getObject("bucket", "data.jsonl");
+const plaintext = await MaskuraClient.decryptPayload(stored, privateKeyPem);
+```
+
+Store `privateKeyPem` securely; only the public key is uploaded. The package
+retains CommonJS output and supports Node 18+ or browsers with Web Crypto.
+`decryptPayload` also reads legacy RSA envelopes, and
+`generateLegacyRsaKeypair` remains available only for pre-hybrid gateways and
+compatibility fixtures. See the
+[encryption reference](../../docs/encryption.md#client-tooling-status).

--- a/sdks/overlay/typescript/highlevel.ts
+++ b/sdks/overlay/typescript/highlevel.ts
@@ -1,26 +1,19 @@
-/**
- * High-level Maskura client: object I/O plus legacy envelope compatibility.
- *
- * The generated low-level client covers the dashboard API (keys, plugins,
- * backends). This module adds the S3 data-plane operations the gateway
- * exposes plus the client side of the envelope-encryption scheme:
- *
- * - `putObject` / `getObject` — raw byte objects through the gateway,
- *   authenticated with the Maskura API key headers.
- * - `generateKeypair` / `attachPublicKey` — legacy RSA provisioning for
- *   pre-hybrid gateways. Current gateways reject these RSA public keys.
- * - `decryptPayload` — recover plaintext from legacy stored payloads: scans for
- *   `RSA-OAEP/AES-256-GCM` envelopes, unwraps each DEK with the client-held
- *   private key, and AES-256-GCM-decrypts the field back to plaintext.
- *
- * Read path (client-side decryption):
- *   const raw = await client.getObject("my-bucket", "ingest/data.jsonl");
- *   const plaintext = await MaskuraClient.decryptPayload(raw, privateKeyPem);
- *
- * Uses only the Web Crypto API and global fetch (browser or Node >= 18).
- */
+/** High-level Maskura data-plane and envelope-encryption client. */
+import { x25519 } from "@noble/curves/ed25519";
+import { hkdf } from "@noble/hashes/hkdf";
+import { sha256 } from "@noble/hashes/sha256";
+import { ml_kem768 } from "@noble/post-quantum/ml-kem";
 
 declare const globalThis: any;
+
+const HYBRID_ALG = "X25519+ML-KEM-768/AES-256-GCM";
+const LEGACY_RSA_ALG = "RSA-OAEP/AES-256-GCM";
+const HYBRID_PUBLIC_LABEL = "MASKURA HYBRID PUBLIC KEY";
+const HYBRID_PRIVATE_LABEL = "MASKURA HYBRID PRIVATE KEY";
+const KDF_INFO = new TextEncoder().encode("maskura/hybrid/envelope-dek/v1");
+const X25519_KEY_LEN = 32;
+const MLKEM_CIPHERTEXT_LEN = 1088;
+const MLKEM_SEED_LEN = 64;
 
 export interface MaskuraClientOptions {
   endpoint: string;
@@ -46,12 +39,25 @@ export class MaskuraClient {
     return { "x-maskura-access-key": this.accessKey, "x-maskura-secret-key": this.secretKey };
   }
 
-  // -- keys ---------------------------------------------------------
-
-  /** Generate a legacy RSA-2048 envelope keypair (SPKI/PKCS#8 PEM).
-   * Current gateways accept only Maskura hybrid public keys for new writes.
-   */
+  /** Generate a gateway-compatible X25519 + ML-KEM-768 keypair. */
   static async generateKeypair(): Promise<{ privateKeyPem: string; publicKeyPem: string }> {
+    const x25519Secret = MaskuraClient.randomBytes(X25519_KEY_LEN);
+    const mlkemSeed = MaskuraClient.randomBytes(MLKEM_SEED_LEN);
+    const mlkem = ml_kem768.keygen(mlkemSeed);
+    return {
+      publicKeyPem: MaskuraClient.toPem(
+        MaskuraClient.concat(x25519.getPublicKey(x25519Secret), mlkem.publicKey),
+        HYBRID_PUBLIC_LABEL,
+      ),
+      privateKeyPem: MaskuraClient.toPem(
+        MaskuraClient.concat(x25519Secret, mlkemSeed),
+        HYBRID_PRIVATE_LABEL,
+      ),
+    };
+  }
+
+  /** Generate an RSA keypair for pre-hybrid gateways and old fixtures. */
+  static async generateLegacyRsaKeypair(): Promise<{ privateKeyPem: string; publicKeyPem: string }> {
     const subtle = globalThis.crypto.subtle;
     const kp = await subtle.generateKey(
       {
@@ -63,17 +69,13 @@ export class MaskuraClient {
       true,
       ["encrypt", "decrypt"],
     );
-    const spki = await subtle.exportKey("spki", kp.publicKey);
-    const pkcs8 = await subtle.exportKey("pkcs8", kp.privateKey);
     return {
-      publicKeyPem: MaskuraClient.toPem(spki, "PUBLIC KEY"),
-      privateKeyPem: MaskuraClient.toPem(pkcs8, "PRIVATE KEY"),
+      publicKeyPem: MaskuraClient.toPem(new Uint8Array(await subtle.exportKey("spki", kp.publicKey)), "PUBLIC KEY"),
+      privateKeyPem: MaskuraClient.toPem(new Uint8Array(await subtle.exportKey("pkcs8", kp.privateKey)), "PRIVATE KEY"),
     };
   }
 
-  /** Bind a public key to this API key. Current gateways reject the legacy RSA
-   * keys returned by `generateKeypair`; this remains for pre-hybrid gateways.
-   */
+  /** Bind a Maskura hybrid public key to this API key. */
   async attachPublicKey(publicKeyPem: string): Promise<void> {
     const resp = await fetch(`${this.endpoint}/dashboard/api/keys/public-key`, {
       method: "PUT",
@@ -83,8 +85,6 @@ export class MaskuraClient {
     });
     if (!resp.ok) throw new Error(`attachPublicKey failed: ${resp.status} ${await resp.text()}`);
   }
-
-  // -- object data plane -------------------------------------------
 
   /** Upload `data` to `bucket/key` through the Maskura filter pipeline. */
   async putObject(
@@ -113,20 +113,15 @@ export class MaskuraClient {
     return new Uint8Array(await resp.arrayBuffer());
   }
 
-  // -- envelope crypto ----------------------------------------------
-
-  /** Decrypt every envelope in `payload` back to plaintext. */
+  /** Decrypt current hybrid or legacy RSA envelopes in `payload`. */
   static async decryptPayload(payload: Uint8Array, privateKeyPem: string): Promise<Uint8Array> {
-    const subtle = globalThis.crypto.subtle;
-    const privKey = await subtle.importKey(
-      "pkcs8",
-      MaskuraClient.pemToDer(privateKeyPem),
-      { name: "RSA-OAEP", hash: "SHA-256" },
-      false,
-      ["decrypt"],
-    );
+    const hybrid = privateKeyPem.includes(`-----BEGIN ${HYBRID_PRIVATE_LABEL}-----`);
+    const algorithm = hybrid ? HYBRID_ALG : LEGACY_RSA_ALG;
+    const privateKey = hybrid
+      ? MaskuraClient.parseHybridPrivateKey(privateKeyPem)
+      : await MaskuraClient.importLegacyRsaPrivateKey(privateKeyPem);
     const bytes = Array.from(payload);
-    const marker = Array.from(new TextEncoder().encode('"alg":"RSA-OAEP/AES-256-GCM"'));
+    const marker = Array.from(new TextEncoder().encode(`"alg":"${algorithm}"`));
     const out: number[] = [];
     let pos = 0;
     while (true) {
@@ -135,7 +130,7 @@ export class MaskuraClient {
         for (let i = pos; i < bytes.length; i++) out.push(bytes[i]!);
         break;
       }
-      const start = bytes.lastIndexOf(0x7b /* { */, idx);
+      const start = bytes.lastIndexOf(0x7b, idx);
       if (start < 0) {
         for (let i = pos; i < idx + marker.length; i++) out.push(bytes[i]!);
         pos = idx + marker.length;
@@ -143,14 +138,11 @@ export class MaskuraClient {
       }
       let depth = 0;
       let end = -1;
-      for (let j = start; j < bytes.length; j++) {
-        if (bytes[j] === 0x7b) depth++;
-        else if (bytes[j] === 0x7d) {
-          depth--;
-          if (depth === 0) {
-            end = j + 1;
-            break;
-          }
+      for (let offset = start; offset < bytes.length; offset++) {
+        if (bytes[offset] === 0x7b) depth++;
+        else if (bytes[offset] === 0x7d && --depth === 0) {
+          end = offset + 1;
+          break;
         }
       }
       if (end < 0) {
@@ -158,7 +150,9 @@ export class MaskuraClient {
         break;
       }
       const env = JSON.parse(new TextDecoder().decode(new Uint8Array(bytes.slice(start, end))));
-      const plain = await MaskuraClient.decryptEnvelope(env, privKey);
+      const plain = hybrid
+        ? await MaskuraClient.decryptHybridEnvelope(env, privateKey as HybridPrivateKey)
+        : await MaskuraClient.decryptLegacyRsaEnvelope(env, privateKey as CryptoKey);
       for (let i = pos; i < start; i++) out.push(bytes[i]!);
       for (let i = 0; i < plain.length; i++) out.push(plain[i]!);
       pos = end;
@@ -166,43 +160,105 @@ export class MaskuraClient {
     return new Uint8Array(out);
   }
 
-  private static async decryptEnvelope(env: any, privKey: CryptoKey): Promise<number[]> {
-    if (env.alg !== "RSA-OAEP/AES-256-GCM") throw new Error(`unsupported alg: ${env.alg}`);
-    const subtle = globalThis.crypto.subtle;
-    const dek = await subtle.decrypt(
-      { name: "RSA-OAEP" },
-      privKey,
-      MaskuraClient.b64ToBuf(env.enc_dek),
+  private static parseHybridPrivateKey(pem: string): HybridPrivateKey {
+    const raw = MaskuraClient.pemToBytes(pem, HYBRID_PRIVATE_LABEL);
+    const expected = X25519_KEY_LEN + MLKEM_SEED_LEN;
+    if (raw.length !== expected) {
+      throw new Error(`Hybrid private key must contain ${expected} bytes, got ${raw.length}.`);
+    }
+    const mlkem = ml_kem768.keygen(raw.slice(X25519_KEY_LEN));
+    return { x25519Secret: raw.slice(0, X25519_KEY_LEN), mlkemSecret: mlkem.secretKey };
+  }
+
+  private static async decryptHybridEnvelope(env: any, key: HybridPrivateKey): Promise<Uint8Array> {
+    if (env.alg !== HYBRID_ALG) throw new Error(`unsupported alg: ${env.alg}`);
+    const encapsulated = MaskuraClient.b64ToBytes(env.enc_dek);
+    const expected = X25519_KEY_LEN + MLKEM_CIPHERTEXT_LEN;
+    if (encapsulated.length !== expected) {
+      throw new Error(`Hybrid enc_dek must contain ${expected} bytes, got ${encapsulated.length}.`);
+    }
+    const x25519Shared = x25519.getSharedSecret(key.x25519Secret, encapsulated.slice(0, X25519_KEY_LEN));
+    const mlkemShared = ml_kem768.decapsulate(encapsulated.slice(X25519_KEY_LEN), key.mlkemSecret);
+    const dek = hkdf(
+      sha256,
+      MaskuraClient.concat(x25519Shared, mlkemShared),
+      new Uint8Array(0),
+      KDF_INFO,
+      32,
     );
-    const iv = MaskuraClient.b64ToBuf(env.iv);
-    const ct = new Uint8Array(MaskuraClient.b64ToBuf(env.ct));
-    const tag = new Uint8Array(MaskuraClient.b64ToBuf(env.tag));
-    const aead = await subtle.importKey("raw", dek, "AES-GCM", false, ["decrypt"]);
-    const combined = new Uint8Array(ct.length + tag.length);
-    combined.set(ct, 0);
-    combined.set(tag, ct.length);
-    const pt = await subtle.decrypt({ name: "AES-GCM", iv, tagLength: 128 }, aead, combined);
-    return Array.from(new Uint8Array(pt));
+    return MaskuraClient.decryptAesGcm(env, dek);
   }
 
-  private static toPem(der: ArrayBuffer, label: string): string {
-    const bytes = new Uint8Array(der);
-    let bin = "";
-    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]!);
-    const b64 = btoa(bin).replace(/(.{64})/g, "$1\n");
-    return `-----BEGIN ${label}-----\n${b64}\n-----END ${label}-----\n`;
+  private static async importLegacyRsaPrivateKey(pem: string): Promise<CryptoKey> {
+    return globalThis.crypto.subtle.importKey(
+      "pkcs8",
+      MaskuraClient.pemToBytes(pem, "PRIVATE KEY"),
+      { name: "RSA-OAEP", hash: "SHA-256" },
+      false,
+      ["decrypt"],
+    );
   }
 
-  private static pemToDer(pem: string): ArrayBuffer {
-    const b64 = pem.replace(/-----BEGIN [^-]+-----/g, "").replace(/-----END [^-]+-----/g, "").replace(/\s+/g, "");
-    return MaskuraClient.b64ToBuf(b64);
+  private static async decryptLegacyRsaEnvelope(env: any, key: CryptoKey): Promise<Uint8Array> {
+    if (env.alg !== LEGACY_RSA_ALG) throw new Error(`unsupported alg: ${env.alg}`);
+    const dek = await globalThis.crypto.subtle.decrypt(
+      { name: "RSA-OAEP" },
+      key,
+      MaskuraClient.b64ToBytes(env.enc_dek),
+    );
+    return MaskuraClient.decryptAesGcm(env, new Uint8Array(dek));
   }
 
-  private static b64ToBuf(b64: string): ArrayBuffer {
-    const bin = atob(b64);
-    const bytes = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-    return bytes.buffer;
+  private static async decryptAesGcm(env: any, dek: Uint8Array): Promise<Uint8Array> {
+    const subtle = globalThis.crypto.subtle;
+    const key = await subtle.importKey("raw", dek, "AES-GCM", false, ["decrypt"]);
+    const plaintext = await subtle.decrypt(
+      { name: "AES-GCM", iv: MaskuraClient.b64ToBytes(env.iv), tagLength: 128 },
+      key,
+      MaskuraClient.concat(MaskuraClient.b64ToBytes(env.ct), MaskuraClient.b64ToBytes(env.tag)),
+    );
+    return new Uint8Array(plaintext);
+  }
+
+  private static randomBytes(length: number): Uint8Array {
+    return globalThis.crypto.getRandomValues(new Uint8Array(length));
+  }
+
+  private static concat(...arrays: Uint8Array[]): Uint8Array {
+    const output = new Uint8Array(arrays.reduce((sum, value) => sum + value.length, 0));
+    let offset = 0;
+    for (const value of arrays) {
+      output.set(value, offset);
+      offset += value.length;
+    }
+    return output;
+  }
+
+  private static toPem(bytes: Uint8Array, label: string): string {
+    let binary = "";
+    for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+      binary += String.fromCharCode.apply(
+        null,
+        Array.from(bytes.subarray(offset, offset + 0x8000)),
+      );
+    }
+    const body = btoa(binary).match(/.{1,64}/g)?.join("\n") ?? "";
+    return `-----BEGIN ${label}-----\n${body}\n-----END ${label}-----\n`;
+  }
+
+  private static pemToBytes(pem: string, label: string): Uint8Array {
+    const begin = `-----BEGIN ${label}-----`;
+    const end = `-----END ${label}-----`;
+    const value = pem.trim();
+    if (!value.startsWith(begin) || !value.endsWith(end)) {
+      throw new Error(`Expected a ${label} PEM block.`);
+    }
+    return MaskuraClient.b64ToBytes(value.slice(begin.length, -end.length).replace(/\s+/g, ""));
+  }
+
+  private static b64ToBytes(value: string): Uint8Array {
+    const binary = atob(value);
+    return Uint8Array.from(binary, (character) => character.charCodeAt(0));
   }
 
   private static indexOf(haystack: number[], needle: number[], from: number): number {
@@ -216,7 +272,10 @@ export class MaskuraClient {
   }
 }
 
-export type S4ClientOptions = MaskuraClientOptions;
+interface HybridPrivateKey {
+  x25519Secret: Uint8Array;
+  mlkemSecret: Uint8Array;
+}
 
-/** Permanent compatibility export for existing integrations. */
+export type S4ClientOptions = MaskuraClientOptions;
 export class S4Client extends MaskuraClient {}

--- a/sdks/overlay/typescript/package.json
+++ b/sdks/overlay/typescript/package.json
@@ -30,10 +30,13 @@
     "build": "tsc"
   },
   "dependencies": {
+    "@noble/curves": "^1.9.7",
+    "@noble/hashes": "^1.8.0",
+    "@noble/post-quantum": "^0.4.1",
     "whatwg-fetch": "^3.0.0",
     "es6-promise": "^4.2.4"
   },
   "devDependencies": {
-    "typescript": "^4.0"
+    "typescript": "^5.9.3"
   }
 }

--- a/sdks/overlay/typescript/test/highlevel-crypto.test.cjs
+++ b/sdks/overlay/typescript/test/highlevel-crypto.test.cjs
@@ -1,0 +1,100 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { x25519 } = require("@noble/curves/ed25519");
+const { hkdf } = require("@noble/hashes/hkdf");
+const { sha256 } = require("@noble/hashes/sha256");
+const { ml_kem768 } = require("@noble/post-quantum/ml-kem");
+const { MaskuraClient } = require("../dist/highlevel.js");
+
+function pemBytes(pem, label) {
+  return Uint8Array.from(
+    Buffer.from(
+      pem
+        .replace(`-----BEGIN ${label}-----`, "")
+        .replace(`-----END ${label}-----`, "")
+        .replace(/\s+/g, ""),
+      "base64",
+    ),
+  );
+}
+
+function concat(...values) {
+  return Uint8Array.from(Buffer.concat(values.map((value) => Buffer.from(value))));
+}
+
+test("hybrid keypair and gateway envelope round trip", async () => {
+  const pair = await MaskuraClient.generateKeypair();
+  const privateRaw = pemBytes(pair.privateKeyPem, "MASKURA HYBRID PRIVATE KEY");
+  const publicRaw = pemBytes(pair.publicKeyPem, "MASKURA HYBRID PUBLIC KEY");
+  assert.equal(privateRaw.length, 96);
+  assert.equal(publicRaw.length, 1216);
+
+  const ephemeralSecret = crypto.getRandomValues(new Uint8Array(32));
+  const encapsulated = ml_kem768.encapsulate(publicRaw.slice(32));
+  const dek = hkdf(
+    sha256,
+    concat(
+      x25519.getSharedSecret(ephemeralSecret, publicRaw.slice(0, 32)),
+      encapsulated.sharedSecret,
+    ),
+    new Uint8Array(0),
+    new TextEncoder().encode("maskura/hybrid/envelope-dek/v1"),
+    32,
+  );
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await crypto.subtle.importKey("raw", dek, "AES-GCM", false, ["encrypt"]);
+  const sealed = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv, tagLength: 128 },
+      key,
+      new TextEncoder().encode("alice@example.com"),
+    ),
+  );
+  const envelope = {
+    alg: "X25519+ML-KEM-768/AES-256-GCM",
+    iv: Buffer.from(iv).toString("base64"),
+    enc_dek: Buffer.from(
+      concat(x25519.getPublicKey(ephemeralSecret), encapsulated.cipherText),
+    ).toString("base64"),
+    ct: Buffer.from(sealed.slice(0, -16)).toString("base64"),
+    tag: Buffer.from(sealed.slice(-16)).toString("base64"),
+  };
+  const payload = new TextEncoder().encode(`before ${JSON.stringify(envelope)} after`);
+  const plaintext = await MaskuraClient.decryptPayload(payload, pair.privateKeyPem);
+  assert.equal(new TextDecoder().decode(plaintext), "before alice@example.com after");
+});
+
+test("legacy RSA envelopes remain readable", async () => {
+  const pair = await MaskuraClient.generateLegacyRsaKeypair();
+  const publicKey = await crypto.subtle.importKey(
+    "spki",
+    pemBytes(pair.publicKeyPem, "PUBLIC KEY"),
+    { name: "RSA-OAEP", hash: "SHA-256" },
+    false,
+    ["encrypt"],
+  );
+  const dek = crypto.getRandomValues(new Uint8Array(32));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const aesKey = await crypto.subtle.importKey("raw", dek, "AES-GCM", false, ["encrypt"]);
+  const sealed = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv, tagLength: 128 },
+      aesKey,
+      new TextEncoder().encode("legacy@example.com"),
+    ),
+  );
+  const envelope = {
+    alg: "RSA-OAEP/AES-256-GCM",
+    iv: Buffer.from(iv).toString("base64"),
+    enc_dek: Buffer.from(await crypto.subtle.encrypt({ name: "RSA-OAEP" }, publicKey, dek)).toString(
+      "base64",
+    ),
+    ct: Buffer.from(sealed.slice(0, -16)).toString("base64"),
+    tag: Buffer.from(sealed.slice(-16)).toString("base64"),
+  };
+  const plaintext = await MaskuraClient.decryptPayload(
+    new TextEncoder().encode(JSON.stringify(envelope)),
+    pair.privateKeyPem,
+  );
+  assert.equal(new TextDecoder().decode(plaintext), "legacy@example.com");
+});

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -35,12 +35,21 @@ client = MaskuraClient(
 )
 ```
 
-Object PUT/GET helpers work with current gateways. The high-level
-`generate_keypair` and `decrypt_payload` helpers implement the legacy RSA
-envelope for compatibility with older stored objects. Current gateways accept
-only Maskura hybrid X25519 + ML-KEM-768 public keys for new encrypted writes;
-see the [client tooling status](../../docs/encryption.md#client-tooling-status)
-before using envelope encryption.
+The high-level client supports the current hybrid encryption flow:
+
+```python
+private_pem, public_pem = MaskuraClient.generate_keypair()
+client.attach_public_key(public_pem)
+client.put_object("bucket", "data.jsonl", b'{"email":"jane@example.com"}')
+stored = client.get_object("bucket", "data.jsonl")
+plaintext = MaskuraClient.decrypt_payload(stored, private_pem)
+```
+
+Store `private_pem` securely; only the public key is uploaded. Hybrid support
+requires `cryptography >= 47`. `decrypt_payload` also reads legacy RSA
+envelopes, and `generate_legacy_rsa_keypair` remains available only for
+pre-hybrid gateways and compatibility fixtures. See the
+[encryption reference](../../docs/encryption.md#client-tooling-status).
 
 ## Tests
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "pydantic (>=2)",
   "typing-extensions (>=4.7.1)",
   "requests (>=2.31)",
-  "cryptography (>=42)"
+  "cryptography (>=47)"
 ]
 
 [project.urls]

--- a/sdks/python/requirements.txt
+++ b/sdks/python/requirements.txt
@@ -3,4 +3,4 @@ python_dateutil >= 2.8.2
 pydantic >= 2
 typing-extensions >= 4.7.1
 requests >= 2.31
-cryptography >= 42
+cryptography >= 47

--- a/sdks/python/s4_client/highlevel.py
+++ b/sdks/python/s4_client/highlevel.py
@@ -1,24 +1,8 @@
-"""High-level Maskura client: object I/O plus legacy envelope compatibility.
+"""High-level Maskura client: object I/O and envelope encryption helpers.
 
-The generated low-level client covers the dashboard API (keys, plugins,
-backends). This module adds the S3 data-plane operations the gateway exposes
-plus the client side of the envelope-encryption scheme:
-
-* ``put_object`` / ``get_object`` — raw byte objects through the gateway,
-  authenticated with the Maskura API key headers (``x-maskura-access-key`` /
-  ``x-maskura-secret-key``).
-* ``generate_keypair`` / ``attach_public_key`` — legacy RSA provisioning for
-  pre-hybrid gateways. Current gateways reject these RSA public keys.
-* ``decrypt_payload`` — recover plaintext from legacy stored payloads: scans for
-  ``RSA-OAEP/AES-256-GCM`` envelopes, unwraps each DEK with the client-held
-  private key, and AES-256-GCM-decrypts the field back to plaintext.
-
-Legacy read path (client-side decryption):
-    raw = client.get_object("my-bucket", "ingest/data.jsonl")
-    plaintext = MaskuraClient.decrypt_payload(raw, private_pem)
-
-Extra dependencies beyond the generated client: ``requests`` and
-``cryptography``.
+The generated low-level client covers the dashboard API. This module adds the
+S3 data-plane operations plus client-held hybrid key generation and decryption.
+New keys use X25519 + ML-KEM-768; legacy RSA envelopes remain readable.
 """
 
 from __future__ import annotations
@@ -29,16 +13,40 @@ from typing import Tuple
 
 import requests
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.asymmetric import padding, rsa, x25519
+from cryptography.hazmat.primitives.asymmetric.mlkem import MLKEM768PrivateKey
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
-_ENVELOPE_ALG = "RSA-OAEP/AES-256-GCM"
-_MARKER = b'"alg":"' + _ENVELOPE_ALG.encode() + b'"'
+_HYBRID_ALG = "X25519+ML-KEM-768/AES-256-GCM"
+_LEGACY_RSA_ALG = "RSA-OAEP/AES-256-GCM"
+_HYBRID_PUBLIC_LABEL = "MASKURA HYBRID PUBLIC KEY"
+_HYBRID_PRIVATE_LABEL = "MASKURA HYBRID PRIVATE KEY"
+_KDF_INFO = b"maskura/hybrid/envelope-dek/v1"
+_X25519_KEY_LEN = 32
+_MLKEM_CIPHERTEXT_LEN = 1088
+_MLKEM_SEED_LEN = 64
 _OAEP = padding.OAEP(
     mgf=padding.MGF1(algorithm=hashes.SHA256()),
     algorithm=hashes.SHA256(),
     label=None,
 )
+
+
+def _encode_pem(label: str, raw: bytes) -> str:
+    body = base64.b64encode(raw).decode()
+    lines = "\n".join(body[offset : offset + 64] for offset in range(0, len(body), 64))
+    return f"-----BEGIN {label}-----\n{lines}\n-----END {label}-----\n"
+
+
+def _decode_pem(label: str, pem: str) -> bytes:
+    begin = f"-----BEGIN {label}-----"
+    end = f"-----END {label}-----"
+    value = pem.strip()
+    if not value.startswith(begin) or not value.endswith(end):
+        raise ValueError(f"expected a {label} PEM block")
+    body = "".join(value[len(begin) : -len(end)].split())
+    return base64.b64decode(body, validate=True)
 
 
 class MaskuraClient:
@@ -56,19 +64,28 @@ class MaskuraClient:
             "x-maskura-secret-key": self.secret_key,
         }
 
-    # -- keys ---------------------------------------------------------
-
     @staticmethod
     def generate_keypair() -> Tuple[str, str]:
-        """Generate a legacy RSA-2048 envelope keypair.
+        """Generate a gateway-compatible hybrid keypair.
 
-        Current gateways accept only Maskura hybrid public keys for new writes;
-        this helper exists to support pre-hybrid gateways and stored objects.
-
-        Returns ``(private_key_pem, public_key_pem)`` — PKCS#8 private key
-        and SPKI public key, both PEM. Store the private key somewhere safe;
-        it is the only way to decrypt what Maskura stores.
+        Returns ``(private_key_pem, public_key_pem)``. The private PEM contains
+        only the X25519 secret and the ML-KEM seed and must never be uploaded.
         """
+        x25519_private = x25519.X25519PrivateKey.generate()
+        mlkem_private = MLKEM768PrivateKey.generate()
+        private_raw = x25519_private.private_bytes_raw() + mlkem_private.private_bytes_raw()
+        public_raw = (
+            x25519_private.public_key().public_bytes_raw()
+            + mlkem_private.public_key().public_bytes_raw()
+        )
+        return (
+            _encode_pem(_HYBRID_PRIVATE_LABEL, private_raw),
+            _encode_pem(_HYBRID_PUBLIC_LABEL, public_raw),
+        )
+
+    @staticmethod
+    def generate_legacy_rsa_keypair() -> Tuple[str, str]:
+        """Generate an RSA keypair for pre-hybrid gateways and old fixtures."""
         private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
         private_pem = private.private_bytes(
             encoding=serialization.Encoding.PEM,
@@ -82,11 +99,7 @@ class MaskuraClient:
         return private_pem, public_pem
 
     def attach_public_key(self, public_key_pem: str) -> None:
-        """Bind a public key to this API key.
-
-        Current gateways reject the legacy RSA keys created by
-        ``generate_keypair``. This method remains for pre-hybrid gateways.
-        """
+        """Bind a Maskura hybrid public key to this API key."""
         resp = requests.put(
             f"{self.endpoint}/dashboard/api/keys/public-key",
             headers=self._headers(),
@@ -95,10 +108,8 @@ class MaskuraClient:
         )
         resp.raise_for_status()
 
-    # -- object data plane -------------------------------------------
-
     def put_object(self, bucket: str, key: str, data: bytes, content_type: str = "text/plain") -> None:
-        """Upload ``data`` to ``bucket/key`` through the Maskura filter pipeline."""
+        """Upload ``data`` to ``bucket/key`` through the Maskura pipeline."""
         resp = requests.put(
             f"{self.endpoint}/{bucket}/{key}",
             headers={**self._headers(), "Content-Type": content_type},
@@ -117,38 +128,40 @@ class MaskuraClient:
         resp.raise_for_status()
         return resp.content
 
-    # -- envelope crypto ----------------------------------------------
-
     @staticmethod
     def decrypt_payload(payload: bytes, private_key_pem: str) -> bytes:
-        """Decrypt every envelope in ``payload`` back to plaintext.
+        """Decrypt current hybrid or legacy RSA envelopes in ``payload``."""
+        if f"-----BEGIN {_HYBRID_PRIVATE_LABEL}-----" in private_key_pem:
+            key = MaskuraClient._load_hybrid_private_key(private_key_pem)
+            supported_alg = _HYBRID_ALG
+        else:
+            key = serialization.load_pem_private_key(private_key_pem.encode(), password=None)
+            if not isinstance(key, rsa.RSAPrivateKey):
+                raise ValueError("expected a Maskura hybrid or RSA private key")
+            supported_alg = _LEGACY_RSA_ALG
 
-        Encrypted fields are replaced in place; anything else (e.g. the
-        non-Luhn numbers the detector ignores) is left untouched.
-        """
-        key = serialization.load_pem_private_key(private_key_pem.encode(), password=None)
+        marker = b'"alg":"' + supported_alg.encode() + b'"'
         out = bytearray()
         pos = 0
         while True:
-            idx = payload.find(_MARKER, pos)
+            idx = payload.find(marker, pos)
             if idx < 0:
                 out += payload[pos:]
                 break
             start = payload.rfind(b"{", 0, idx)
             if start < 0:
-                out += payload[pos : idx + len(_MARKER)]
-                pos = idx + len(_MARKER)
+                out += payload[pos : idx + len(marker)]
+                pos = idx + len(marker)
                 continue
             depth = 0
             end = -1
-            for j in range(start, len(payload)):
-                c = payload[j]
-                if c == 0x7B:
+            for offset in range(start, len(payload)):
+                if payload[offset] == 0x7B:
                     depth += 1
-                elif c == 0x7D:
+                elif payload[offset] == 0x7D:
                     depth -= 1
                     if depth == 0:
-                        end = j + 1
+                        end = offset + 1
                         break
             if end < 0:
                 out += payload[pos:]
@@ -161,12 +174,40 @@ class MaskuraClient:
         return bytes(out)
 
     @staticmethod
+    def _load_hybrid_private_key(private_key_pem: str) -> tuple[x25519.X25519PrivateKey, MLKEM768PrivateKey]:
+        raw = _decode_pem(_HYBRID_PRIVATE_LABEL, private_key_pem)
+        expected = _X25519_KEY_LEN + _MLKEM_SEED_LEN
+        if len(raw) != expected:
+            raise ValueError(f"hybrid private key must contain {expected} bytes, got {len(raw)}")
+        return (
+            x25519.X25519PrivateKey.from_private_bytes(raw[:_X25519_KEY_LEN]),
+            MLKEM768PrivateKey.from_seed_bytes(raw[_X25519_KEY_LEN:]),
+        )
+
+    @staticmethod
     def _decrypt_envelope(env: dict, private_key) -> bytes:
-        assert env["alg"] == _ENVELOPE_ALG, env["alg"]
-        dek = private_key.decrypt(base64.b64decode(env["enc_dek"]), _OAEP)
-        ciphertext = base64.b64decode(env["ct"]) + base64.b64decode(env["tag"])
-        return AESGCM(dek).decrypt(base64.b64decode(env["iv"]), ciphertext, None)
+        algorithm = env.get("alg")
+        enc_dek = base64.b64decode(env["enc_dek"], validate=True)
+        if algorithm == _HYBRID_ALG:
+            x25519_private, mlkem_private = private_key
+            expected = _X25519_KEY_LEN + _MLKEM_CIPHERTEXT_LEN
+            if len(enc_dek) != expected:
+                raise ValueError(f"hybrid enc_dek must contain {expected} bytes, got {len(enc_dek)}")
+            x25519_public = x25519.X25519PublicKey.from_public_bytes(enc_dek[:_X25519_KEY_LEN])
+            shared = x25519_private.exchange(x25519_public) + mlkem_private.decapsulate(
+                enc_dek[_X25519_KEY_LEN:]
+            )
+            dek = HKDF(
+                algorithm=hashes.SHA256(), length=32, salt=None, info=_KDF_INFO
+            ).derive(shared)
+        elif algorithm == _LEGACY_RSA_ALG:
+            dek = private_key.decrypt(enc_dek, _OAEP)
+        else:
+            raise ValueError(f"unsupported envelope algorithm: {algorithm or 'missing'}")
+        ciphertext = base64.b64decode(env["ct"], validate=True) + base64.b64decode(
+            env["tag"], validate=True
+        )
+        return AESGCM(dek).decrypt(base64.b64decode(env["iv"], validate=True), ciphertext, None)
 
 
-# Permanent compatibility export for existing integrations.
 S4Client = MaskuraClient

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -29,7 +29,7 @@ REQUIRES = [
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",
     "requests >= 2.31",
-    "cryptography >= 42",
+    "cryptography >= 47",
 ]
 
 setup(

--- a/sdks/python/test/test_highlevel_crypto.py
+++ b/sdks/python/test/test_highlevel_crypto.py
@@ -1,0 +1,77 @@
+import base64
+import json
+import os
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, x25519
+from cryptography.hazmat.primitives.asymmetric.mlkem import MLKEM768PublicKey
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from s4_client.highlevel import MaskuraClient
+
+
+def _pem_bytes(pem, label):
+    return base64.b64decode(
+        pem.replace(f"-----BEGIN {label}-----", "")
+        .replace(f"-----END {label}-----", "")
+        .replace("\n", "")
+    )
+
+
+def test_hybrid_keypair_and_gateway_envelope_roundtrip():
+    private_pem, public_pem = MaskuraClient.generate_keypair()
+    private_raw = _pem_bytes(private_pem, "MASKURA HYBRID PRIVATE KEY")
+    public_raw = _pem_bytes(public_pem, "MASKURA HYBRID PUBLIC KEY")
+    assert len(private_raw) == 96
+    assert len(public_raw) == 1216
+
+    ephemeral = x25519.X25519PrivateKey.generate()
+    x25519_shared = ephemeral.exchange(x25519.X25519PublicKey.from_public_bytes(public_raw[:32]))
+    mlkem_shared, mlkem_ciphertext = MLKEM768PublicKey.from_public_bytes(
+        public_raw[32:]
+    ).encapsulate()
+    dek = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=b"maskura/hybrid/envelope-dek/v1",
+    ).derive(x25519_shared + mlkem_shared)
+    iv = os.urandom(12)
+    sealed = AESGCM(dek).encrypt(iv, b"alice@example.com", None)
+    envelope = {
+        "alg": "X25519+ML-KEM-768/AES-256-GCM",
+        "iv": base64.b64encode(iv).decode(),
+        "enc_dek": base64.b64encode(
+            ephemeral.public_key().public_bytes_raw() + mlkem_ciphertext
+        ).decode(),
+        "ct": base64.b64encode(sealed[:-16]).decode(),
+        "tag": base64.b64encode(sealed[-16:]).decode(),
+    }
+    payload = b"before " + json.dumps(envelope, separators=(",", ":")).encode() + b" after"
+    assert MaskuraClient.decrypt_payload(payload, private_pem) == b"before alice@example.com after"
+
+
+def test_legacy_rsa_envelopes_remain_readable():
+    private_pem, public_pem = MaskuraClient.generate_legacy_rsa_keypair()
+    public_key = serialization.load_pem_public_key(public_pem.encode())
+    dek = os.urandom(32)
+    iv = os.urandom(12)
+    sealed = AESGCM(dek).encrypt(iv, b"legacy@example.com", None)
+    wrapped = public_key.encrypt(
+        dek,
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
+    )
+    envelope = {
+        "alg": "RSA-OAEP/AES-256-GCM",
+        "iv": base64.b64encode(iv).decode(),
+        "enc_dek": base64.b64encode(wrapped).decode(),
+        "ct": base64.b64encode(sealed[:-16]).decode(),
+        "tag": base64.b64encode(sealed[-16:]).decode(),
+    }
+    payload = json.dumps(envelope, separators=(",", ":")).encode()
+    assert MaskuraClient.decrypt_payload(payload, private_pem) == b"legacy@example.com"

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -48,9 +48,19 @@ const client = new MaskuraClient({
 });
 ```
 
-Object PUT/GET helpers work with current gateways. The high-level
-`generateKeypair` and `decryptPayload` helpers implement the legacy RSA
-envelope for compatibility with older stored objects. Current gateways accept
-only Maskura hybrid X25519 + ML-KEM-768 public keys for new encrypted writes;
-see the [client tooling status](../../docs/encryption.md#client-tooling-status)
-before using envelope encryption.
+The high-level client supports the current hybrid encryption flow:
+
+```typescript
+const { privateKeyPem, publicKeyPem } = await MaskuraClient.generateKeypair();
+await client.attachPublicKey(publicKeyPem);
+await client.putObject("bucket", "data.jsonl", new TextEncoder().encode('{"email":"jane@example.com"}'));
+const stored = await client.getObject("bucket", "data.jsonl");
+const plaintext = await MaskuraClient.decryptPayload(stored, privateKeyPem);
+```
+
+Store `privateKeyPem` securely; only the public key is uploaded. The package
+retains CommonJS output and supports Node 18+ or browsers with Web Crypto.
+`decryptPayload` also reads legacy RSA envelopes, and
+`generateLegacyRsaKeypair` remains available only for pre-hybrid gateways and
+compatibility fixtures. See the
+[encryption reference](../../docs/encryption.md#client-tooling-status).

--- a/sdks/typescript/highlevel.ts
+++ b/sdks/typescript/highlevel.ts
@@ -1,26 +1,19 @@
-/**
- * High-level Maskura client: object I/O plus legacy envelope compatibility.
- *
- * The generated low-level client covers the dashboard API (keys, plugins,
- * backends). This module adds the S3 data-plane operations the gateway
- * exposes plus the client side of the envelope-encryption scheme:
- *
- * - `putObject` / `getObject` — raw byte objects through the gateway,
- *   authenticated with the Maskura API key headers.
- * - `generateKeypair` / `attachPublicKey` — legacy RSA provisioning for
- *   pre-hybrid gateways. Current gateways reject these RSA public keys.
- * - `decryptPayload` — recover plaintext from legacy stored payloads: scans for
- *   `RSA-OAEP/AES-256-GCM` envelopes, unwraps each DEK with the client-held
- *   private key, and AES-256-GCM-decrypts the field back to plaintext.
- *
- * Read path (client-side decryption):
- *   const raw = await client.getObject("my-bucket", "ingest/data.jsonl");
- *   const plaintext = await MaskuraClient.decryptPayload(raw, privateKeyPem);
- *
- * Uses only the Web Crypto API and global fetch (browser or Node >= 18).
- */
+/** High-level Maskura data-plane and envelope-encryption client. */
+import { x25519 } from "@noble/curves/ed25519";
+import { hkdf } from "@noble/hashes/hkdf";
+import { sha256 } from "@noble/hashes/sha256";
+import { ml_kem768 } from "@noble/post-quantum/ml-kem";
 
 declare const globalThis: any;
+
+const HYBRID_ALG = "X25519+ML-KEM-768/AES-256-GCM";
+const LEGACY_RSA_ALG = "RSA-OAEP/AES-256-GCM";
+const HYBRID_PUBLIC_LABEL = "MASKURA HYBRID PUBLIC KEY";
+const HYBRID_PRIVATE_LABEL = "MASKURA HYBRID PRIVATE KEY";
+const KDF_INFO = new TextEncoder().encode("maskura/hybrid/envelope-dek/v1");
+const X25519_KEY_LEN = 32;
+const MLKEM_CIPHERTEXT_LEN = 1088;
+const MLKEM_SEED_LEN = 64;
 
 export interface MaskuraClientOptions {
   endpoint: string;
@@ -46,12 +39,25 @@ export class MaskuraClient {
     return { "x-maskura-access-key": this.accessKey, "x-maskura-secret-key": this.secretKey };
   }
 
-  // -- keys ---------------------------------------------------------
-
-  /** Generate a legacy RSA-2048 envelope keypair (SPKI/PKCS#8 PEM).
-   * Current gateways accept only Maskura hybrid public keys for new writes.
-   */
+  /** Generate a gateway-compatible X25519 + ML-KEM-768 keypair. */
   static async generateKeypair(): Promise<{ privateKeyPem: string; publicKeyPem: string }> {
+    const x25519Secret = MaskuraClient.randomBytes(X25519_KEY_LEN);
+    const mlkemSeed = MaskuraClient.randomBytes(MLKEM_SEED_LEN);
+    const mlkem = ml_kem768.keygen(mlkemSeed);
+    return {
+      publicKeyPem: MaskuraClient.toPem(
+        MaskuraClient.concat(x25519.getPublicKey(x25519Secret), mlkem.publicKey),
+        HYBRID_PUBLIC_LABEL,
+      ),
+      privateKeyPem: MaskuraClient.toPem(
+        MaskuraClient.concat(x25519Secret, mlkemSeed),
+        HYBRID_PRIVATE_LABEL,
+      ),
+    };
+  }
+
+  /** Generate an RSA keypair for pre-hybrid gateways and old fixtures. */
+  static async generateLegacyRsaKeypair(): Promise<{ privateKeyPem: string; publicKeyPem: string }> {
     const subtle = globalThis.crypto.subtle;
     const kp = await subtle.generateKey(
       {
@@ -63,17 +69,13 @@ export class MaskuraClient {
       true,
       ["encrypt", "decrypt"],
     );
-    const spki = await subtle.exportKey("spki", kp.publicKey);
-    const pkcs8 = await subtle.exportKey("pkcs8", kp.privateKey);
     return {
-      publicKeyPem: MaskuraClient.toPem(spki, "PUBLIC KEY"),
-      privateKeyPem: MaskuraClient.toPem(pkcs8, "PRIVATE KEY"),
+      publicKeyPem: MaskuraClient.toPem(new Uint8Array(await subtle.exportKey("spki", kp.publicKey)), "PUBLIC KEY"),
+      privateKeyPem: MaskuraClient.toPem(new Uint8Array(await subtle.exportKey("pkcs8", kp.privateKey)), "PRIVATE KEY"),
     };
   }
 
-  /** Bind a public key to this API key. Current gateways reject the legacy RSA
-   * keys returned by `generateKeypair`; this remains for pre-hybrid gateways.
-   */
+  /** Bind a Maskura hybrid public key to this API key. */
   async attachPublicKey(publicKeyPem: string): Promise<void> {
     const resp = await fetch(`${this.endpoint}/dashboard/api/keys/public-key`, {
       method: "PUT",
@@ -83,8 +85,6 @@ export class MaskuraClient {
     });
     if (!resp.ok) throw new Error(`attachPublicKey failed: ${resp.status} ${await resp.text()}`);
   }
-
-  // -- object data plane -------------------------------------------
 
   /** Upload `data` to `bucket/key` through the Maskura filter pipeline. */
   async putObject(
@@ -113,20 +113,15 @@ export class MaskuraClient {
     return new Uint8Array(await resp.arrayBuffer());
   }
 
-  // -- envelope crypto ----------------------------------------------
-
-  /** Decrypt every envelope in `payload` back to plaintext. */
+  /** Decrypt current hybrid or legacy RSA envelopes in `payload`. */
   static async decryptPayload(payload: Uint8Array, privateKeyPem: string): Promise<Uint8Array> {
-    const subtle = globalThis.crypto.subtle;
-    const privKey = await subtle.importKey(
-      "pkcs8",
-      MaskuraClient.pemToDer(privateKeyPem),
-      { name: "RSA-OAEP", hash: "SHA-256" },
-      false,
-      ["decrypt"],
-    );
+    const hybrid = privateKeyPem.includes(`-----BEGIN ${HYBRID_PRIVATE_LABEL}-----`);
+    const algorithm = hybrid ? HYBRID_ALG : LEGACY_RSA_ALG;
+    const privateKey = hybrid
+      ? MaskuraClient.parseHybridPrivateKey(privateKeyPem)
+      : await MaskuraClient.importLegacyRsaPrivateKey(privateKeyPem);
     const bytes = Array.from(payload);
-    const marker = Array.from(new TextEncoder().encode('"alg":"RSA-OAEP/AES-256-GCM"'));
+    const marker = Array.from(new TextEncoder().encode(`"alg":"${algorithm}"`));
     const out: number[] = [];
     let pos = 0;
     while (true) {
@@ -135,7 +130,7 @@ export class MaskuraClient {
         for (let i = pos; i < bytes.length; i++) out.push(bytes[i]!);
         break;
       }
-      const start = bytes.lastIndexOf(0x7b /* { */, idx);
+      const start = bytes.lastIndexOf(0x7b, idx);
       if (start < 0) {
         for (let i = pos; i < idx + marker.length; i++) out.push(bytes[i]!);
         pos = idx + marker.length;
@@ -143,14 +138,11 @@ export class MaskuraClient {
       }
       let depth = 0;
       let end = -1;
-      for (let j = start; j < bytes.length; j++) {
-        if (bytes[j] === 0x7b) depth++;
-        else if (bytes[j] === 0x7d) {
-          depth--;
-          if (depth === 0) {
-            end = j + 1;
-            break;
-          }
+      for (let offset = start; offset < bytes.length; offset++) {
+        if (bytes[offset] === 0x7b) depth++;
+        else if (bytes[offset] === 0x7d && --depth === 0) {
+          end = offset + 1;
+          break;
         }
       }
       if (end < 0) {
@@ -158,7 +150,9 @@ export class MaskuraClient {
         break;
       }
       const env = JSON.parse(new TextDecoder().decode(new Uint8Array(bytes.slice(start, end))));
-      const plain = await MaskuraClient.decryptEnvelope(env, privKey);
+      const plain = hybrid
+        ? await MaskuraClient.decryptHybridEnvelope(env, privateKey as HybridPrivateKey)
+        : await MaskuraClient.decryptLegacyRsaEnvelope(env, privateKey as CryptoKey);
       for (let i = pos; i < start; i++) out.push(bytes[i]!);
       for (let i = 0; i < plain.length; i++) out.push(plain[i]!);
       pos = end;
@@ -166,43 +160,105 @@ export class MaskuraClient {
     return new Uint8Array(out);
   }
 
-  private static async decryptEnvelope(env: any, privKey: CryptoKey): Promise<number[]> {
-    if (env.alg !== "RSA-OAEP/AES-256-GCM") throw new Error(`unsupported alg: ${env.alg}`);
-    const subtle = globalThis.crypto.subtle;
-    const dek = await subtle.decrypt(
-      { name: "RSA-OAEP" },
-      privKey,
-      MaskuraClient.b64ToBuf(env.enc_dek),
+  private static parseHybridPrivateKey(pem: string): HybridPrivateKey {
+    const raw = MaskuraClient.pemToBytes(pem, HYBRID_PRIVATE_LABEL);
+    const expected = X25519_KEY_LEN + MLKEM_SEED_LEN;
+    if (raw.length !== expected) {
+      throw new Error(`Hybrid private key must contain ${expected} bytes, got ${raw.length}.`);
+    }
+    const mlkem = ml_kem768.keygen(raw.slice(X25519_KEY_LEN));
+    return { x25519Secret: raw.slice(0, X25519_KEY_LEN), mlkemSecret: mlkem.secretKey };
+  }
+
+  private static async decryptHybridEnvelope(env: any, key: HybridPrivateKey): Promise<Uint8Array> {
+    if (env.alg !== HYBRID_ALG) throw new Error(`unsupported alg: ${env.alg}`);
+    const encapsulated = MaskuraClient.b64ToBytes(env.enc_dek);
+    const expected = X25519_KEY_LEN + MLKEM_CIPHERTEXT_LEN;
+    if (encapsulated.length !== expected) {
+      throw new Error(`Hybrid enc_dek must contain ${expected} bytes, got ${encapsulated.length}.`);
+    }
+    const x25519Shared = x25519.getSharedSecret(key.x25519Secret, encapsulated.slice(0, X25519_KEY_LEN));
+    const mlkemShared = ml_kem768.decapsulate(encapsulated.slice(X25519_KEY_LEN), key.mlkemSecret);
+    const dek = hkdf(
+      sha256,
+      MaskuraClient.concat(x25519Shared, mlkemShared),
+      new Uint8Array(0),
+      KDF_INFO,
+      32,
     );
-    const iv = MaskuraClient.b64ToBuf(env.iv);
-    const ct = new Uint8Array(MaskuraClient.b64ToBuf(env.ct));
-    const tag = new Uint8Array(MaskuraClient.b64ToBuf(env.tag));
-    const aead = await subtle.importKey("raw", dek, "AES-GCM", false, ["decrypt"]);
-    const combined = new Uint8Array(ct.length + tag.length);
-    combined.set(ct, 0);
-    combined.set(tag, ct.length);
-    const pt = await subtle.decrypt({ name: "AES-GCM", iv, tagLength: 128 }, aead, combined);
-    return Array.from(new Uint8Array(pt));
+    return MaskuraClient.decryptAesGcm(env, dek);
   }
 
-  private static toPem(der: ArrayBuffer, label: string): string {
-    const bytes = new Uint8Array(der);
-    let bin = "";
-    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]!);
-    const b64 = btoa(bin).replace(/(.{64})/g, "$1\n");
-    return `-----BEGIN ${label}-----\n${b64}\n-----END ${label}-----\n`;
+  private static async importLegacyRsaPrivateKey(pem: string): Promise<CryptoKey> {
+    return globalThis.crypto.subtle.importKey(
+      "pkcs8",
+      MaskuraClient.pemToBytes(pem, "PRIVATE KEY"),
+      { name: "RSA-OAEP", hash: "SHA-256" },
+      false,
+      ["decrypt"],
+    );
   }
 
-  private static pemToDer(pem: string): ArrayBuffer {
-    const b64 = pem.replace(/-----BEGIN [^-]+-----/g, "").replace(/-----END [^-]+-----/g, "").replace(/\s+/g, "");
-    return MaskuraClient.b64ToBuf(b64);
+  private static async decryptLegacyRsaEnvelope(env: any, key: CryptoKey): Promise<Uint8Array> {
+    if (env.alg !== LEGACY_RSA_ALG) throw new Error(`unsupported alg: ${env.alg}`);
+    const dek = await globalThis.crypto.subtle.decrypt(
+      { name: "RSA-OAEP" },
+      key,
+      MaskuraClient.b64ToBytes(env.enc_dek),
+    );
+    return MaskuraClient.decryptAesGcm(env, new Uint8Array(dek));
   }
 
-  private static b64ToBuf(b64: string): ArrayBuffer {
-    const bin = atob(b64);
-    const bytes = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-    return bytes.buffer;
+  private static async decryptAesGcm(env: any, dek: Uint8Array): Promise<Uint8Array> {
+    const subtle = globalThis.crypto.subtle;
+    const key = await subtle.importKey("raw", dek, "AES-GCM", false, ["decrypt"]);
+    const plaintext = await subtle.decrypt(
+      { name: "AES-GCM", iv: MaskuraClient.b64ToBytes(env.iv), tagLength: 128 },
+      key,
+      MaskuraClient.concat(MaskuraClient.b64ToBytes(env.ct), MaskuraClient.b64ToBytes(env.tag)),
+    );
+    return new Uint8Array(plaintext);
+  }
+
+  private static randomBytes(length: number): Uint8Array {
+    return globalThis.crypto.getRandomValues(new Uint8Array(length));
+  }
+
+  private static concat(...arrays: Uint8Array[]): Uint8Array {
+    const output = new Uint8Array(arrays.reduce((sum, value) => sum + value.length, 0));
+    let offset = 0;
+    for (const value of arrays) {
+      output.set(value, offset);
+      offset += value.length;
+    }
+    return output;
+  }
+
+  private static toPem(bytes: Uint8Array, label: string): string {
+    let binary = "";
+    for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+      binary += String.fromCharCode.apply(
+        null,
+        Array.from(bytes.subarray(offset, offset + 0x8000)),
+      );
+    }
+    const body = btoa(binary).match(/.{1,64}/g)?.join("\n") ?? "";
+    return `-----BEGIN ${label}-----\n${body}\n-----END ${label}-----\n`;
+  }
+
+  private static pemToBytes(pem: string, label: string): Uint8Array {
+    const begin = `-----BEGIN ${label}-----`;
+    const end = `-----END ${label}-----`;
+    const value = pem.trim();
+    if (!value.startsWith(begin) || !value.endsWith(end)) {
+      throw new Error(`Expected a ${label} PEM block.`);
+    }
+    return MaskuraClient.b64ToBytes(value.slice(begin.length, -end.length).replace(/\s+/g, ""));
+  }
+
+  private static b64ToBytes(value: string): Uint8Array {
+    const binary = atob(value);
+    return Uint8Array.from(binary, (character) => character.charCodeAt(0));
   }
 
   private static indexOf(haystack: number[], needle: number[], from: number): number {
@@ -216,7 +272,10 @@ export class MaskuraClient {
   }
 }
 
-export type S4ClientOptions = MaskuraClientOptions;
+interface HybridPrivateKey {
+  x25519Secret: Uint8Array;
+  mlkemSecret: Uint8Array;
+}
 
-/** Permanent compatibility export for existing integrations. */
+export type S4ClientOptions = MaskuraClientOptions;
 export class S4Client extends MaskuraClient {}

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -30,10 +30,13 @@
     "build": "tsc"
   },
   "dependencies": {
+    "@noble/curves": "^1.9.7",
+    "@noble/hashes": "^1.8.0",
+    "@noble/post-quantum": "^0.4.1",
     "whatwg-fetch": "^3.0.0",
     "es6-promise": "^4.2.4"
   },
   "devDependencies": {
-    "typescript": "^4.0"
+    "typescript": "^5.9.3"
   }
 }

--- a/sdks/typescript/test/highlevel-crypto.test.cjs
+++ b/sdks/typescript/test/highlevel-crypto.test.cjs
@@ -1,0 +1,100 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { x25519 } = require("@noble/curves/ed25519");
+const { hkdf } = require("@noble/hashes/hkdf");
+const { sha256 } = require("@noble/hashes/sha256");
+const { ml_kem768 } = require("@noble/post-quantum/ml-kem");
+const { MaskuraClient } = require("../dist/highlevel.js");
+
+function pemBytes(pem, label) {
+  return Uint8Array.from(
+    Buffer.from(
+      pem
+        .replace(`-----BEGIN ${label}-----`, "")
+        .replace(`-----END ${label}-----`, "")
+        .replace(/\s+/g, ""),
+      "base64",
+    ),
+  );
+}
+
+function concat(...values) {
+  return Uint8Array.from(Buffer.concat(values.map((value) => Buffer.from(value))));
+}
+
+test("hybrid keypair and gateway envelope round trip", async () => {
+  const pair = await MaskuraClient.generateKeypair();
+  const privateRaw = pemBytes(pair.privateKeyPem, "MASKURA HYBRID PRIVATE KEY");
+  const publicRaw = pemBytes(pair.publicKeyPem, "MASKURA HYBRID PUBLIC KEY");
+  assert.equal(privateRaw.length, 96);
+  assert.equal(publicRaw.length, 1216);
+
+  const ephemeralSecret = crypto.getRandomValues(new Uint8Array(32));
+  const encapsulated = ml_kem768.encapsulate(publicRaw.slice(32));
+  const dek = hkdf(
+    sha256,
+    concat(
+      x25519.getSharedSecret(ephemeralSecret, publicRaw.slice(0, 32)),
+      encapsulated.sharedSecret,
+    ),
+    new Uint8Array(0),
+    new TextEncoder().encode("maskura/hybrid/envelope-dek/v1"),
+    32,
+  );
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await crypto.subtle.importKey("raw", dek, "AES-GCM", false, ["encrypt"]);
+  const sealed = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv, tagLength: 128 },
+      key,
+      new TextEncoder().encode("alice@example.com"),
+    ),
+  );
+  const envelope = {
+    alg: "X25519+ML-KEM-768/AES-256-GCM",
+    iv: Buffer.from(iv).toString("base64"),
+    enc_dek: Buffer.from(
+      concat(x25519.getPublicKey(ephemeralSecret), encapsulated.cipherText),
+    ).toString("base64"),
+    ct: Buffer.from(sealed.slice(0, -16)).toString("base64"),
+    tag: Buffer.from(sealed.slice(-16)).toString("base64"),
+  };
+  const payload = new TextEncoder().encode(`before ${JSON.stringify(envelope)} after`);
+  const plaintext = await MaskuraClient.decryptPayload(payload, pair.privateKeyPem);
+  assert.equal(new TextDecoder().decode(plaintext), "before alice@example.com after");
+});
+
+test("legacy RSA envelopes remain readable", async () => {
+  const pair = await MaskuraClient.generateLegacyRsaKeypair();
+  const publicKey = await crypto.subtle.importKey(
+    "spki",
+    pemBytes(pair.publicKeyPem, "PUBLIC KEY"),
+    { name: "RSA-OAEP", hash: "SHA-256" },
+    false,
+    ["encrypt"],
+  );
+  const dek = crypto.getRandomValues(new Uint8Array(32));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const aesKey = await crypto.subtle.importKey("raw", dek, "AES-GCM", false, ["encrypt"]);
+  const sealed = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv, tagLength: 128 },
+      aesKey,
+      new TextEncoder().encode("legacy@example.com"),
+    ),
+  );
+  const envelope = {
+    alg: "RSA-OAEP/AES-256-GCM",
+    iv: Buffer.from(iv).toString("base64"),
+    enc_dek: Buffer.from(await crypto.subtle.encrypt({ name: "RSA-OAEP" }, publicKey, dek)).toString(
+      "base64",
+    ),
+    ct: Buffer.from(sealed.slice(0, -16)).toString("base64"),
+    tag: Buffer.from(sealed.slice(-16)).toString("base64"),
+  };
+  const plaintext = await MaskuraClient.decryptPayload(
+    new TextEncoder().encode(JSON.stringify(envelope)),
+    pair.privateKeyPem,
+  );
+  assert.equal(new TextDecoder().decode(plaintext), "legacy@example.com");
+});


### PR DESCRIPTION
## Summary
- make hybrid X25519 + ML-KEM-768 key generation and decryption the default in the Python and TypeScript high-level clients
- add matching key generation and local decrypt support to the Maskura CLI with owner-only, create-new private-key files
- retain explicit read compatibility for legacy RSA envelopes
- preserve the hand-written client layer through OpenAPI regeneration and exercise both SDKs in CI

## Verification
- === Building noop (WASI) ===
- Python SDK: 24 tests passed
- TypeScript SDK: build + 3 crypto/client tests passed
- Rust CLI/gateway deterministic hybrid vector round-trip