### PR TITLE
ci: remove PAT dependency from release orchestration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     tags: ['v*']
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Existing v* tag to build and publish
+        required: true
+        type: string
 
 permissions:
   artifact-metadata: write
@@ -16,6 +22,7 @@ env:
   RUSTFLAGS: -D warnings
   CARGO_BUILD_JOBS: 2
   IMAGE: ghcr.io/${{ github.repository_owner }}/maskura/maskura
+  RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
 
 jobs:
   contract:
@@ -24,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Verify release tag and version surfaces
-        run: python3 scripts/check-release-contract.py --tag "${{ github.ref_name }}"
+        run: python3 scripts/check-release-contract.py --tag "${{ env.RELEASE_TAG }}"
 
   # Native per-arch builds: amd64 on the x64 runner, arm64 on the native
   # arm64 runner. No cross-compilation, so ring/aws-lc-sys/openssl-sys build
@@ -69,7 +76,7 @@ jobs:
           cp target/release/maskura-mcp dist/maskura-mcp-linux-${{ matrix.suffix }}
           cp target/release/maskura dist/maskura-linux-${{ matrix.suffix }}
           cp -r target/components/. dist/components/
-          version="${{ github.ref_name }}"
+          version="${{ env.RELEASE_TAG }}"
           expected="maskura ${version#v}"
           test "$(dist/maskura-linux-${{ matrix.suffix }} --version)" = "$expected"
 
@@ -95,11 +102,11 @@ jobs:
           file: Dockerfile.release
           platforms: ${{ matrix.platform }}
           load: true
-          tags: ${{ env.IMAGE }}:${{ github.ref_name }}-${{ matrix.suffix }}
+          tags: ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}-${{ matrix.suffix }}
 
       - name: Boot-smoke image (${{ matrix.suffix }})
         env:
-          IMAGE_REF: ${{ env.IMAGE }}:${{ github.ref_name }}-${{ matrix.suffix }}
+          IMAGE_REF: ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}-${{ matrix.suffix }}
         run: bash scripts/release-image-smoke.sh "$IMAGE_REF"
 
       - name: Log in to GHCR
@@ -111,7 +118,7 @@ jobs:
 
       - name: Push image (${{ matrix.suffix }})
         env:
-          IMAGE_REF: ${{ env.IMAGE }}:${{ github.ref_name }}-${{ matrix.suffix }}
+          IMAGE_REF: ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}-${{ matrix.suffix }}
         run: |
           docker push "$IMAGE_REF"
 
@@ -142,7 +149,7 @@ jobs:
 
       - name: Smoke native binaries
         run: |
-          version="${{ github.ref_name }}"
+          version="${{ env.RELEASE_TAG }}"
           expected="maskura ${version#v}"
           test "$(target/release/maskura --version)" = "$expected"
           target/release/maskura --version
@@ -206,14 +213,14 @@ jobs:
       - name: Merge multi-arch manifest
         run: |
           docker buildx imagetools create \
-            -t ${{ env.IMAGE }}:${{ github.ref_name }} \
-            ${{ env.IMAGE }}:${{ github.ref_name }}-amd64 \
-            ${{ env.IMAGE }}:${{ github.ref_name }}-arm64
+            -t ${{ env.IMAGE }}:${{ env.RELEASE_TAG }} \
+            ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}-amd64 \
+            ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}-arm64
 
       - name: Resolve published image digests
         id: image-digests
         run: |
-          canonical=$(docker buildx imagetools inspect "${{ env.IMAGE }}:${{ github.ref_name }}" --format '{{json .Manifest}}' | jq -r '.digest')
+          canonical=$(docker buildx imagetools inspect "${{ env.IMAGE }}:${{ env.RELEASE_TAG }}" --format '{{json .Manifest}}' | jq -r '.digest')
           test -n "$canonical" && test "$canonical" != "null"
           echo "canonical=$canonical" >> "$GITHUB_OUTPUT"
           printf '%s@%s\n' "${{ env.IMAGE }}" "$canonical" > dist/IMAGE_DIGESTS
