### PR TITLE
ci: defer breaking pre-1 SDK crypto updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,12 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+      # Dependabot classifies pre-1 0.x jumps as minor even when the library's
+      # API is breaking. Keep the post-quantum client upgrade coordinated with
+      # its high-level key and envelope interoperability migration.
+      - dependency-name: "@noble/post-quantum"
+        versions:
+          - ">=0.5.0"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## What

Defer automated `@noble/post-quantum` upgrades from 0.4 to later pre-1 lines.

## Why

Dependabot classifies 0.4→0.7 as semver-minor, so it is not covered by the major-update policy even though the library API changes. This migration must move with the SDK high-level key/envelope code and explicit interoperability tests. Advisory scanning and all other minor/patch automation remain enabled.

## Verification

- `just pre-push`
- Dependabot YAML parsed locally