### PR TITLE
ci: require deliberate dependency major migrations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,16 +11,12 @@ updates:
         update-types:
           - minor
           - patch
-    # sha2 0.11 and hmac 0.13 use digest 0.11, while hkdf and the rest of the
-    # current crypto stack still require digest 0.10. Re-enable these majors as
-    # a coordinated migration once the dependency graph can move together.
+    # Breaking Rust releases frequently require coordinated ecosystem and code
+    # migrations. Keep advisory scanning active, but schedule majors manually.
     ignore:
-      - dependency-name: sha2
-        versions:
-          - "0.11.x"
-      - dependency-name: hmac
-        versions:
-          - "0.13.x"
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: npm
     # Generated SDK output is replaced by `just build-sdks`. The overlay is the
@@ -34,6 +30,15 @@ updates:
       typescript-dependencies:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
+    # Major SDK crypto/toolchain upgrades need API migration and explicit
+    # interoperability tests rather than an automated manifest-only bump.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## What

- keep grouped automated minor and patch updates for Rust and the maintained TypeScript SDK overlay
- stop automated semver-major PRs for those ecosystems

## Why

The newly exposed backlog consists entirely of breaking ecosystem migrations (`rand*`, `toml`, `tower-http`, and the JS crypto/toolchain stack). These need coordinated code/API updates and focused interoperability review, not isolated manifest bumps. Dependabot alerts plus the existing Rust, Python, TypeScript, CodeQL, and supply-chain audits remain active.

## Verification

- `just pre-push`
- Dependabot YAML parsed locally