@@ -227,7 +234,7 @@ jobs:
 
       - name: Prove the versioned image before promotion
         env:
-          MASKURA_PROOF_IMAGE: ${{ env.IMAGE }}:${{ github.ref_name }}
+          MASKURA_PROOF_IMAGE: ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}
         run: bash examples/prove-maskura.sh
 
       - name: Attest canonical container provenance
@@ -240,7 +247,7 @@ jobs:
       - name: Extract release artifacts from image
         run: |
           mkdir -p dist/plugins
-          docker create --name maskura-extract --platform linux/amd64 "${{ env.IMAGE }}:${{ github.ref_name }}-amd64"
+          docker create --name maskura-extract --platform linux/amd64 "${{ env.IMAGE }}:${{ env.RELEASE_TAG }}-amd64"
           docker cp maskura-extract:/usr/local/bin/maskura-gateway dist/maskura-gateway-linux-x86_64
           docker cp maskura-extract:/app/components/. dist/plugins/
           docker rm maskura-extract
@@ -276,7 +283,7 @@ jobs:
         run: |
           docker buildx imagetools create \
             -t ${{ env.IMAGE }}:latest \
-            ${{ env.IMAGE }}:${{ github.ref_name }}
+            ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}
 
       - name: Make the Maskura image public
         continue-on-error: true
@@ -291,20 +298,20 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-        run: bash scripts/release-notes.sh "${{ github.ref_name }}" release-notes.md
+        run: bash scripts/release-notes.sh "${{ env.RELEASE_TAG }}" release-notes.md
 
       - name: Create GitHub Release
         id: github-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "release ${{ github.ref_name }} already exists; leaving it unchanged (no re-announce)"
+          if gh release view "${{ env.RELEASE_TAG }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "release ${{ env.RELEASE_TAG }} already exists; leaving it unchanged (no re-announce)"
             echo "created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          gh release create "${{ github.ref_name }}" \
+          gh release create "${{ env.RELEASE_TAG }}" \
              dist/maskura-gateway-linux-x86_64 \
              dist/maskura-mcp-linux-amd64 \
              dist/maskura-mcp-linux-arm64 \
@@ -330,7 +337,7 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: bash scripts/post-release-discord.sh "${{ github.ref_name }}" release-notes.md
+        run: bash scripts/post-release-discord.sh "${{ env.RELEASE_TAG }}" release-notes.md
 
   verify-release:
     needs: release
@@ -347,7 +354,7 @@ jobs:
       - name: Verify published image architectures
         run: |
           docker buildx imagetools inspect \
-            "${{ env.IMAGE }}:${{ github.ref_name }}" \
+            "${{ env.IMAGE }}:${{ env.RELEASE_TAG }}" \
             --format '{{json .Manifest}}' > manifest.json
           python3 - <<'PY'
           import json
@@ -367,7 +374,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir verify-dist
-          gh release download "${{ github.ref_name }}" \
+          gh release download "${{ env.RELEASE_TAG }}" \
             --repo "${{ github.repository }}" \
             --dir verify-dist
           (cd verify-dist && sha256sum --check SHA256SUMS)

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -1,47 +1,29 @@
 name: Tag on version bump
 
