### PR TITLE
ci: clear dependency PR backlog at source

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,26 +11,27 @@ updates:
         update-types:
           - minor
           - patch
+    # sha2 0.11 and hmac 0.13 use digest 0.11, while hkdf and the rest of the
+    # current crypto stack still require digest 0.10. Re-enable these majors as
+    # a coordinated migration once the dependency graph can move together.
+    ignore:
+      - dependency-name: sha2
+        versions:
+          - "0.11.x"
+      - dependency-name: hmac
+        versions:
+          - "0.13.x"
 
   - package-ecosystem: npm
-    directory: /sdks/typescript
+    # Generated SDK output is replaced by `just build-sdks`. The overlay is the
+    # maintained source and is copied into every generated client.
+    directory: /sdks/overlay/typescript
     schedule:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
     groups:
       typescript-dependencies:
-        patterns:
-          - "*"
-
-  - package-ecosystem: pip
-    directory: /sdks/python
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 5
-    groups:
-      python-dependencies:
         patterns:
           - "*"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,7 +2829,7 @@ version = "0.7.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
- "base64 0.22.1",
+ "base64 0.23.1",
  "clap",
  "dirs",
  "hkdf",
@@ -2879,7 +2879,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "axum",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "crc",
@@ -2967,7 +2967,7 @@ name = "maskura-plugin-crypto-deterministic"
 version = "0.7.1"
 dependencies = [
  "aes-siv",
- "base64 0.22.1",
+ "base64 0.23.1",
  "maskura-plugin-sdk",
  "serde_json",
 ]
