### PR TITLE
Wire release notes and Discord announcements

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -1,0 +1,64 @@
+name: Announce release
+
+# Manually (re)announce an already-published release to Discord, or build the
+# payload with dry_run to preview it. Kept separate from release.yml so the
+# tag-triggered release path stays free of dispatch/ref ambiguity.
+#
+# Secrets: DISCORD_WEBHOOK_URL (see docs/adr/0015-release-notes-and-discord-notifications.md).
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to announce (e.g. v0.6.0)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Build the Discord payload but do not post'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: announce-release-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+      DRY_RUN: ${{ inputs.dry_run }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Validate release tag
+        run: |
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Refusing invalid release tag: ${RELEASE_TAG}" >&2
+            exit 1
+          fi
+
+      - name: Fetch published release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view "${RELEASE_TAG}" \
+            --repo "${{ github.repository }}" \
+            --json body -q .body > release-notes.md
+          test -s release-notes.md
+
+      - name: Post to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ "${DRY_RUN}" = "true" ]; then
+            bash scripts/post-release-discord.sh "${RELEASE_TAG}" release-notes.md --dry-run
+          else
+            bash scripts/post-release-discord.sh "${RELEASE_TAG}" release-notes.md
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,10 @@ jobs:
         run: cargo fmt --check
       - name: Proof harness syntax
         run: |
-          bash -n examples/prove-maskura.sh examples/local-quickstart.sh examples/maskura-demo.sh scripts/bench-filters.sh
+          bash -n examples/prove-maskura.sh examples/local-quickstart.sh examples/maskura-demo.sh scripts/bench-filters.sh scripts/release-notes.sh scripts/post-release-discord.sh scripts/test-release-notifications.sh
           python3 -c 'import ast, pathlib; [ast.parse(path.read_text()) for path in map(pathlib.Path, ["examples/python-hybrid-roundtrip.py", "scripts/check-release-contract.py"])]'
           python3 scripts/check-release-contract.py
+          bash scripts/test-release-notifications.sh
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,17 +325,24 @@ jobs:
           gh api -X PATCH "/orgs/${{ github.repository_owner }}/packages/container/s4%2Fs4" \
             -f visibility=public
 
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: bash scripts/release-notes.sh "${{ github.ref_name }}" release-notes.md
+
       - name: Create GitHub Release
+        id: github-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          notes=()
-          notes_file="docs/releases/${{ github.ref_name }}.md"
-          if [ -f "$notes_file" ]; then
-            # The file's H1 is useful in mdBook; the GitHub Release already
-            # supplies its own title, so prepend the body below that heading.
-            notes=(--notes "$(tail -n +3 "$notes_file")")
+          if gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "release ${{ github.ref_name }} already exists; leaving it unchanged (no re-announce)"
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
           gh release create "${{ github.ref_name }}" \
              dist/maskura-gateway-linux-x86_64 \
              dist/s4-gateway-linux-x86_64 \
@@ -363,8 +370,16 @@ jobs:
              --repo "${{ github.repository }}" \
              --verify-tag \
              --fail-on-no-commits \
