### PR TITLE
ci: verify GHCR visibility without package mutation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,14 +285,6 @@ jobs:
             -t ${{ env.IMAGE }}:latest \
             ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}
 
-      - name: Make the Maskura image public
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api -X PATCH "/orgs/${{ github.repository_owner }}/packages/container/maskura%2Fmaskura" \
-            -f visibility=public
-
       - name: Generate release notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -352,6 +344,8 @@ jobs:
           driver: docker-container
 
       - name: Verify published image architectures
+        # This job never logs in to GHCR. A successful inspect therefore proves
+        # that the versioned manifest is anonymously pullable as well as complete.
         run: |
           docker buildx imagetools inspect \
             "${{ env.IMAGE }}:${{ env.RELEASE_TAG }}" \

--- a/crates/gateway/src/transaction/spool.rs
+++ b/crates/gateway/src/transaction/spool.rs
@@ -163,14 +163,19 @@ impl CompatibilitySpoolTransaction {
             if !is_recognized_spool_file(name) {
                 continue;
             }
-            let metadata = entry.metadata().await.map_err(spool_error)?;
+            let metadata = match entry.metadata().await {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(spool_error(error)),
+            };
             if !metadata.is_file() || metadata.modified().map_err(spool_error)? > cutoff {
                 continue;
             }
-            tokio::fs::remove_file(entry.path())
-                .await
-                .map_err(spool_error)?;
-            removed += 1;
+            match tokio::fs::remove_file(entry.path()).await {
+                Ok(()) => removed += 1,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(spool_error(error)),
+            }
         }
         Ok(removed)
     }
@@ -436,6 +441,45 @@ mod tests {
         assert!(!stale_read.exists());
         assert!(unrelated.exists());
         let _ = std::fs::remove_file(unrelated);
+        let _ = std::fs::remove_dir(directory);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_cleanup_tolerates_files_removed_by_another_sweeper() {
+        let directory = std::env::temp_dir().join(format!(
+            "maskura-spool-concurrent-cleanup-{}",
+            Uuid::now_v7()
+        ));
+        tokio::fs::create_dir_all(&directory).await.unwrap();
+        for index in 0..128 {
+            tokio::fs::write(
+                directory.join(format!("{FILE_PREFIX}{index}.tmp")),
+                b"stale",
+            )
+            .await
+            .unwrap();
+        }
+
+        let config = config(directory.clone(), 1);
+        let mut cleanups = tokio::task::JoinSet::new();
+        for _ in 0..8 {
+            let config = config.clone();
+            cleanups
+                .spawn(async move { CompatibilitySpoolTransaction::cleanup_stale(&config).await });
+        }
+        while let Some(result) = cleanups.join_next().await {
+            result.unwrap().unwrap();
+        }
+
+        assert!(
+            tokio::fs::read_dir(&directory)
+                .await
+                .unwrap()
+                .next_entry()
+                .await
+                .unwrap()
+                .is_none()
+        );
         let _ = std::fs::remove_dir(directory);
     }
 }

--- a/docs/adr/0015-release-notes-and-discord-notifications.md
+++ b/docs/adr/0015-release-notes-and-discord-notifications.md
@@ -61,6 +61,12 @@ with `GITHUB_TOKEN`; the reusable-workflow call deliberately avoids depending
 on that behavior. Directly pushed `v*` tags remain supported by the release
 workflow's existing `push.tags` trigger.
 
+Container visibility is managed as persistent GHCR package configuration, not
+mutated during every release. The `verify-release` job intentionally does not
+log in to GHCR before inspecting the published manifest. That anonymous pull is
+the release-time proof that the package remains public; a visibility regression
+fails the release instead of being hidden behind a non-fatal API request.
+
 The two optional integration secrets (`DEEPSEEK_API_KEY` and
 `DISCORD_WEBHOOK_URL`) are configured as GitHub Actions repository secrets and
 never appear in the repository. No personal access token is required for
@@ -81,6 +87,8 @@ pattern can drive it later if a public community channel is wanted.
   stored only as a GitHub Actions secret and rotated in the secret store.
 - Automatic tagging and release execution use short-lived, repository-scoped
   GitHub tokens; a maintainer PAT cannot expire underneath the release path.
+- Every release verifies the versioned multi-architecture image without GHCR
+  credentials, covering both manifest contents and public pull access.
 - Discord announcement failures are non-fatal and may require a manual replay;
   the release itself remains available and verifiable.
 - No `CHANGELOG.md` is committed; GitHub Releases remain the canonical,

--- a/scripts/check-public-copy.py
+++ b/scripts/check-public-copy.py
@@ -8,9 +8,10 @@ import re
 ROOT = Path(__file__).resolve().parents[1]
 PUBLIC_ENTRY_POINTS = (ROOT / "README.md",)
 FORBIDDEN = re.compile(
-    r"not the product|what makes (?:us|maskura) different|we built|the moat|"
+    r"not the product|one built-in policy|what makes (?:us|maskura) different|"
+    r"we built|the moat|the defensible (?:thing|product)|"
     r"commodity (?:feature|product)|strategic problem|under-marketed|"
-    r"defensible product",
+    r"defensible product|marketing the commodity",
     re.IGNORECASE,
 )
 

--- a/scripts/check-release-contract.py
+++ b/scripts/check-release-contract.py
@@ -153,6 +153,18 @@ def main() -> None:
         raise SystemExit(
             "release.yml must use RELEASE_TAG everywhere except its push-trigger fallback"
         )
+    if (
+        "Make the Maskura image public" in release_workflow
+        or "visibility=public" in release_workflow
+    ):
+        raise SystemExit(
+            "release.yml must verify anonymous GHCR access instead of mutating package visibility"
+        )
+    verify_job = release_workflow.split("  verify-release:", maxsplit=1)[1]
+    if "docker/login-action" in verify_job:
+        raise SystemExit(
+            "verify-release must remain logged out so image inspection proves anonymous access"
+        )
 
     print(f"release contract passed for v{version}")
 


### PR DESCRIPTION
## Summary

- remove the non-fatal package-visibility API mutation that returned 404 during v0.7.1
- keep `verify-release` logged out of GHCR so manifest inspection proves anonymous pull access
- lock this behavior into the release contract and ADR

## Evidence

The published v0.7.1 manifest returns HTTP 200 with an anonymous GHCR token. The release verifier already runs on a fresh runner without `docker/login-action`.

## Verification

- `just pre-push`
- workflow YAML parse
- `python3 scripts/check-release-contract.py --tag v0.7.1`
- anonymous request for `ghcr.io/231self/maskura/maskura:v0.7.1` returned HTTP 200