### PR TITLE
security: remediate CodeQL findings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ sections that do not.
 
 ## Test plan
 
-- [ ] `just check` (fmt + clippy + build filters + tests)
+- [ ] `just pre-push` (checks + Rust/Python/npm dependency audits)
 - [ ] `just e2e` (if gateway/data-plane behavior changed)
 - [ ] `cargo check -p s4-gateway` (dashboard/HTML changes — embedded via include_str!)
 - [ ] `mdbook build docs` (if `docs/` chapters changed)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,10 +177,9 @@ jobs:
         run: |
           cargo install --locked cargo-audit --version 0.22.2
           cargo install --locked cargo-deny --version 0.20.2
-      - name: RustSec advisory audit
-        run: bash scripts/audit-rust.sh
-      - name: Dependency policy audit
-        run: cargo deny check
+          python3 -m pip install pip-audit==2.9.0
+      - name: Dependency and supply-chain audit
+        run: bash scripts/audit-dependencies.sh
 
   dependency-review:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,10 @@ Thanks for considering a contribution to Maskura.
 1. Fork [Maskura on GitHub](https://github.com/231self/maskura/fork) and clone your fork.
 2. Install Rust 1.97.0 (see `rust-toolchain.toml`) with the `wasm32-wasip1` target:
    `rustup target add wasm32-wasip1`
-3. Install `wasm-tools` (`cargo install --locked wasm-tools --version 1.255.0`) and `just`.
-4. Run `just check` — it must pass locally before opening a PR.
+3. Install `wasm-tools` (`cargo install --locked wasm-tools --version 1.255.0`),
+   `cargo-audit`, `cargo-deny`, `just`, `uv`, and Node.js/npm.
+4. Run `just pre-push` — it must pass locally before publishing a bookmark or
+   opening a PR. `just push` runs that gate and then `jj git push`.
 
 ## Conventions
 
@@ -45,8 +47,10 @@ Thanks for considering a contribution to Maskura.
 ## Testing
 
 ```bash
-just check        # full gate
-just e2e          # MinIO end-to-end (Docker)
+just check          # correctness gate
+just pre-push       # correctness + dependency/security policy
+just push           # pre-push gate + jj git push
+just e2e            # MinIO end-to-end (Docker)
 cargo test --workspace
 ```
 

--- a/README.md
+++ b/README.md
@@ -332,10 +332,19 @@ S3 SDK / CLI / tool ──▶ Maskura Gateway (Wasm plugin pipeline) ──▶ s
 ## Development
 
 ```bash
-just check        # fmt + clippy + build filters + tests
-just e2e          # end-to-end against MinIO (Docker)
-just build-sdks   # regenerate Python/TypeScript SDKs from the OpenAPI spec
+just check          # fmt + clippy + build filters + tests
+just pre-push       # check + Rust/Python/npm advisories + dependency policy
+just push           # run pre-push, then publish the current jj bookmark
+just e2e            # end-to-end against MinIO (Docker)
+just build-sdks     # regenerate Python/TypeScript SDKs from the OpenAPI spec
 ```
+
+`just pre-push` is the local trust gate: it mirrors the dependency-security
+checks that would otherwise first appear in GitHub, and verifies that Actions
+and Docker base images remain pinned to immutable revisions. It requires
+`cargo-audit`, `cargo-deny`, `uvx`, and `npm`. Dependabot still handles scheduled
+update discovery; the local gate blocks known vulnerable dependencies before a
+push.
 
 ### Run CI/release locally (no GitHub minutes)
 

--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ docker run --rm -p 8080:8080 -v maskura-data:/data \
   ghcr.io/231self/maskura/maskura:latest
 ```
 
-The local-mode startup output prints `MASKURA_ACCESS_KEY` and
-`MASKURA_SECRET_KEY`. Use them with the CLI or `aws --endpoint-url
-http://localhost:8080 s3 ...`. Objects, local API keys, and in-progress staged
+With `AUTH_DISABLED=true`, clients can use any non-empty placeholder credentials;
+the quickstart uses `demo`. The gateway never prints generated key secrets to its
+logs. Objects, local API keys, and in-progress staged
 multipart uploads survive container restarts through the mounted volume. Keep
 the `.maskura/wrapping.key` file with the volume backup; losing it makes
 encrypted incomplete uploads unrecoverable.

--- a/crates/gateway/src/read_spool.rs
+++ b/crates/gateway/src/read_spool.rs
@@ -53,12 +53,9 @@ impl EncryptedReadSpool {
                 "transformed-read spool object limit must be greater than zero".to_string(),
             ));
         }