-# Auto-tags main with v<version> whenever the workspace version in the root
-# Cargo.toml changes, so release.yml (on: push: tags: ['v*']) builds and
-# publishes release artifacts. Tags stopped at v0.3.8 while Cargo.toml climbed
-# to 0.5.2, which is why no release artifacts have built since.
-#
-# SECRET REQUIREMENT
-# ------------------
-# A tag pushed with the default GITHUB_TOKEN does NOT trigger release.yml:
-# GitHub suppresses workflow/event fan-out from GITHUB_TOKEN to prevent loops.
-# The tag must instead be pushed with a Personal Access Token (PAT) that has
-# `contents: write` and `workflows: write` scopes.
-#
-#   1. Create a fine-grained PAT scoped to this repo (231self/maskura) with:
-#        Contents:  Read and write
-#        Workflows: Read and write
-#   2. Add it as an Actions secret named RELEASE_TOKEN
-#      (Settings → Secrets and variables → Actions → New repository secret).
-#
-# The token is referenced via secrets.RELEASE_TOKEN below and is never
-# committed to the repository.
+# Auto-tags main with v<version> whenever the workspace version changes, then
+# calls the reusable release workflow directly. GitHub intentionally suppresses
+# workflow fan-out from tags pushed with GITHUB_TOKEN, so the explicit call is
+# what makes the release reliable without a personal access token.
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   tag-if-bumped:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      created: ${{ steps.push.outputs.created }}
+      tag: ${{ steps.version.outputs.tag }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           # Full history (and tags) so we can diff the previous commit's
           # Cargo.toml and check whether the tag already exists.
           fetch-depth: 0
-          # Don't persist the GITHUB_TOKEN credential helper: it would override
-          # the PAT URL below and push the tag as github-actions[bot], which
-          # cannot trigger release.yml.
-          persist-credentials: false
 
       - name: Detect version bump
         id: version
@@ -58,9 +40,8 @@ jobs:
           fi
 
       - name: Push tag
+        id: push
         if: steps.version.outputs.bumped == 'true'
-        env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           tag="${{ steps.version.outputs.tag }}"
           if [ -z "$tag" ]; then
@@ -70,9 +51,23 @@ jobs:
           python3 scripts/check-release-contract.py --tag "$tag"
           if git rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1; then
             echo "tag $tag already exists; skipping"
+            echo "created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git tag "$tag"
-          git config --unset-all http.https://github.com/.extraheader || true
-          git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin "refs/tags/$tag"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+  release:
+    needs: tag-if-bumped
+    if: needs.tag-if-bumped.outputs.created == 'true'
+    permissions:
+      artifact-metadata: write
+      attestations: write
+      contents: write
+      id-token: write
+      packages: write
+    uses: ./.github/workflows/release.yml
+    with:
+      release_tag: ${{ needs.tag-if-bumped.outputs.tag }}
+    secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,10 +183,10 @@ Document every infrastructure, auth, storage, and deployment choice so automatio
 - Local dev uses Supabase CLI default credentials.
 - **Release automation** (`.github/workflows/release.yml`): `DEEPSEEK_API_KEY`
   (optional; authors release notes with a GitHub-generated fallback),
-  `DISCORD_WEBHOOK_URL` (announces new releases), and `RELEASE_TOKEN` (the
-  fine-grained PAT used by `.github/workflows/tag-on-version-bump.yml` to push
-  `v*` tags so the release workflow fires). Maintainers configure these as
-  GitHub Actions repository secrets. See ADR 0015.
+  and `DISCORD_WEBHOOK_URL` (announces new releases). Maintainers configure
+  these as GitHub Actions repository secrets. Version bumps use the scoped
+  `GITHUB_TOKEN` to create the tag and call the reusable release workflow
+  directly; no maintainer PAT is required. See ADR 0015.
 
 ### Key Formats
 

--- a/docs/adr/0015-release-notes-and-discord-notifications.md
+++ b/docs/adr/0015-release-notes-and-discord-notifications.md
@@ -1,4 +1,4 @@
-# ADR 0015: LLM-authored release notes and Discord announcements
+# ADR 0015: Release orchestration, authored notes, and Discord announcements
 
 - Status: Accepted
 - Date: 2026-09-10
@@ -6,6 +6,10 @@
 ## Context
 
 Releases are cut from `main` by `.github/workflows/release.yml` on `v*` tags.
+The version-bump workflow originally used a personal access token to push the
+tag so GitHub would start the release workflow as a second event. That added a
+maintainer-owned credential whose expiry or permission drift could stop all
+releases after the code had already merged.
 GitHub Releases previously used GitHub's raw list of merged-PR titles. That
 text is accurate but reads as an internal changelog: it has no summary,
 grouping, or upgrade guidance, so it is a weak official note for users.
@@ -50,12 +54,18 @@ does not double-post.
 already-published version, with a dry-run preview. It validates the tag input
 and reads the canonical release body from GitHub before posting.
 
-The three secrets (`DEEPSEEK_API_KEY`, `DISCORD_WEBHOOK_URL`, `RELEASE_TOKEN`)
-are configured as GitHub Actions repository secrets and never appear in the
-repository. `RELEASE_TOKEN` is the PAT that `tag-on-version-bump.yml` uses to
-push `v*` tags because a tag pushed with `GITHUB_TOKEN` does not trigger the
-release workflow. `DEEPSEEK_API_KEY` is optional at runtime; when absent,
-releases ship with GitHub-generated notes.
+`tag-on-version-bump.yml` creates the immutable tag with the scoped
+`GITHUB_TOKEN`, then invokes `release.yml` through `workflow_call` with that tag
+as an explicit input. GitHub does not fan out a new workflow from a tag pushed
+with `GITHUB_TOKEN`; the reusable-workflow call deliberately avoids depending
+on that behavior. Directly pushed `v*` tags remain supported by the release
+workflow's existing `push.tags` trigger.
+
+The two optional integration secrets (`DEEPSEEK_API_KEY` and
+`DISCORD_WEBHOOK_URL`) are configured as GitHub Actions repository secrets and
+never appear in the repository. No personal access token is required for
+tagging or release orchestration. When `DEEPSEEK_API_KEY` is absent, releases
+ship with GitHub-generated notes.
 
 Reddit publishing is deferred, not rejected; the same notes and secrets
 pattern can drive it later if a public community channel is wanted.
@@ -69,6 +79,8 @@ pattern can drive it later if a public community channel is wanted.
   risk; cost is bounded to one request per release with a 90-second timeout.
 - A Discord webhook is a bearer credential that can post to its channel. It is
   stored only as a GitHub Actions secret and rotated in the secret store.
+- Automatic tagging and release execution use short-lived, repository-scoped
+  GitHub tokens; a maintainer PAT cannot expire underneath the release path.
 - Discord announcement failures are non-fatal and may require a manual replay;
   the release itself remains available and verifiable.
 - No `CHANGELOG.md` is committed; GitHub Releases remain the canonical,

--- a/scripts/check-release-contract.py
+++ b/scripts/check-release-contract.py
@@ -127,6 +127,33 @@ def main() -> None:
         if expected not in path.read_text():
             raise SystemExit(f"{path.relative_to(ROOT)} does not reference {expected}")
 
+    tag_workflow = (ROOT / ".github/workflows/tag-on-version-bump.yml").read_text()
+    release_workflow = (ROOT / ".github/workflows/release.yml").read_text()
+    if "RELEASE_TOKEN" in tag_workflow:
+        raise SystemExit("version-bump tagging must not depend on a maintainer PAT")
+    for expected in (
+        "contents: write",
+        "uses: ./.github/workflows/release.yml",
+        "release_tag: ${{ needs.tag-if-bumped.outputs.tag }}",
+        "secrets: inherit",
+    ):
+        if expected not in tag_workflow:
+            raise SystemExit(
+                f"tag-on-version-bump.yml is missing reusable-release contract {expected!r}"
+            )
+    for expected in (
+        "workflow_call:",
+        "RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}",
+    ):
+        if expected not in release_workflow:
+            raise SystemExit(
+                f"release.yml is missing reusable-release contract {expected!r}"
+            )
+    if release_workflow.count("github.ref_name") != 1:
+        raise SystemExit(
+            "release.yml must use RELEASE_TAG everywhere except its push-trigger fallback"
+        )
+
     print(f"release contract passed for v{version}")
 
 


### PR DESCRIPTION
## Summary

- create version tags with the scoped `GITHUB_TOKEN`
- invoke the release pipeline directly as a reusable workflow, avoiding suppressed event fan-out
- remove the maintainer PAT requirement and document the architecture change
- make the release contract fail locally if the PAT dependency or tag-input drift returns

## Verification

- YAML syntax parsed for both workflows
- `python3 scripts/check-release-contract.py --tag v0.7.1`
- `just pre-push`