-             --generate-notes \
-             "${notes[@]}"
+             --notes-file release-notes.md
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Announce release on Discord
+        if: steps.github-release.outputs.created == 'true'
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: bash scripts/post-release-discord.sh "${{ github.ref_name }}" release-notes.md
 
   verify-release:
     needs: release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,12 @@ Document every infrastructure, auth, storage, and deployment choice so automatio
 - All secrets via environment variables, never in source or committed config.
 - `LISTEN_ADDR`, `S3_ENDPOINT`, `DATABASE_URL`, `SUPABASE_JWT_SECRET`, `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and the explicit customer/operator settings documented in `docs/security.md`.
 - Local dev uses Supabase CLI default credentials.
+- **Release automation** (`.github/workflows/release.yml`): `DEEPSEEK_API_KEY`
+  (optional; authors release notes with a GitHub-generated fallback),
+  `DISCORD_WEBHOOK_URL` (announces new releases), and `RELEASE_TOKEN` (the
+  fine-grained PAT used by `.github/workflows/tag-on-version-bump.yml` to push
+  `v*` tags so the release workflow fires). Maintainers configure these as
+  GitHub Actions repository secrets. See ADR 0015.
 
 ### Key Formats
 

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -17,7 +17,9 @@ here, extend `CODEOWNERS`, and then enable required CODEOWNERS reviews on
   Architecture Decision Records in `docs/adr/` and merged with their change.
 - Releases are cut from `main` by the release workflow and published as
   GitHub Releases with prebuilt binaries and the canonical/legacy container
-  images.
+  images. Release notes are authored in CI (DeepSeek, with a GitHub-generated
+  fallback) and announced to Discord; see
+  `docs/adr/0015-release-notes-and-discord-notifications.md`.
 
 ## Architecture Decision Records
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -31,3 +31,4 @@
 - [ADR 0012: Local filesystem object storage](adr/0012-local-filesystem-object-storage.md)
 - [ADR 0013: Durable local multipart storage](adr/0013-durable-local-multipart-storage.md)
 - [ADR 0014: Supply-chain security and release provenance](adr/0014-supply-chain-security.md)
+- [ADR 0015: LLM-authored release notes and Discord announcements](adr/0015-release-notes-and-discord-notifications.md)

--- a/docs/adr/0015-release-notes-and-discord-notifications.md
+++ b/docs/adr/0015-release-notes-and-discord-notifications.md
@@ -1,0 +1,75 @@
+# ADR 0015: LLM-authored release notes and Discord announcements
+
+- Status: Accepted
+- Date: 2026-09-10
+
+## Context
+
+Releases are cut from `main` by `.github/workflows/release.yml` on `v*` tags.
+GitHub Releases previously used GitHub's raw list of merged-PR titles. That
+text is accurate but reads as an internal changelog: it has no summary,
+grouping, or upgrade guidance, so it is a weak official note for users.
+
+There was also no channel for telling users that a version shipped. An earlier
+proposal used the Reddit API to post to r/maskura, but Reddit requires a
+registered OAuth application and either a stored account password or a
+one-time refresh-token exchange, plus a moderator or approved-submitter
+relationship for the posting account. For a one-way release notification,
+that is a disproportionate credential and trust surface. A Discord Incoming
+Webhook needs a single URL, no bot, no OAuth, and no user account in the loop.
+
+## Decision
+
+Release notes are authored in CI with no required human step:
+
+1. `scripts/release-notes.sh` fetches GitHub's PR-based generated notes for the
+   tag through the `releases/generate-notes` API. This reuses GitHub's merged-PR
+   discovery instead of reimplementing it.
+2. When `DEEPSEEK_API_KEY` is present, that text is rewritten by the DeepSeek
+   chat API (`deepseek-chat`, overridable with `DEEPSEEK_MODEL`) into a summary
+   plus grouped highlights, with breaking-change and upgrade sections only
+   when the input supports them. The prompt forbids inventing features,
+   versions, dates, or links and requires retaining input PR references.
+3. On a missing key, network error, timeout, non-success status, or empty
+   response, the script falls back to GitHub's generated notes. The LLM is an
+   optional editorial pass, never a release dependency.
+
+The resulting notes become both the GitHub Release body and the source of the
+announcement.
+
+Announcements go to Discord through an Incoming Webhook
+(`DISCORD_WEBHOOK_URL`). `scripts/post-release-discord.sh` builds a rich embed
+with the title, notes, release link, timestamp, and footer, plus a "View on
+GitHub" button. It truncates notes past Discord's 4096-character embed limit
+and links to the full release. Mentions are disabled in the webhook payload.
+The automatic step is gated on the release having been created in that run and
+is non-fatal, so a webhook problem never blocks a release and a workflow rerun
+does not double-post.
+
+`.github/workflows/announce-release.yml` provides a manual replay for an
+already-published version, with a dry-run preview. It validates the tag input
+and reads the canonical release body from GitHub before posting.
+
+The three secrets (`DEEPSEEK_API_KEY`, `DISCORD_WEBHOOK_URL`, `RELEASE_TOKEN`)
+are configured as GitHub Actions repository secrets and never appear in the
+repository. `RELEASE_TOKEN` is the PAT that `tag-on-version-bump.yml` uses to
+push `v*` tags because a tag pushed with `GITHUB_TOKEN` does not trigger the
+release workflow. `DEEPSEEK_API_KEY` is optional at runtime; when absent,
+releases ship with GitHub-generated notes.
+
+Reddit publishing is deferred, not rejected; the same notes and secrets
+pattern can drive it later if a public community channel is wanted.
+
+## Consequences
+
+- Every release gets a summarized note with no required manual authoring, and
+  users can be notified where they already are.
+- Notes are non-deterministic across runs and depend on an external LLM
+  provider. The fallback makes this a quality risk rather than an availability
+  risk; cost is bounded to one request per release with a 90-second timeout.
+- A Discord webhook is a bearer credential that can post to its channel. It is
+  stored only as a GitHub Actions secret and rotated in the secret store.
+- Discord announcement failures are non-fatal and may require a manual replay;
+  the release itself remains available and verifiable.
+- No `CHANGELOG.md` is committed; GitHub Releases remain the canonical,
+  per-version record.

--- a/justfile
+++ b/justfile
@@ -21,9 +21,12 @@ check-lint:
 
 # Keep the public evidence entry points executable and parseable without
 # starting Docker or reaching the network.
-check-evidence: check-release
-  bash -n examples/prove-maskura.sh examples/local-quickstart.sh examples/maskura-demo.sh scripts/bench-filters.sh
+check-evidence: check-release test-release-notifications
+  bash -n examples/prove-maskura.sh examples/local-quickstart.sh examples/maskura-demo.sh scripts/bench-filters.sh scripts/release-notes.sh scripts/post-release-discord.sh scripts/test-release-notifications.sh
   python3 -c 'import ast, pathlib; ast.parse(pathlib.Path("examples/python-hybrid-roundtrip.py").read_text())'
+
+test-release-notifications:
+  bash scripts/test-release-notifications.sh
 
 # Ensure every public version surface agrees before a release tag can be cut.
 check-release:

--- a/scripts/post-release-discord.sh
+++ b/scripts/post-release-discord.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Post a release to a Discord channel through an Incoming Webhook.
+#
+# Builds a rich embed (title, notes, release link, timestamp, footer) plus a
+# "View on GitHub" link button. Notes longer than Discord's 4096-character
+# embed limit are truncated with a link to the full release.
+#
+# Usage:
+#   scripts/post-release-discord.sh <tag> <notes-file> [--dry-run]
+#
+# Environment:
+#   DISCORD_WEBHOOK_URL   required unless --dry-run.
+#   GITHUB_REPOSITORY     owner/repo (default: 231self/maskura).
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <tag> <notes-file> [--dry-run]" >&2
+}
+
+TAG=""
+NOTES=""
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [ -z "$TAG" ]; then
+        TAG="$arg"
+      elif [ -z "$NOTES" ]; then
+        NOTES="$arg"
+      else
+        usage
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+if [ -z "$TAG" ] || [ -z "$NOTES" ]; then
+  usage
+  exit 2
+fi
+if [ ! -f "$NOTES" ]; then
+  echo "ERROR: notes file not found: $NOTES" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq not found" >&2
+  exit 1
+fi
+
+REPO="${GITHUB_REPOSITORY:-231self/maskura}"
+RELEASE_URL="https://github.com/$REPO/releases/tag/$TAG"
+TITLE="Maskura $TAG"
+MAX_DESCRIPTION=4096
+
+body="$(cat "$NOTES")"
+suffix="$(printf '\n\n…[Read the full notes](%s)' "$RELEASE_URL")"
+
+# Character length, not bytes: Discord counts characters.
+if [ "$(printf '%s' "$body" | wc -m | tr -d ' ')" -gt "$MAX_DESCRIPTION" ]; then
+  suffix_len="$(printf '%s' "$suffix" | wc -m | tr -d ' ')"
+  keep=$((MAX_DESCRIPTION - suffix_len))
+  truncated="$(printf '%s' "$body" | cut -c1-"$keep")"
+  description="${truncated}${suffix}"
+else
+  description="$body"
+fi
+
+timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+payload="$(jq -n \
+  --arg title "$TITLE" \
+  --arg url "$RELEASE_URL" \
+  --arg desc "$description" \
+  --arg ts "$timestamp" \
+  --arg footer "Maskura release $TAG" \
+  '{
+    allowed_mentions: {parse: []},
+    embeds: [{
+      title: $title,
+      url: $url,
+      description: $desc,
+      color: 4177232,
+      timestamp: $ts,
+      footer: {text: $footer}
+    }],
+    components: [{
+      type: 1,
+      components: [{
+        type: 2,
+        style: 5,
+        label: "View on GitHub",
+        url: $url
+      }]
+    }]
+  }')"
+
+if [ "$DRY_RUN" = true ]; then
+  printf '%s\n' "$payload"
+  echo "dry-run: payload built, not posted to Discord" >&2
+  exit 0
+fi
+
+if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
+  echo "ERROR: DISCORD_WEBHOOK_URL not set" >&2
+  exit 1
+fi
+
+status="$(curl -sS --max-time 30 -o /dev/null -w '%{http_code}' \
+  -H 'Content-Type: application/json' \
+  -d "$payload" \
+  "$DISCORD_WEBHOOK_URL")"
+
+case "$status" in
+  2*)
+    echo "Posted $TAG to Discord (HTTP $status)"
+    ;;
+  *)
+    echo "ERROR: Discord webhook returned HTTP $status" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Author release notes for a tag.
+#
+# The source material is GitHub's own PR-based "What's Changed" text for the
+# tag (the same content `gh release create --generate-notes` would produce).
+# When DEEPSEEK_API_KEY is set, that text is rewritten by the DeepSeek chat
+# API into polished Markdown release notes. Any failure, timeout, or missing
+# key silently falls back to the raw GitHub-generated notes so a release is
+# never blocked.
+#
+# Usage:
+#   scripts/release-notes.sh <tag> [output-file]
+#
+# Environment:
+#   GH_TOKEN             GitHub token for the generate-notes API (or gh auth).
+#   GITHUB_REPOSITORY    owner/repo (default: 231self/maskura).
+#   DEEPSEEK_API_KEY     optional; enables the LLM rewrite.
+#   DEEPSEEK_MODEL       optional; default: deepseek-chat.
+#   DEEPSEEK_API_URL     optional; default: https://api.deepseek.com/chat/completions.
+#   PREVIOUS_TAG         optional; pins the comparison base.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <tag> [output-file]" >&2
+}
+
+TAG="${1:-}"
+OUT="${2:-release-notes.md}"
+if [ -z "$TAG" ]; then
+  usage
+  exit 2
+fi
+
+REPO="${GITHUB_REPOSITORY:-231self/maskura}"
+MODEL="${DEEPSEEK_MODEL:-deepseek-chat}"
+API_URL="${DEEPSEEK_API_URL:-https://api.deepseek.com/chat/completions}"
+
+for bin in gh jq; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "ERROR: $bin not found" >&2
+    exit 1
+  fi
+done
+
+# 1. GitHub's generated PR notes: the LLM input and the fallback body.
+generate_args=(--method POST "repos/$REPO/releases/generate-notes" -f "tag_name=$TAG")
+if [ -n "${PREVIOUS_TAG:-}" ]; then
+  generate_args+=(-f "previous_tag_name=$PREVIOUS_TAG")
+fi
+
+raw_notes="$(gh api "${generate_args[@]}" -q .body 2>/dev/null || true)"
+if [ -z "$raw_notes" ]; then
+  echo "WARN: GitHub generate-notes returned no content; using a minimal fallback" >&2
+  raw_notes="Release $TAG"
+fi
+
+# 2. Optional DeepSeek rewrite.
+notes="$raw_notes"
+source_used="github-generated"
+
+if [ -z "${DEEPSEEK_API_KEY:-}" ]; then
+  echo "INFO: DEEPSEEK_API_KEY not set; using GitHub-generated notes" >&2
+elif ! command -v curl >/dev/null 2>&1; then
+  echo "WARN: curl not found; using GitHub-generated notes" >&2
+else
+  system_prompt="You are the release-notes writer for Maskura, an S3-compatible object gateway that cleanses PII. Rewrite the provided merged-PR list into professional GitHub release notes in Markdown. Start with a single-sentence summary of the release. Then a '## Highlights' section as a bullet list of user-visible changes, grouping related items and omitting pure internal chores unless they are notable. Include '## Breaking changes' only if any exist among the input. Include '## Upgrade notes' only if an action is required. Do not invent features, versions, dates, or links, and do not drop the PR references present in the input. Output only the Markdown body: no top-level title heading (the release title is separate), no preamble, no code fences around the whole output."
+
+  user_prompt="Release tag: $TAG
+
+Raw merged-PR notes from GitHub:
+$raw_notes"
+
+  payload="$(jq -n \
+    --arg model "$MODEL" \
+    --arg system "$system_prompt" \
+    --arg user "$user_prompt" \
+    '{model: $model, temperature: 0.3, messages: [{role: "system", content: $system}, {role: "user", content: $user}]}')"
+
+  response="$(curl -sS --max-time 90 \
+    -H "Authorization: Bearer $DEEPSEEK_API_KEY" \
+    -H 'Content-Type: application/json' \
+    -d "$payload" \
+    "$API_URL" 2>/dev/null || true)"
+
+  content="$(printf '%s' "$response" | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)"
+  if [ -n "$content" ]; then
+    notes="$content"
+    source_used="deepseek:$MODEL"
+  else
+    echo "WARN: DeepSeek returned no usable content; falling back to GitHub-generated notes" >&2
+  fi
+fi
+
+printf '%s\n' "$notes" > "$OUT"
+echo "Wrote release notes to $OUT (source: $source_used)"

--- a/scripts/test-release-notifications.sh
+++ b/scripts/test-release-notifications.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "$test_dir"' EXIT
+
+printf '%s\n' '## Highlights' '- Safe release notes' > "$test_dir/notes.md"
+payload="$(
+  GITHUB_REPOSITORY=231self/maskura \
+    bash "$repo_root/scripts/post-release-discord.sh" \
+      v1.2.3 "$test_dir/notes.md" --dry-run 2> "$test_dir/dry-run.log"
+)"
+
+jq -e '
+  .allowed_mentions.parse == []
+  and .embeds[0].title == "Maskura v1.2.3"
+  and .embeds[0].url == "https://github.com/231self/maskura/releases/tag/v1.2.3"
+  and .components[0].components[0].label == "View on GitHub"
+' <<< "$payload" >/dev/null
+grep -q 'payload built, not posted' "$test_dir/dry-run.log"
+
+awk 'BEGIN { for (i = 0; i < 5000; i++) printf "x" }' > "$test_dir/long-notes.md"
+long_payload="$(
+  GITHUB_REPOSITORY=231self/maskura \
+    bash "$repo_root/scripts/post-release-discord.sh" \
+      v1.2.3 "$test_dir/long-notes.md" --dry-run 2>/dev/null
+)"
+jq -e '
+  (.embeds[0].description | length) <= 4096
+  and (.embeds[0].description | endswith(
+    "…[Read the full notes](https://github.com/231self/maskura/releases/tag/v1.2.3)"
+  ))
+' <<< "$long_payload" >/dev/null
+
+mkdir "$test_dir/bin"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  "printf '%s\\n' '## What changed' '- fixed #1'" \
+  > "$test_dir/bin/gh"
+chmod +x "$test_dir/bin/gh"
+
+PATH="$test_dir/bin:$PATH" \
+  GITHUB_REPOSITORY=231self/maskura \
+  bash "$repo_root/scripts/release-notes.sh" \
+    v1.2.3 "$test_dir/generated-notes.md" 2> "$test_dir/release-notes.log"
+
+grep -q '^## What changed$' "$test_dir/generated-notes.md"
+grep -q 'using GitHub-generated notes' "$test_dir/release-notes.log"
+
+if bash "$repo_root/scripts/post-release-discord.sh" \
+  v1.2.3 "$test_dir/missing.md" --dry-run >/dev/null 2>&1; then
+  echo 'expected a missing notes file to fail' >&2
+  exit 1
+fi
+
+echo 'Release notification tests passed'


### PR DESCRIPTION
## Summary

- connect the existing release-note authoring and Discord webhook scripts to the hardened release workflow
- add a manual, dry-runnable announcement workflow so v0.6.0 can be replayed without recreating the release
- validate workflow inputs, disable Discord mentions, and test short, truncated, fallback, and failure paths
- record the release-notification trust boundary in ADR 0015

## Verification

- `just check-evidence`
- `just pre-push`
- workflow YAML parse
- live GitHub generated-notes fallback for `v0.6.0`

The already-published v0.6.0 release will be announced through the manual workflow after this merges; future releases announce automatically only when a new GitHub Release is created.