@@ -2977,7 +2977,7 @@ name = "maskura-plugin-crypto-envelope"
 version = "0.7.1"
 dependencies = [
  "aes-gcm",
- "base64 0.22.1",
+ "base64 0.23.1",
  "hkdf",
  "maskura-plugin-pii-core",
  "maskura-plugin-sdk",
@@ -3029,7 +3029,7 @@ version = "0.7.1"
 name = "maskura-plugin-sdk"
 version = "0.1.0"
 dependencies = [
- "wit-bindgen 0.60.0",
+ "wit-bindgen 0.61.1",
 ]
 
 [[package]]
@@ -3056,7 +3056,7 @@ dependencies = [
 name = "maskura-test-plugin-binary-reductor"
 version = "0.7.1"
 dependencies = [
- "wit-bindgen 0.60.0",
+ "wit-bindgen 0.61.1",
 ]
 
 [[package]]
@@ -3611,9 +3611,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pollster"
-version = "0.4.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+checksum = "bc6355899e1c9462875b6757c79f3caa011a1fdae12bbb1a2e72dd1f234f8336"
 
 [[package]]
 name = "polyval"
@@ -5917,16 +5917,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.254.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09480d646178e5fdd12bb06e812d0af9a3a191dbc9cd697fdc86687beade7393"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.254.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e974fe6821a8cf64575d51ea2194e2c8f77e7b66e9afe7419ce8a97f9ee0d251"
@@ -5937,14 +5927,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.254.0"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01df5f3b4ca7881e843f3bc0fb8a3905d79c68692250dcb8e33e698705ccdb6"
+checksum = "18a11585adb92fe9b55ad1d760e8d8fb5d87e0d2e303cb8eed57f078d54293a2"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.254.0",
- "wasmparser 0.254.0",
+ "wasm-encoder 0.258.0",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]
@@ -5975,23 +5965,12 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.254.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
-dependencies = [
- "bitflags",
- "hashbrown 0.17.1",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9a61719f93a87b16d325921e251800c4833f8fab50fa21c7de73aed50086313"
 dependencies = [
  "bitflags",
+ "hashbrown 0.17.1",
  "indexmap",
  "semver",
 ]
@@ -6821,9 +6800,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.60.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a301904d6657d6364c758d869e5389d05d393b16d5b65db60b4f03cbe71bb80d"
+checksum = "e473fd0095479f9689ac7d2a52c427cc96bb2b973ace50238dfcc1ab1cd52d93"
 dependencies = [
  "bitflags",
  "wit-bindgen-rust-macro",
@@ -6831,20 +6810,20 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.60.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48521bb96e56cbb9e031ad306c80dc20e89e69e49ada02781ee06f60fbcb545f"
+checksum = "87445680dfe6d6b5369e884bd63c03a3335268e855365b2fc3f7bcdce96a630e"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.254.0",
+ "wit-parser 0.258.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.60.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df3fe9b9a0066f82fd0c2f07f79d0ffc0f85c53fa5f998516d8722712479042"
+checksum = "72f2fe494de0d898216caf0fd0ae76af75753fcb3ff4f465b46131537cf24cf8"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -6858,9 +6837,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.60.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d689c4bc9d6af067c651cfba444766343c9a4bdef15fad1e2efab95c0c277af0"
+checksum = "59283a01aec94f60f92ada22ffe182a5cea8acfce43be3be688de8d52df55312"
 dependencies = [
  "anyhow",
  "macro-string",
@@ -6874,9 +6853,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.254.0"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0e65bb94c369b3c4741ce3d1d2704b1fec93db7c540df0e521a097e7ceeb5be"
+checksum = "481b5c47b2ecce0389b5e08a05557d6a190c9cd761773b8880a8017ee04dc7ef"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -6885,10 +6864,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.254.0",
+ "wasm-encoder 0.258.0",
  "wasm-metadata",
- "wasmparser 0.254.0",
- "wit-parser 0.254.0",
+ "wasmparser 0.258.0",
+ "wit-parser 0.258.0",
 ]
 
 [[package]]
@@ -6912,9 +6891,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.254.0"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1655131e4f7d3f0cb141f6eca71315ca40eff0f3d4de7cff0a82bacedd8c89b4"
+checksum = "ff4daaa3cd97ae49ecd0a99dc009d453f93e0f083dd3be38c0f24a83a93e37ac"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -6926,7 +6905,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-ident",
- "wasmparser 0.254.0",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ hkdf = "0.12"
 
 wasmtime = "47"
 wasmtime-wasi = "47"
-wit-bindgen = "0.60"
+wit-bindgen = "0.61"
 
 addr-spec = "0.9"
 card-validate = "2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Pre-built Wasm components committed to components/. Each invocation builds
 # one native target; the release workflow assembles its multi-arch manifest.
 
-FROM rust:1.97.0-trixie@sha256:b92b8c8574f8f3b207fcb0912fb3e2de4041580b5934d90312d53938c9a038a9 AS build
+FROM rust:1.98.0-trixie@sha256:620dbcd124499c59e2406d3741574b5c5838cf9eb9656f0c3a03948f79b02959 AS build
 WORKDIR /src
 ARG CARGO_BUILD_JOBS=2
 
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     && cargo build --locked --release --jobs "$CARGO_BUILD_JOBS" -p maskura-gateway \
     && cp /src/target/release/maskura-gateway /src/gateway-bin
 
-FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
+FROM debian:trixie-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -3,7 +3,7 @@
 # GitHub runner (warm cargo cache) and staged in dist/; this Dockerfile just
 # packages them. The release job builds natively per architecture, so this
 # builds in seconds (no compilation in Docker).
-FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
+FROM debian:trixie-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,7 +18,7 @@ reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-feature
 clap = { version = "4", features = ["derive", "env"] }
 dirs = "6"
 aes-gcm.workspace = true
-base64 = "0.22"
+base64 = "0.23"
 hkdf.workspace = true
 ml-kem.workspace = true
 rand.workspace = true

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -42,7 +42,7 @@ serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-base64 = "0.22"
+base64 = "0.23"
 jsonwebtoken.workspace = true
 reqwest.workspace = true
 psl.workspace = true
@@ -66,12 +66,12 @@ num-bigint = "0.4"
 
 [dev-dependencies]
 proptest.workspace = true
-pollster = "0.4"
+pollster = "1.0"
 tower = "0.5"
 sha2 = "0.10"
 sha1 = "0.10"
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }
-base64 = "0.22"
+base64 = "0.23"
 rand_core = { version = "0.6", default-features = false }
 rand_chacha = { version = "0.3", default-features = false }
 aes-siv = { version = "0.7", default-features = false, features = ["alloc"] }

--- a/plugins/crypto/deterministic/Cargo.toml
+++ b/plugins/crypto/deterministic/Cargo.toml
@@ -10,5 +10,5 @@ crate-type = ["cdylib"]
 [dependencies]
 maskura-plugin-sdk = { path = "../../../crates/plugin-sdk" }
 serde_json = "1"
-base64 = "0.22"
+base64 = "0.23"
 aes-siv = { version = "0.7", default-features = false, features = ["alloc"] }

--- a/plugins/crypto/envelope/Cargo.toml
+++ b/plugins/crypto/envelope/Cargo.toml
@@ -19,4 +19,4 @@ aes-gcm = { version = "0.10", default-features = false, features = ["aes", "allo
 rand_core = { version = "0.6", default-features = false }
 rand_chacha = { version = "0.3", default-features = false }
 serde_json = "1"
-base64 = "0.22"
+base64 = "0.23"


### PR DESCRIPTION
## What

- update the pinned Rust and Debian container bases
- update `base64` to 0.23, `pollster` to 1.0, and `wit-bindgen` to 0.61
- point npm Dependabot at the maintained TypeScript SDK overlay instead of regenerated output
- stop pip update PRs against the regenerated Python manifest
- defer the incompatible sha2 0.11 and hmac 0.13 lines until the digest-based crypto stack can migrate together

## Why

This consolidates the four already-green dependency PRs and fixes the source of the unmergeable ones. Generated SDK manifests are replaced by `just build-sdks`, while isolated sha2/hmac majors split `digest` 0.10/0.11 types across HKDF/HMAC/SHA and do not compile. Security and supply-chain scans remain unchanged.

## Verification

- `just pre-push`
- Dependabot YAML parsed locally
- exact dependency/container updates previously passed the full PR matrix in #121, #124, #126, and #127