+        let directory = prepare_spool_directory(directory).await?;
         let reserved_bytes = disk_reservation(max_object_bytes)?;
         quota.reserve_bytes(reserved_bytes)?;
-        if let Err(error) = tokio::fs::create_dir_all(&directory).await {
-            quota.release_bytes(reserved_bytes);
-            return Err(TransactionError::Spool(error.to_string()));
-        }
         let path = directory.join(format!("{READ_FILE_PREFIX}{}.tmp", Uuid::now_v7()));
         let mut options = OpenOptions::new();
         options.create_new(true).write(true);
@@ -199,6 +196,30 @@ impl EncryptedReadSpool {
     pub fn path(&self) -> &std::path::Path {
         &self.path
     }
+}
+
+async fn prepare_spool_directory(directory: PathBuf) -> Result<PathBuf, TransactionError> {
+    tokio::fs::create_dir_all(&directory)
+        .await
+        .map_err(spool_error)?;
+    let metadata = tokio::fs::symlink_metadata(&directory)
+        .await
+        .map_err(spool_error)?;
+    if !metadata.file_type().is_dir() {
+        return Err(TransactionError::Spool(
+            "transformed-read spool path must be a directory, not a symlink or file".to_string(),
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        tokio::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o700))
+            .await
+            .map_err(spool_error)?;
+    }
+    tokio::fs::canonicalize(directory)
+        .await
+        .map_err(spool_error)
 }
 
 impl Drop for EncryptedReadSpool {
@@ -389,6 +410,8 @@ mod tests {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt as _;
+            let directory_mode = std::fs::metadata(&directory).unwrap().permissions().mode();
+            assert_eq!(directory_mode & 0o777, 0o700);
             let mode = std::fs::metadata(spool.path())
                 .unwrap()
                 .permissions()
@@ -403,6 +426,28 @@ mod tests {
         spool.abort().await;
         assert_eq!(quota.reserved_bytes(), 0);
         let _ = tokio::fs::remove_dir(directory).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spool_directory_symlink_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let root = directory();
+        let target = root.join("target");
+        let link = root.join("link");
+        tokio::fs::create_dir_all(&target).await.unwrap();
+        symlink(&target, &link).unwrap();
+
+        let error = EncryptedReadSpool::begin(link, 8, Arc::new(SpoolQuota::new(64)))
+            .await
+            .err()
+            .expect("symlink spool directory must fail");
+        assert!(error.to_string().contains("must be a directory"));
+
+        tokio::fs::remove_file(root.join("link")).await.unwrap();
+        tokio::fs::remove_dir(target).await.unwrap();
+        tokio::fs::remove_dir(root).await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -12474,22 +12474,17 @@ pub async fn build_state_with_pipeline_template(
             .map_err(|error| anyhow::anyhow!(error.to_string()))?;
     }
 
-    // Local mode: ensure a demo key exists and print it so SDK demos and
-    // `aws s3 --endpoint-url` work out of the box.
+    // Local mode: ensure a demo principal exists for plugin context. Auth is
+    // disabled, so clients use non-secret placeholder credentials and the
+    // generated key secret must never be written to process logs.
     if auth_disabled {
         let demo_workspace = workspace_storage.resolve_workspace("demo-user").await?;
         let existing = keys.list_for_user("demo-user").await?;
         if existing.is_empty() {
-            let (secret, created) = keys
+            let (_secret, created) = keys
                 .create_key("demo-user", &demo_workspace, "local-default", 0, None)
                 .await?;
-            println!("MASKURA_ACCESS_KEY={}", created.key_id);
-            println!("MASKURA_SECRET_KEY={secret}");
-        } else if let Some(k) = existing.into_iter().find(|k| k.label == "local-default")
-            && let Some(secret) = keys.decrypt_secret(&k.key_id).await?
-        {
-            println!("MASKURA_ACCESS_KEY={}", k.key_id);
-            println!("MASKURA_SECRET_KEY={secret}");
+            info!(key_id = %created.key_id, "created local demo API key");
         }
     }
 

--- a/crates/s4-mcp/src/main.rs
+++ b/crates/s4-mcp/src/main.rs
@@ -17,7 +17,7 @@ use rmcp::model::{CallToolResult, ContentBlock, Implementation, ServerCapabiliti
 use rmcp::tool;
 use rmcp::transport::stdio;
 use rmcp::{ErrorData as McpError, ServerHandler, ServiceExt, tool_handler, tool_router};
-use url::Url;
+use url::{Host, Url};
 
 const DEFAULT_GATEWAY_URL: &str = "http://localhost:8080";
 const MAX_TEXT_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
@@ -71,6 +71,11 @@ impl Config {
         if !matches!(gateway_url.scheme(), "http" | "https") || gateway_url.host().is_none() {
             anyhow::bail!("MASKURA_GATEWAY_URL must be an absolute HTTP(S) URL");
         }
+        if gateway_url.scheme() == "http" && !is_loopback_url(&gateway_url) {
+            anyhow::bail!(
+                "MASKURA_GATEWAY_URL must use HTTPS unless it targets a loopback address"
+            );
+        }
 
         let auth = if let Some(token) = mcp_token {
             GatewayAuth::McpToken(parse_secret_header("MASKURA_MCP_TOKEN", &token)?)
@@ -109,6 +114,15 @@ impl Config {
             }
         }
         headers
+    }
+}
+
+fn is_loopback_url(url: &Url) -> bool {
+    match url.host() {
+        Some(Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(address)) => address.is_loopback(),
+        Some(Host::Ipv6(address)) => address.is_loopback(),
+        None => false,
     }
 }
 
@@ -608,6 +622,42 @@ mod tests {
         .to_string();
         assert!(error.contains("MASKURA_MCP_TOKEN"));
         assert!(!error.contains("secret"));
+    }
+
+    #[test]
+    fn config_rejects_cleartext_non_loopback_gateways() {
+        let error = Config::new(
+            "http://gateway.example.com:8080",
+            Some("token".to_string()),
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("HTTPS"));
+    }
+
+    #[test]
+    fn config_accepts_https_and_ip_loopback_gateways() {
+        assert!(
+            Config::new(
+                "https://gateway.example.com",
+                Some("token".to_string()),
+                None,
+                None,
+            )
+            .is_ok()
+        );
+        assert!(
+            Config::new(
+                "http://127.0.0.1:8080",
+                Some("token".to_string()),
+                None,
+                None,
+            )
+            .is_ok()
+        );
+        assert!(Config::new("http://[::1]:8080", Some("token".to_string()), None, None,).is_ok());
     }
 
     #[test]

--- a/crates/s4ctl/src/main.rs
+++ b/crates/s4ctl/src/main.rs
@@ -1414,8 +1414,8 @@ async fn main() -> anyhow::Result<()> {
                         );
                         println!("# Or with curl:");
                         println!("curl -X PUT \"{}\" \\", url);
-                        println!("  -H \"x-maskura-access-key: {}\" \\", client.access_key);
-                        println!("  -H \"x-maskura-secret-key: {}\"", client.secret_key);
+                        println!("  -H \"x-maskura-access-key: $MASKURA_ACCESS_KEY\" \\");
+                        println!("  -H \"x-maskura-secret-key: $MASKURA_SECRET_KEY\"");
                         println!("  --data-binary @file");
                     } else {
                         let err = String::from_utf8_lossy(&status.stderr);

--- a/docs/adr/0010-workspace-bound-hosted-mcp.md
+++ b/docs/adr/0010-workspace-bound-hosted-mcp.md
@@ -36,7 +36,9 @@ workspace after insertion.
 Transport-independent MCP request schemas, result types, validation, tool
 definitions, legacy aliases, dispatch, and S3 list parsing live in the small
 `maskura-mcp-protocol` crate. The stdio binary consumes those types and
-continues to call the network S3 surface with its configured credential.
+continues to call the network S3 surface with its configured credential. The
+stdio client sends credentials over HTTPS only, except when the configured host
+is a literal loopback address; non-loopback cleartext HTTP fails during startup.
 
 Hosted adapters use `s4_gateway::server::invoke_mcp`. They provide an already
 authenticated `AuthenticatedMcpPrincipal`, server operation UUID, typed tool
@@ -55,6 +57,8 @@ authentication, metering, backend, or presigned URL headers.
   usage paths as S3 without opening a loopback listener.
 - Text MCP bodies and responses have non-configurable hard ceilings. The
   private transport remains responsible for envelope and chunk preparse bounds.
+- Local stdio development remains simple over loopback HTTP, while a
+  misconfigured remote gateway cannot receive MCP or API credentials in cleartext.
 - Cancellation reaches active Wasm work and waits for gateway settlement;
   provider SDK calls that do not expose cooperative cancellation may complete
   before the invocation returns its committed outcome.

--- a/docs/adr/0014-supply-chain-security.md
+++ b/docs/adr/0014-supply-chain-security.md
@@ -17,9 +17,15 @@ origin and dependency inventory of a downloaded release.
 Every external GitHub Action is referenced by a full commit SHA, with the
 human-readable release line retained as a comment for update tooling and
 reviewers. The aggregate `check` required on `main` includes `cargo audit`,
-`cargo deny`, dependency-diff review, and CodeQL analysis of Rust, Python,
-JavaScript/TypeScript, and GitHub Actions workflows in addition to the existing
-format, lint, test, SDK, database, interoperability, and end-to-end jobs.
+`cargo deny`, `pip-audit`, `npm audit`, dependency-diff review, and CodeQL
+analysis of Rust, Python, JavaScript/TypeScript, and GitHub Actions workflows in
+addition to the existing format, lint, test, SDK, database, interoperability,
+and end-to-end jobs.
+
+`just pre-push` is the canonical local gate. It runs the correctness suite, the
+same Rust, Python, and npm dependency audits, and immutable-reference checks for
+workflow actions and container base images. `just push` runs that gate before
+delegating publication to `jj git push`.
 
 The RustSec audit has one narrowly guarded exception for RUSTSEC-2023-0071.
 SQLx's compile-time migration macro records the vulnerable `rsa` crate through
@@ -44,8 +50,9 @@ set as the Linux binaries. The release also includes the repository SBOM.
 behavior; dependency updates require an explicit reviewed SHA change.
 - Dependabot proposes grouped weekly updates for Rust, both generated SDKs,
   GitHub Actions, and container images; security updates remain enabled.
-- Newly disclosed Rust advisories or dependency-policy violations block the
-  aggregate merge check rather than remaining a local-only command.
+- Newly disclosed Rust, Python, or npm advisories and dependency-policy
+  violations block the aggregate merge check rather than remaining a
+  local-only command.
 - Code scanning covers source, generated clients, and workflow code and
   publishes findings through GitHub's security surface.
 - Release consumers can verify file hashes, inspect the SBOM, and validate

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -11,7 +11,8 @@ object tools to Claude, Codex, Cursor, and other MCP clients:
 The stdio server does not implement a second storage or processing path. Every tool
 calls the Maskura Gateway's S3-compatible HTTP surface, so gateway authentication,
 the configured plugin pipeline, backend selection, limits, and metering still
-apply.
+apply. Credential-bearing connections require HTTPS; cleartext HTTP is accepted
+only for literal loopback hosts (`localhost`, `127.0.0.0/8`, or `::1`).
 
 ## Install
 

--- a/justfile
+++ b/justfile
@@ -17,10 +17,10 @@ check-fmt:
   cargo fmt --check
 
 check-lint:
-  cargo clippy --all-targets -- -D warnings
+  cargo clippy --locked --all-targets -- -D warnings
 
 test:
-  cargo test --workspace
+  cargo test --locked --workspace
 
 build-filters:
   bash scripts/build-filters.sh
@@ -31,7 +31,19 @@ deny:
 audit:
   bash scripts/audit-rust.sh
 
-# Meta-linter: runs all static checks + dependency audit (like ruff/golangci-lint)
+# Audit every shipped dependency ecosystem and verify immutable build inputs.
+audit-dependencies:
+  bash scripts/audit-dependencies.sh
+
+# Canonical local gate before publishing a jj bookmark.
+pre-push: check audit-dependencies
+  @echo "Pre-push checks passed"
+
+# Safe publishing path for this jj repository. Extra arguments are passed to jj.
+push *args: pre-push
+  jj git push {{args}}
+
+# Meta-linter: runs all static checks + Rust dependency policy
 lint: check-fmt check-lint deny
   @echo "Meta-lint passed"
 

--- a/scripts/audit-dependencies.sh
+++ b/scripts/audit-dependencies.sh
@@ -12,8 +12,8 @@ require_command() {
 }
 
 require_command cargo
+require_command grep
 require_command npm
-require_command rg
 
 echo "==> Rust advisories"
 bash scripts/audit-rust.sh
@@ -48,16 +48,16 @@ cp sdks/typescript/package.json "$npm_audit_dir/package.json"
 )
 
 echo "==> Immutable CI and container references"
-if rg --pcre2 -n \
-  'uses:\s+(?!\./)[^@[:space:]]+@(?![0-9a-f]{40}(?:[[:space:]]|$))' \
-  .github/workflows; then
+if grep -REn \
+  'uses:[[:space:]]+[^./[:space:]][^[:space:]]*@' \
+  .github/workflows \
+  | grep -Ev '@[0-9a-f]{40}([[:space:]]|$)'; then
   echo "error: external GitHub Actions must use a full 40-character commit SHA" >&2
   exit 1
 fi
 
-if rg --pcre2 -n \
-  '^FROM\s+[^@[:space:]]+(?::[^@[:space:]]+)?(?!@sha256:[0-9a-f]{64})(?:\s+AS\s+.*)?$' \
-  Dockerfile Dockerfile.release; then
+if grep -nE '^FROM[[:space:]]+' Dockerfile Dockerfile.release \
+  | grep -Ev '@sha256:[0-9a-f]{64}([[:space:]]|$)'; then
   echo "error: Docker base images must use an immutable sha256 digest" >&2
   exit 1
 fi

--- a/scripts/audit-dependencies.sh
+++ b/scripts/audit-dependencies.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: $1 is required for the dependency audit" >&2
+    exit 1
+  fi
+}
+
+require_command cargo
+require_command npm
+require_command rg
+
+echo "==> Rust advisories"
+bash scripts/audit-rust.sh
+
+echo "==> Rust dependency policy"
+cargo deny check --hide-inclusion-graph
+
+echo "==> Python advisories"
+if command -v uvx >/dev/null 2>&1; then
+  uvx --from pip-audit==2.9.0 pip-audit \
+    --strict \
+    --progress-spinner off \
+    --requirement sdks/python/requirements.txt
+elif python3 -c 'import pip_audit' >/dev/null 2>&1; then
+  python3 -m pip_audit \
+    --strict \
+    --progress-spinner off \
+    --requirement sdks/python/requirements.txt
+else
+  echo "error: install uv or pip-audit 2.9.0 for the Python dependency audit" >&2
+  exit 1
+fi
+
+echo "==> TypeScript advisories"
+npm_audit_dir="$(mktemp -d)"
+trap 'rm -rf -- "$npm_audit_dir"' EXIT
+cp sdks/typescript/package.json "$npm_audit_dir/package.json"
+(
+  cd "$npm_audit_dir"
+  npm install --package-lock-only --ignore-scripts --no-audit --no-fund >/dev/null
+  npm audit
+)
+
+echo "==> Immutable CI and container references"
+if rg --pcre2 -n \
+  'uses:\s+(?!\./)[^@[:space:]]+@(?![0-9a-f]{40}(?:[[:space:]]|$))' \
+  .github/workflows; then
+  echo "error: external GitHub Actions must use a full 40-character commit SHA" >&2
+  exit 1
+fi
+
+if rg --pcre2 -n \
+  '^FROM\s+[^@[:space:]]+(?::[^@[:space:]]+)?(?!@sha256:[0-9a-f]{64})(?:\s+AS\s+.*)?$' \
+  Dockerfile Dockerfile.release; then
+  echo "error: Docker base images must use an immutable sha256 digest" >&2
+  exit 1
+fi
+
+echo "Dependency and supply-chain audits passed"

--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -122,6 +122,14 @@ from pathlib import Path
 import sys
 
 root = Path(sys.argv[1])
+api_client = root.joinpath("s4_client/api_client.py")
+api_client_source = api_client.read_text()
+unsafe_json_suffix = r"[\w!#$&.+-^_]+"
+safe_json_suffix = r"[\w!#$&.+^_-]+"
+if unsafe_json_suffix not in api_client_source:
+    raise SystemExit("generated Python JSON media-type expression changed upstream")
+api_client.write_text(api_client_source.replace(unsafe_json_suffix, safe_json_suffix))
+
 pyproject = root.joinpath("pyproject.toml").read_text()
 pyproject = pyproject.replace('name = "s4_client"', 'name = "maskura_client"', 1)
 pyproject = pyproject.replace(

--- a/sdks/python/s4_client/api_client.py
+++ b/sdks/python/s4_client/api_client.py
@@ -408,7 +408,7 @@ class ApiClient:
                 data = json.loads(response_text)
             except ValueError:
                 data = response_text
-        elif re.match(r'^application/(json|[\w!#$&.+-^_]+\+json)\s*(;|$)', content_type, re.IGNORECASE):
+        elif re.match(r'^application/(json|[\w!#$&.+^_-]+\+json)\s*(;|$)', content_type, re.IGNORECASE):
             if response_text == "":
                 data = ""
             else:


### PR DESCRIPTION
## Summary

- require HTTPS for credential-bearing stdio MCP connections, while retaining literal loopback HTTP for local development
- stop the auth-disabled gateway from printing generated API secrets and stop CLI presign output from echoing stored credentials
- harden transformed-read spool directories with symlink rejection, canonical paths, and owner-only permissions
- repair the generated Python JSON media-type regex and make the SDK generator reapply and verify the fix
- add a canonical `just pre-push` gate and `just push` jj wrapper; audit Rust, Python, and npm dependencies locally and in CI
- verify GitHub Actions and Docker base images stay pinned to immutable revisions
- document the MCP transport and supply-chain trust boundaries in the existing ADRs and public guides

## CodeQL triage

This addresses the actionable production findings surfaced when `security-extended` became active on `main`. The three PR findings on the transformed-read spool were reviewed and dismissed as false positives with specific recorded justifications: the path is operator-only startup configuration, not request data, and is symlink-checked, mode-restricted, canonicalized, and used only with UUID `create_new` files. After merge and a fresh default-branch scan, remaining findings will be triaged individually: deterministic test vectors, zero-initialized buffers overwritten by CSPRNG/KDF/read operations, an intentional reveal-once CLI response, and test-only database fixtures.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --workspace` (full suite)
- Python SDK: 24 tests
- TypeScript SDK: build + 3 tests
- SDK regenerated from OpenAPI; generated output is stable
- MCP stdio end-to-end round trip
- `just audit-dependencies`: RustSec, cargo-deny, pip-audit, npm audit, immutable-reference checks
- README contains no legacy `s4` spellings or literal `<release-tag>`; runnable Docker examples use the published multi-arch `:latest` tag
