### PR TITLE
docs: require guarded jj pushes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ sections that do not.
 
 ## Test plan
 
-- [ ] `just pre-push` (checks + Rust/Python/npm dependency audits)
+- [ ] `just pre-push` (fmt/clippy + Rust/Python/npm dependency audits)
 - [ ] `just e2e` (if gateway/data-plane behavior changed)
 - [ ] `cargo check -p s4-gateway` (dashboard/HTML changes — embedded via include_str!)
 - [ ] `mdbook build docs` (if `docs/` chapters changed)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,12 +8,16 @@ This is a **jj** repository. Do not use `git` directly for mutations.
 jj st                # show working copy status
 jj log               # show commit history
 jj commit -m "msg"   # commit working copy changes
-jj git push          # push to origin
+just pre-push         # required local correctness + security gate
+just push             # run the gate, then push with jj
 jj git fetch         # fetch from origin
 ```
 
 All commits require a description (-m). Avoid interactive flags.
 Verify with `jj st` and `jj log` after each mutation.
+Always use `just push` to publish changes. A direct `jj git push` bypasses the
+local gate and is allowed only after `just pre-push` has passed in the same
+working copy.
 
 Author identity: commit as `amit231self <amit@231self.com>` (jj user config).
 Never append AI `Co-Authored-By` / `Generated with <tool>` trailers (Claude,
@@ -31,6 +35,8 @@ owner after an explicit, documented decision.
 - `just build-sdks` — generate Python + TypeScript client SDKs from OpenAPI spec
 - `just deny` — run cargo-deny
 - `just audit` — run cargo-audit
+- `just pre-push` — format/lint plus Rust/Python/npm dependency and pinning audits
+- `just push` — required guarded wrapper around `jj git push`
 
 ## Code Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Thanks for considering a contribution to Maskura.
 
 ```bash
 just check          # correctness gate
-just pre-push       # correctness + dependency/security policy
+just pre-push       # fmt/clippy + dependency/security policy
 just push           # pre-push gate + jj git push
 just e2e            # MinIO end-to-end (Docker)
 cargo test --workspace

--- a/README.md
+++ b/README.md
@@ -333,18 +333,18 @@ S3 SDK / CLI / tool ──▶ Maskura Gateway (Wasm plugin pipeline) ──▶ s
 
 ```bash
 just check          # fmt + clippy + build filters + tests
-just pre-push       # check + Rust/Python/npm advisories + dependency policy
+just pre-push       # fmt/clippy + Rust/Python/npm advisories + pin policy
 just push           # run pre-push, then publish the current jj bookmark
 just e2e            # end-to-end against MinIO (Docker)
 just build-sdks     # regenerate Python/TypeScript SDKs from the OpenAPI spec
 ```
 
-`just pre-push` is the local trust gate: it mirrors the dependency-security
-checks that would otherwise first appear in GitHub, and verifies that Actions
-and Docker base images remain pinned to immutable revisions. It requires
-`cargo-audit`, `cargo-deny`, `uvx`, and `npm`. Dependabot still handles scheduled
-update discovery; the local gate blocks known vulnerable dependencies before a
-push.
+`just pre-push` is the fast local trust gate: it runs formatting and clippy,
+mirrors the dependency-security checks that would otherwise first appear in
+GitHub, and verifies that Actions and Docker base images remain pinned to
+immutable revisions. It requires `cargo-audit`, `cargo-deny`, `uvx`, and `npm`.
+Dependabot still handles scheduled update discovery; protected CI runs the long
+Wasm, test, SDK, database, interoperability, and end-to-end suites.
 
 ### Run CI/release locally (no GitHub minutes)
 

--- a/docs/adr/0014-supply-chain-security.md
+++ b/docs/adr/0014-supply-chain-security.md
@@ -22,10 +22,12 @@ analysis of Rust, Python, JavaScript/TypeScript, and GitHub Actions workflows in
 addition to the existing format, lint, test, SDK, database, interoperability,
 and end-to-end jobs.
 
-`just pre-push` is the canonical local gate. It runs the correctness suite, the
-same Rust, Python, and npm dependency audits, and immutable-reference checks for
-workflow actions and container base images. `just push` runs that gate before
-delegating publication to `jj git push`.
+`just pre-push` is the canonical fast local gate. It runs formatting and
+clippy, the same Rust, Python, and npm dependency audits, and
+immutable-reference checks for workflow actions and container base images.
+The protected CI remains responsible for the long Wasm, SDK, database,
+interoperability, end-to-end, and full test suites. `just push` runs the local
+gate before delegating publication to `jj git push`.
 
 The RustSec audit has one narrowly guarded exception for RUSTSEC-2023-0071.
 SQLx's compile-time migration macro records the vulnerable `rsa` crate through

--- a/justfile
+++ b/justfile
@@ -35,8 +35,9 @@ audit:
 audit-dependencies:
   bash scripts/audit-dependencies.sh
 
-# Canonical local gate before publishing a jj bookmark.
-pre-push: check audit-dependencies
+# Canonical fast local gate before publishing a jj bookmark. The protected CI
+# remains responsible for the long Wasm, SDK, database, interop, and E2E suites.
+pre-push: check-fast audit-dependencies
   @echo "Pre-push checks passed"
 
 # Safe publishing path for this jj repository. Extra arguments are passed to jj.


### PR DESCRIPTION
## Summary

- require agents to publish through the guarded `just push` wrapper
- retain direct `jj git push` only after the same working copy passes `just pre-push`
- keep the local gate fast enough to use on every push: fmt, clippy, Rust/Python/npm advisories, dependency policy, and immutable pins
- leave the long Wasm, SDK, database, interoperability, E2E, and full test suites enforced by protected CI

## Verification

- `just pre-push`
- `just push --bookmark codex/require-pre-push-gate`
